### PR TITLE
chore(python): use CDP_API_KEY_ID

### DIFF
--- a/.github/workflows/python_e2e_test.yml
+++ b/.github/workflows/python_e2e_test.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Run E2E tests
         env:
-          CDP_API_KEY_NAME: ${{ secrets.CDP_API_KEY_NAME }}
+          CDP_API_KEY_ID: ${{ secrets.CDP_API_KEY_ID }}
           CDP_API_KEY_SECRET: ${{ secrets.CDP_API_KEY_SECRET }}
           CDP_WALLET_SECRET: ${{ secrets.CDP_WALLET_SECRET }}
         run: uv run pytest cdp/test/test_e2e.py -v

--- a/python/.env.example
+++ b/python/.env.example
@@ -1,3 +1,3 @@
-CDP_API_KEY_NAME=your_api_key_name_here
+CDP_API_KEY_ID=your_api_key_id_here
 CDP_API_KEY_SECRET=your_private_key_here
 CDP_WALLET_SECRET=your_wallet_auth_key_here

--- a/python/README.md
+++ b/python/README.md
@@ -38,7 +38,7 @@ To start, [create a CDP API Key](https://portal.cdp.coinbase.com/access/api). Sa
 One option is to export your CDP API Key and Wallet Secret as environment variables:
 
 ```bash
-export CDP_API_KEY_NAME="YOUR_API_KEY_ID"
+export CDP_API_KEY_ID="YOUR_API_KEY_ID"
 export CDP_API_KEY_SECRET="YOUR_API_KEY_SECRET"
 export CDP_WALLET_SECRET="YOUR_WALLET_SECRET"
 ```
@@ -57,7 +57,7 @@ Another option is to save your CDP API Key and Wallet Secret in a `.env` file:
 
 ```bash
 touch .env
-echo "CDP_API_KEY_NAME=YOUR_API_KEY_ID" >> .env
+echo "CDP_API_KEY_ID=YOUR_API_KEY_ID" >> .env
 echo "CDP_API_KEY_SECRET=YOUR_API_KEY_SECRET" >> .env
 echo "CDP_WALLET_SECRET=YOUR_WALLET_SECRET" >> .env
 ```

--- a/python/cdp/cdp_client.py
+++ b/python/cdp/cdp_client.py
@@ -25,7 +25,7 @@ class CdpClient:
         """Instantiate the CdpClient.
 
         Args:
-            api_key_id (str, optional): The API key ID. Defaults to the CDP_API_KEY_NAME environment variable.
+            api_key_id (str, optional): The API key ID. Defaults to the CDP_API_KEY_ID environment variable.
             api_key_secret (str, optional): The API key secret. Defaults to the CDP_API_KEY_SECRET environment variable.
             wallet_secret (str, optional): The wallet secret. Defaults to the CDP_WALLET_SECRET environment variable.
             debugging (bool, optional): Whether to enable debugging. Defaults to False.
@@ -34,7 +34,7 @@ class CdpClient:
             source (str, optional): The source. Defaults to SDK_DEFAULT_SOURCE.
             source_version (str, optional): The source version. Defaults to __version__.
         """
-        api_key_id = api_key_id or os.getenv("CDP_API_KEY_NAME")
+        api_key_id = api_key_id or os.getenv("CDP_API_KEY_ID") or os.getenv("CDP_API_KEY_NAME")
         api_key_secret = api_key_secret or os.getenv("CDP_API_KEY_SECRET")
         wallet_secret = wallet_secret or os.getenv("CDP_WALLET_SECRET")
 
@@ -44,7 +44,7 @@ class CdpClient:
 
 You can set them as environment variables:
 
-CDP_API_KEY_NAME=your-api-key-id
+CDP_API_KEY_ID=your-api-key-id
 CDP_API_KEY_SECRET=your-api-key-secret
 
 You can also pass them as options to the constructor:

--- a/python/changelog.d/30.feature.md
+++ b/python/changelog.d/30.feature.md
@@ -3,7 +3,7 @@ Add support for configuring `CdpClient` via environment variables.
 Developers can now simply set the following environment variables in their shell:
 
 ```bash
-export CDP_API_KEY_NAME=your-api-key-id
+export CDP_API_KEY_ID=your-api-key-id
 export CDP_API_KEY_SECRET=your-api-key-secret
 export CDP_WALLET_SECRET=your-wallet-secret
 ```
@@ -20,7 +20,7 @@ Or, load from a `.env` file:
 
 ```bash
 # .env
-CDP_API_KEY_NAME=your-api-key-id
+CDP_API_KEY_ID=your-api-key-id
 CDP_API_KEY_SECRET=your-api-key-secret
 CDP_WALLET_SECRET=your-wallet-secret
 ```


### PR DESCRIPTION
<!--
Thanks for contributing to CDP SDK!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

This PR is a fast follow fix for a change made in #30. The client config now accepts `CDP_API_KEY_ID` (in addition to `CDP_API_KEY_NAME` for backwards compat).

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
 -->

## Tests

<!--
When adding new functionality or fixing a bug, you should be testing your changes with one or more
API method examples in the examples directory.

Please provide samples of the methods you tested with, the outputs for each method,
and any other relevant context, like which network was used.

Use the following format if helpful:

```
Method: <name of method used>
Network: <network used>
Setup: <any other relevant context>

Output:
<example output>
```

For example:

```
Method: createAccount
Network: Base Sepolia

Output:
EVM Account Address:  0xC2c7D554292Bb6AE502fafc3F5c0C46B534d6f31
```
 -->

## Checklist

A couple of things to include in your PR for completeness:

- [ ] Added a changelog entry

<!--
For instructions on adding changelog entries:
See here for TypeScript: https://github.com/coinbase/cdp-sdk/blob/main/typescript/CONTRIBUTING.md#changelog
and here for Python: https://github.com/coinbase/cdp-sdk/blob/main/python/CONTRIBUTING.md#changelog
-->
