### PR TITLE
fix(typescript): accept CDP_API_KEY_ID over CDP_API_KEY_NAME

### DIFF
--- a/.github/workflows/typescript_e2e_test.yml
+++ b/.github/workflows/typescript_e2e_test.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Run E2E Tests
         env:
-          CDP_API_KEY_NAME: ${{ secrets.CDP_API_KEY_NAME }}
+          CDP_API_KEY_ID: ${{ secrets.CDP_API_KEY_ID }}
           CDP_API_KEY_SECRET: ${{ secrets.CDP_API_KEY_SECRET }}
           CDP_WALLET_SECRET: ${{ secrets.CDP_WALLET_SECRET }}
         run: pnpm run test:e2e

--- a/typescript/.changeset/spicy-bananas-travel.md
+++ b/typescript/.changeset/spicy-bananas-travel.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/cdp-sdk": patch
+---
+
+Accept CDP_API_KEY_ID over CDP_API_KEY_NAME

--- a/typescript/.env.example
+++ b/typescript/.env.example
@@ -1,3 +1,3 @@
-CDP_API_KEY_NAME=your_api_key_name_here
+CDP_API_KEY_ID=your_api_key_id_here
 CDP_API_KEY_SECRET=your_private_key_here
 CDP_WALLET_SECRET=your_wallet_auth_key_here

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -38,7 +38,7 @@ To start, [create a CDP API Key](https://portal.cdp.coinbase.com/access/api). Sa
 One option is to export your CDP API Key and Wallet Secret as environment variables:
 
 ```bash
-export CDP_API_KEY_NAME="YOUR_API_KEY_ID"
+export CDP_API_KEY_ID="YOUR_API_KEY_ID"
 export CDP_API_KEY_SECRET="YOUR_API_KEY_SECRET"
 export CDP_WALLET_SECRET="YOUR_WALLET_SECRET"
 ```
@@ -57,7 +57,7 @@ Another option is to save your CDP API Key and Wallet Secret in a `.env` file:
 
 ```bash
 touch .env
-echo "CDP_API_KEY_NAME=YOUR_API_KEY_ID" >> .env
+echo "CDP_API_KEY_ID=YOUR_API_KEY_ID" >> .env
 echo "CDP_API_KEY_SECRET=YOUR_API_KEY_SECRET" >> .env
 echo "CDP_WALLET_SECRET=YOUR_WALLET_SECRET" >> .env
 ```

--- a/typescript/src/client/cdp.ts
+++ b/typescript/src/client/cdp.ts
@@ -38,7 +38,7 @@ export class CdpClient {
    *
    * These parameters can be set as environment variables:
    * ```
-   * CDP_API_KEY_NAME=your-api-key-id
+   * CDP_API_KEY_ID=your-api-key-id
    * CDP_API_KEY_SECRET=your-api-key-secret
    * CDP_WALLET_SECRET=your-wallet-secret
    * ```
@@ -62,7 +62,7 @@ export class CdpClient {
    * @param {CdpClientOptions} [options] - Configuration options for the CdpClient.
    */
   constructor(options: CdpClientOptions = {}) {
-    const apiKeyId = options.apiKeyId ?? process.env.CDP_API_KEY_NAME;
+    const apiKeyId = options.apiKeyId ?? process.env.CDP_API_KEY_ID ?? process.env.CDP_API_KEY_NAME;
     const apiKeySecret = options.apiKeySecret ?? process.env.CDP_API_KEY_SECRET;
     const walletSecret = options.walletSecret ?? process.env.CDP_WALLET_SECRET;
 
@@ -72,7 +72,7 @@ export class CdpClient {
 
 You can set them as environment variables:
 
-CDP_API_KEY_NAME=your-api-key-id
+CDP_API_KEY_ID=your-api-key-id
 CDP_API_KEY_SECRET=your-api-key-secret
 
 You can also pass them as options to the constructor:


### PR DESCRIPTION
<!--
Thanks for contributing to CDP SDK!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

#29 should have made this change to use `CDP_API_KEY_ID` instead of `CDP_API_KEY_NAME`. It's being added as an option for devs, while keeping `CDP_API_KEY_NAME` as a fallback value for backwards compat.

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
 -->

## Tests

<!--
When adding new functionality or fixing a bug, you should be testing your changes with one or more
API method examples in the examples directory.

Please provide samples of the methods you tested with, the outputs for each method,
and any other relevant context, like which network was used.

Use the following format if helpful:

```
Method: <name of method used>
Network: <network used>
Setup: <any other relevant context>

Output:
<example output>
```

For example:

```
Method: createAccount
Network: Base Sepolia

Output:
EVM Account Address:  0xC2c7D554292Bb6AE502fafc3F5c0C46B534d6f31
```
 -->

## Checklist

A couple of things to include in your PR for completeness:

- [x] Added a changelog entry

<!--
For instructions on adding changelog entries:
See here for TypeScript: https://github.com/coinbase/cdp-sdk/blob/main/typescript/CONTRIBUTING.md#changelog
and here for Python: https://github.com/coinbase/cdp-sdk/blob/main/python/CONTRIBUTING.md#changelog
-->
