### PR TITLE
fix: improve error handling

### DIFF
--- a/python/cdp/cdp_client.py
+++ b/python/cdp/cdp_client.py
@@ -1,5 +1,6 @@
 import os
 
+import cdp.analytics
 from cdp.__version__ import __version__
 from cdp.api_clients import ApiClients
 from cdp.constants import SDK_DEFAULT_SOURCE
@@ -85,6 +86,9 @@ For more information, see: https://github.com/coinbase/cdp-sdk/blob/main/python/
             source_version,
         )
         self.api_clients = ApiClients(self.cdp_api_client)
+
+        cdp.analytics.AnalyticsConfig.set(api_key_id)
+
         self._evm = EvmClient(self.api_clients)
         self._solana = SolanaClient(self.api_clients)
 

--- a/python/cdp/test/test_analytics.py
+++ b/python/cdp/test/test_analytics.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from cdp.analytics import ErrorEventData
+from cdp.analytics import AnalyticsConfig, ErrorEventData
 
 
 @pytest.mark.asyncio
@@ -18,6 +18,8 @@ async def test_send_event(mock_post, mock_send_event):
     original_send_event = mock_send_event.original
 
     event_data = ErrorEventData(name="error", method="test", message="test")
+
+    AnalyticsConfig.set("test-api-key-id")
 
     await original_send_event(event_data)
 
@@ -35,12 +37,11 @@ async def test_send_event(mock_post, mock_send_event):
     assert len(event_data) > 0
     assert event_data[0]["event_type"] == "error"
     assert event_data[0]["platform"] == "server"
+    assert event_data[0]["user_id"] == "test-api-key-id"
+    assert event_data[0]["timestamp"] is not None
 
     event_props = event_data[0]["event_properties"]
-    assert event_props["platform"] == "server"
-    assert event_props["project_name"] == "cdp-sdk"
     assert event_props["cdp_sdk_language"] == "python"
     assert event_props["name"] == "error"
     assert event_props["method"] == "test"
     assert event_props["message"] == "test"
-    assert "time_start" in event_props

--- a/python/changelog.d/56.misc.md
+++ b/python/changelog.d/56.misc.md
@@ -1,0 +1,1 @@
+Improve error handling

--- a/typescript/.changeset/clean-ideas-hug.md
+++ b/typescript/.changeset/clean-ideas-hug.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/cdp-sdk": patch
+---
+
+improve error handling

--- a/typescript/src/analytics.test.ts
+++ b/typescript/src/analytics.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { sendEvent } from "./analytics.js";
+import { AnalyticsConfig, sendEvent } from "./analytics.js";
 
 describe("sendEvent", () => {
   it("should use the actual implementation", async () => {
@@ -7,6 +7,8 @@ describe("sendEvent", () => {
       ok: true,
       status: 200,
     });
+
+    AnalyticsConfig.set("test-api-key-id");
 
     await sendEvent({ name: "error", method: "test", message: "test" });
 
@@ -29,14 +31,14 @@ describe("sendEvent", () => {
     expect(eventData[0]).toHaveProperty("event_type", "error");
     expect(eventData[0]).toHaveProperty("platform", "server");
     expect(eventData[0]).toHaveProperty("event_properties");
+    expect(eventData[0]).toHaveProperty("user_id", "test-api-key-id");
+    expect(eventData[0]).toHaveProperty("timestamp");
     expect(eventData[0].event_properties).toMatchObject({
-      platform: "server",
       project_name: "cdp-sdk",
       cdp_sdk_language: "typescript",
       name: "error",
       method: "test",
       message: "test",
     });
-    expect(eventData[0].event_properties).toHaveProperty("time_start");
   });
 });

--- a/typescript/src/auth/hooks/axios/withAuth.ts
+++ b/typescript/src/auth/hooks/axios/withAuth.ts
@@ -108,6 +108,7 @@ export function withAuth(axiosClient: AxiosInstance, options: AuthInterceptorOpt
           headers: error.response?.headers,
           data: error.response?.data,
           message: error.message,
+          cause: error.cause,
         };
 
         console.error("Response Error:", errorDetails);

--- a/typescript/src/client/cdp.test.ts
+++ b/typescript/src/client/cdp.test.ts
@@ -13,6 +13,14 @@ vi.mock("../openapi-client", () => {
   };
 });
 
+vi.mock("../analytics.js", () => {
+  return {
+    AnalyticsConfig: {
+      set: vi.fn(),
+    },
+  };
+});
+
 describe("CdpClient", () => {
   const options = {
     apiKeyId: "test-api-key-id",

--- a/typescript/src/client/cdp.ts
+++ b/typescript/src/client/cdp.ts
@@ -1,3 +1,4 @@
+import { AnalyticsConfig } from "../analytics.js";
 import { CdpOpenApiClient } from "../openapi-client/index.js";
 import { version } from "../version.js";
 import { EvmClient } from "./evm/evm.js";
@@ -106,6 +107,8 @@ For more information, see: https://github.com/coinbase/cdp-sdk/blob/main/typescr
       source: "sdk",
       sourceVersion: version,
     });
+
+    AnalyticsConfig.set(apiKeyId);
 
     this.evm = new EvmClient();
     this.solana = new SolanaClient();

--- a/typescript/src/e2e.test.ts
+++ b/typescript/src/e2e.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect, beforeAll, vi } from "vitest";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 import { serializeTransaction, parseEther, Hex } from "viem";
 import { baseSepolia } from "viem/chains";
@@ -6,6 +6,14 @@ import { CdpClient } from "./client/cdp.js";
 import dotenv from "dotenv";
 
 dotenv.config();
+
+vi.mock("./analytics.js", () => {
+  return {
+    AnalyticsConfig: {
+      set: vi.fn(),
+    },
+  };
+});
 
 describe("CDP Client E2E Tests", () => {
   let cdp: CdpClient;

--- a/typescript/src/openapi-client/errors.ts
+++ b/typescript/src/openapi-client/errors.ts
@@ -9,6 +9,7 @@ export const HttpErrorType = {
   not_found: "not_found",
   bad_gateway: "bad_gateway",
   service_unavailable: "service_unavailable",
+  unknown: "unknown",
 } as const;
 
 export type HttpErrorType = (typeof HttpErrorType)[keyof typeof HttpErrorType];
@@ -36,6 +37,7 @@ export class APIError extends Error {
    * @param errorMessage - The error message
    * @param correlationId - The correlation ID
    * @param errorLink - URL to documentation about this error
+   * @param cause - The cause of the error
    */
   constructor(
     statusCode: number,
@@ -43,8 +45,9 @@ export class APIError extends Error {
     errorMessage: string,
     correlationId?: string,
     errorLink?: string,
+    cause?: Error,
   ) {
-    super(errorMessage);
+    super(errorMessage, { cause });
     this.name = "APIError";
     this.statusCode = statusCode;
     this.errorType = errorType;
@@ -75,6 +78,39 @@ export class APIError extends Error {
       ...(this.correlationId && { correlationId: this.correlationId }),
       ...(this.errorLink && { errorLink: this.errorLink }),
     };
+  }
+}
+
+/**
+ * Error thrown when an Axios request is made but no response is received
+ */
+export class UnknownApiError extends APIError {
+  /**
+   * Constructor for the UnknownApiError class
+   *
+   * @param errorType - The type of error
+   * @param errorMessage - The error message
+   * @param cause - The cause of the error
+   */
+  constructor(errorType: APIErrorType, errorMessage: string, cause?: Error) {
+    super(0, errorType, errorMessage, undefined, undefined, cause);
+    this.name = "UnknownApiError";
+  }
+}
+
+/**
+ * Error thrown when an error is not known
+ */
+export class UnknownError extends Error {
+  /**
+   * Constructor for the UnknownError class
+   *
+   * @param message - The error message
+   * @param cause - The cause of the error
+   */
+  constructor(message: string, cause?: Error) {
+    super(message, { cause });
+    this.name = "UnknownError";
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to CDP SDK!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

This PR adds a client service API key so that we can view error events in Amplitude.
It also expands on the axios error log to include the `error.cause` property in order to capture more information when unexpected errors occur.

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
 -->

## Tests

Tested a few scenarios locally.

**Normal API Error**
```
APIError: EVM account with the given name already exists.
    at cdpApiClient (/Users/ryan/code/public/cdp-sdk/typescript/src/openapi-client/cdpApiClient.ts:137:15)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async EvmClient.createAccount (/Users/ryan/code/public/cdp-sdk/typescript/src/client/evm/evm.ts:79:21)
    at async EvmClient.ClassToWrap.<computed> (/Users/ryan/code/public/cdp-sdk/typescript/src/analytics.ts:115:16)
    at async main (/Users/ryan/code/public/cdp-sdk/typescript/src/examples/evm/getAccount.ts:15:22) {
  statusCode: 409,
  errorType: 'already_exists',
  errorMessage: 'EVM account with the given name already exists.',
  correlationId: '934882a87d822415-IAD',
  errorLink: 'https://docs.cdp.coinbase.com/api-v2/docs/errors#already_exists',
  [cause]: undefined
}
```

**Overriding base path**

I set the `basePath` param on `CdpClient` to `https:/invalid-path-url`. This triggers an error path where an Axios Request was sent, but a Response was never received.

```
UnknownApiError: getaddrinfo ENOTFOUND invalid-path-url
    at cdpApiClient (/Users/ryan/code/public/cdp-sdk/typescript/src/openapi-client/cdpApiClient.ts:126:13)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async EvmClient.listAccounts (/Users/ryan/code/public/cdp-sdk/typescript/src/client/evm/evm.ts:282:25)
    at async EvmClient.ClassToWrap.<computed> (/Users/ryan/code/public/cdp-sdk/typescript/src/analytics.ts:115:16)
    at async main (/Users/ryan/code/public/cdp-sdk/typescript/src/examples/evm/listAccounts.ts:15:14) {
  statusCode: 0,
  errorType: 'unknown',
  errorMessage: 'getaddrinfo ENOTFOUND invalid-path-url',
  correlationId: undefined,
  errorLink: 'https://docs.cdp.coinbase.com/api-v2/docs/errors#unknown'
}
```

**Manually throwing error**

I removed the call to `await axiosInstance(configWithIdempotencyKey)` in `cdpApiClient` to just throw a new error. This triggers an error path where something calamitous has occurred.

```
UnknownError: Something went wrong. Please reach out at https://discord.com/channels/1220414409550336183/1271495764580896789 for help.
    at cdpApiClient (/Users/ryan/code/public/cdp-sdk/typescript/src/openapi-client/cdpApiClient.ts:194:11)
    at Object.listEvmAccounts (/Users/ryan/code/public/cdp-sdk/typescript/src/openapi-client/generated/evm-accounts/evm-accounts.ts:34:10)
    ... 6 lines matching cause stack trace ...
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:116:5) {
  [cause]: Error: boom
      at cdpApiClient (/Users/ryan/code/public/cdp-sdk/typescript/src/openapi-client/cdpApiClient.ts:125:11)
      at Object.listEvmAccounts (/Users/ryan/code/public/cdp-sdk/typescript/src/openapi-client/generated/evm-accounts/evm-accounts.ts:34:10)
      at EvmClient.listAccounts (/Users/ryan/code/public/cdp-sdk/typescript/src/client/evm/evm.ts:282:48)
      at EvmClient.ClassToWrap.<computed> (/Users/ryan/code/public/cdp-sdk/typescript/src/analytics.ts:115:37)
      at main (/Users/ryan/code/public/cdp-sdk/typescript/src/examples/evm/listAccounts.ts:15:28)
      at <anonymous> (/Users/ryan/code/public/cdp-sdk/typescript/src/examples/evm/listAccounts.ts:25:1)
      at ModuleJob.run (node:internal/modules/esm/module_job:271:25)
      at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:578:26)
      at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:116:5)
}
``` 

<!--
When adding new functionality or fixing a bug, you should be testing your changes with one or more
API method examples in the examples directory.

Please provide samples of the methods you tested with, the outputs for each method,
and any other relevant context, like which network was used.

Use the following format if helpful:

```
Method: <name of method used>
Network: <network used>
Setup: <any other relevant context>

Output:
<example output>
```

For example:

```
Method: createAccount
Network: Base Sepolia

Output:
EVM Account Address:  0xC2c7D554292Bb6AE502fafc3F5c0C46B534d6f31
```
 -->

## Checklist

A couple of things to include in your PR for completeness:

- [x] Added a changelog entry

<!--
For instructions on adding changelog entries:
See here for TypeScript: https://github.com/coinbase/cdp-sdk/blob/main/typescript/CONTRIBUTING.md#changelog
and here for Python: https://github.com/coinbase/cdp-sdk/blob/main/python/CONTRIBUTING.md#changelog
-->
