### PR TITLE
Fix typo in contract.ts: "inferrable" -> "inferable"

### DIFF
--- a/typescript/src/types/contract.ts
+++ b/typescript/src/types/contract.ts
@@ -113,7 +113,7 @@ export type ContractFunctionParameters<
   allFunctionNames = ContractFunctionName<abi, mutability>,
   allArgs = ContractFunctionArgs<abi, mutability, functionName>,
   /*
-   * when `args` is inferred to `readonly []` ("inputs": []) or `never` (`abi` declared as `Abi` or not inferrable), allow `args` to be optional.
+   * when `args` is inferred to `readonly []` ("inputs": []) or `never` (`abi` declared as `Abi` or not inferable), allow `args` to be optional.
    * important that both branches return same structural type
    */
 > = {


### PR DESCRIPTION
Fixed a typo in the comment documentation where "inferrable" was incorrectly spelled. Changed to "inferable" which is the correct spelling when referring to type inference capabilities.

This change improves code documentation accuracy without affecting any functionality.