### PR TITLE
depps: bumped dependencies for agentkit support

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -8,13 +8,13 @@ requires-python = ">=3.10"
 
 dependencies = [
     "cryptography>=42.0.0",
-    "pydantic==2.10.3",
+    "pydantic>=2.10.3,<=2.10.4",
     "PyJWT>=2.10.1",
     "python-dateutil==2.9.0.post0",
-    "urllib3==2.2.3",
+    "urllib3>=2.2.3,<=2.3.0",
     "aiohttp==3.11.16",
     "aiohttp-retry==2.9.1",
-    "web3==7.6.0",
+    "web3>=7.6.0,<=7.10.0",
 ]
 
 [project.optional-dependencies]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -291,7 +291,7 @@ requires-dist = [
     { name = "aiohttp-retry", specifier = "==2.9.1" },
     { name = "cryptography", specifier = ">=42.0.0" },
     { name = "myst-parser", marker = "extra == 'dev'", specifier = ">=4.0.1" },
-    { name = "pydantic", specifier = "==2.10.3" },
+    { name = "pydantic", specifier = ">=2.10.3,<=2.10.4" },
     { name = "pyjwt", specifier = ">=2.10.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.26.0" },
@@ -306,8 +306,8 @@ requires-dist = [
     { name = "sphinx-autodoc-typehints", marker = "extra == 'dev'", specifier = ">=3.0.1" },
     { name = "sphinxcontrib-napoleon", marker = "extra == 'dev'", specifier = ">=0.7" },
     { name = "towncrier", marker = "extra == 'dev'", specifier = ">=24.8.0,<25" },
-    { name = "urllib3", specifier = "==2.2.3" },
-    { name = "web3", specifier = "==7.6.0" },
+    { name = "urllib3", specifier = ">=2.2.3,<=2.3.0" },
+    { name = "web3", specifier = ">=7.6.0,<=7.10.0" },
 ]
 provides-extras = ["dev"]
 


### PR DESCRIPTION
## Description

Due to the amount of action providers in AgentKit, and the requirement in Python that only one version of each package be loaded into an environment, we're finding that the dependencies of `cdp-sdk` are slightly too strict.

This PR updates the ranges of 3 dependencies just enough that AgentKit will be able to properly use `cdp-sdk`

## Tests

Untested beyond installing and building. This will get indirectly tested against the next AgentKit Python release that is in development, as I made these changes locally to build against.

## Checklist

![Screenshot 2025-05-01 at 11 06 50 AM](https://github.com/user-attachments/assets/70d739ef-00f0-4571-a711-30d21f48f839)
