### PR TITLE
feat(typescript): Add getOrCreateAccount for evm and solana

### DIFF
--- a/examples/typescript/evm/getOrCreateAccount.ts
+++ b/examples/typescript/evm/getOrCreateAccount.ts
@@ -14,3 +14,11 @@ console.log("EVM Account 2 Address: ", account2.address);
 
 const areAccountsEqual = account.address === account2.address;
 console.log("Are accounts equal? ", areAccountsEqual);
+
+const accountPromise1 = cdp.evm.getOrCreateAccount({ name: 'Account' });
+const accountPromise2 = cdp.evm.getOrCreateAccount({ name: 'Account' });
+
+Promise.all([accountPromise1, accountPromise2]).then(([account1, account2]) => {
+  console.log("EVM Account Address 1: ", account1.address);
+  console.log("EVM Account Address 2: ", account2.address);
+});

--- a/examples/typescript/evm/getOrCreateAccount.ts
+++ b/examples/typescript/evm/getOrCreateAccount.ts
@@ -1,0 +1,16 @@
+// Usage: pnpm tsx evm/getOrCreateAccount.ts
+
+import { CdpClient } from "@coinbase/cdp-sdk";
+
+const cdp = new CdpClient();
+
+// Get or create an account
+const name = 'Account1';
+const account = await cdp.evm.getOrCreateAccount({ name });
+console.log("EVM Account Address: ", account.address);
+
+const account2 = await cdp.evm.getOrCreateAccount({ name });
+console.log("EVM Account 2 Address: ", account2.address);
+
+const areAccountsEqual = account.address === account2.address;
+console.log("Are accounts equal? ", areAccountsEqual);

--- a/examples/typescript/evm/getOrCreateAccount.ts
+++ b/examples/typescript/evm/getOrCreateAccount.ts
@@ -17,8 +17,9 @@ console.log("Are accounts equal? ", areAccountsEqual);
 
 const accountPromise1 = cdp.evm.getOrCreateAccount({ name: 'Account' });
 const accountPromise2 = cdp.evm.getOrCreateAccount({ name: 'Account' });
-
-Promise.all([accountPromise1, accountPromise2]).then(([account1, account2]) => {
+const accountPromise3 = cdp.evm.getOrCreateAccount({ name: 'Account' });
+Promise.all([accountPromise1, accountPromise2, accountPromise3]).then(([account1, account2, account3]) => {
   console.log("EVM Account Address 1: ", account1.address);
   console.log("EVM Account Address 2: ", account2.address);
+  console.log("EVM Account Address 3: ", account3.address);
 });

--- a/examples/typescript/solana/getOrCreateAccount.ts
+++ b/examples/typescript/solana/getOrCreateAccount.ts
@@ -1,0 +1,23 @@
+// Usage: pnpm tsx solana/getOrCreateAccount.ts
+
+import { CdpClient } from "@coinbase/cdp-sdk";
+
+const cdp = new CdpClient();
+
+const account = await cdp.solana.getOrCreateAccount({ name: "Account1" });
+console.log(
+  "Account:",
+  JSON.stringify(account, null, 2)
+);
+
+const account2 = await cdp.solana.getAccount({
+  address: account.address,
+});
+
+console.log(
+  "Account 2:",
+  JSON.stringify(account, null, 2)
+);
+
+const areAccountsEqual = account.address === account2.address;
+console.log("Are accounts equal? ", areAccountsEqual);

--- a/examples/typescript/solana/getOrCreateAccount.ts
+++ b/examples/typescript/solana/getOrCreateAccount.ts
@@ -24,8 +24,9 @@ console.log("Are accounts equal? ", areAccountsEqual);
 
 const accountPromise1 = cdp.solana.getOrCreateAccount({ name: 'Account' });
 const accountPromise2 = cdp.solana.getOrCreateAccount({ name: 'Account' });
-
-Promise.all([accountPromise1, accountPromise2]).then(([account1, account2]) => {
+const accountPromise3 = cdp.solana.getOrCreateAccount({ name: 'Account' });
+Promise.all([accountPromise1, accountPromise2, accountPromise3]).then(([account1, account2, account3]) => {
   console.log("Solana Account Address 1: ", account1.address);
   console.log("Solana Account Address 2: ", account2.address);
+  console.log("Solana Account Address 3: ", account3.address);
 });

--- a/examples/typescript/solana/getOrCreateAccount.ts
+++ b/examples/typescript/solana/getOrCreateAccount.ts
@@ -21,3 +21,11 @@ console.log(
 
 const areAccountsEqual = account.address === account2.address;
 console.log("Are accounts equal? ", areAccountsEqual);
+
+const accountPromise1 = cdp.solana.getOrCreateAccount({ name: 'Account' });
+const accountPromise2 = cdp.solana.getOrCreateAccount({ name: 'Account' });
+
+Promise.all([accountPromise1, accountPromise2]).then(([account1, account2]) => {
+  console.log("Solana Account Address 1: ", account1.address);
+  console.log("Solana Account Address 2: ", account2.address);
+});

--- a/typescript/.changeset/slow-meals-knock.md
+++ b/typescript/.changeset/slow-meals-knock.md
@@ -2,4 +2,4 @@
 "@coinbase/cdp-sdk": minor
 ---
 
-Added a getOrCreateAccount function to the EVM client
+Added a getOrCreateAccount function to the EVM and Solana clients

--- a/typescript/.changeset/slow-meals-knock.md
+++ b/typescript/.changeset/slow-meals-knock.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/cdp-sdk": minor
+---
+
+Added a getOrCreateAccount function to the EVM client

--- a/typescript/src/README.md
+++ b/typescript/src/README.md
@@ -102,13 +102,29 @@ const cdp = new CdpClient({
 #### Create an EVM account as follows:
 
 ```typescript
-const evmAccount = await cdp.evm.createAccount();
+const account = await cdp.evm.createAccount();
 ```
 
 #### Create a Solana account as follows:
 
 ```typescript
-const solanaAccount = await cdp.solana.createAccount();
+const account = await cdp.solana.createAccount();
+```
+
+#### Get or Create an EVM account as follows:
+
+```typescript
+const account = await cdp.evm.getOrCreateAccount({
+  name: 'Account1'
+});
+```
+
+#### Get or Create a Solana account as follows:
+
+```typescript
+const account = await cdp.solana.getOrCreateAccount({
+  name: 'Account1'
+});
 ```
 
 ### Testnet faucet

--- a/typescript/src/accounts/evm/toEvmSmartAccount.ts
+++ b/typescript/src/accounts/evm/toEvmSmartAccount.ts
@@ -30,7 +30,6 @@ export type ToEvmSmartAccountOptions = {
  * @param {EvmSmartAccount} options.smartAccount - The deployed evm smart account.
  * @param {EvmAccount} options.owner - The owner which signs for the smart account.
  * @returns {EvmSmartAccount} A configured EvmSmartAccount instance ready for user operation submission.
- * @throws {Error} If the account is not an original owner of the smart account.
  */
 export function toEvmSmartAccount(
   apiClient: CdpOpenApiClientType,

--- a/typescript/src/client/evm/evm.ts
+++ b/typescript/src/client/evm/evm.ts
@@ -27,6 +27,7 @@ import {
   ListTokenBalancesResult,
   SendTransactionOptions,
   TransactionResult,
+  GetOrCreateServerAccountOptions,
 } from "./evm.types.js";
 import { toEvmServerAccount } from "../../accounts/evm/toEvmServerAccount.js";
 import { toEvmSmartAccount } from "../../accounts/evm/toEvmSmartAccount.js";
@@ -38,6 +39,7 @@ import {
   waitForUserOperation,
   WaitForUserOperationReturnType,
 } from "../../actions/evm/waitForUserOperation.js";
+import { APIError } from "../../openapi-client/errors.js";
 import { CdpOpenApiClient } from "../../openapi-client/index.js";
 import { Hex } from "../../types/misc.js";
 
@@ -220,6 +222,36 @@ export class EvmClient implements EvmClientInterface {
       smartAccount,
       owner: options.owner,
     });
+  }
+
+  /**
+   * Gets a CDP EVM account, or creates one if it doesn't exist.
+   *
+   * @param {GetOrCreateServerAccountOptions} options - Parameters for getting or creating the account.
+   * @param {string} [options.name] - The name of the account to get or create.
+   *
+   * @returns A promise that resolves to the account.
+   *
+   * @example
+   * ```ts
+   * const account = await cdp.evm.getOrCreateAccount({
+   *   name: "MyAccount",
+   * });
+   * ```
+   */
+  async getOrCreateAccount(options: GetOrCreateServerAccountOptions): Promise<ServerAccount> {
+    try {
+      const account = await this.getAccount(options);
+      return account;
+    } catch (error) {
+      // If it failed because the account doesn't exist, create it
+      const doesAccountNotExist = error instanceof APIError && error.statusCode === 404;
+      if (doesAccountNotExist) {
+        return await this.createAccount(options);
+      }
+
+      throw error;
+    }
   }
 
   /**

--- a/typescript/src/client/evm/evm.ts
+++ b/typescript/src/client/evm/evm.ts
@@ -247,7 +247,17 @@ export class EvmClient implements EvmClientInterface {
       // If it failed because the account doesn't exist, create it
       const doesAccountNotExist = error instanceof APIError && error.statusCode === 404;
       if (doesAccountNotExist) {
-        return await this.createAccount(options);
+        try {
+          const account = await this.createAccount(options);
+          return account;
+        } catch (error) {
+          // If it failed because the account already exists, throw an error
+          const doesAccountAlreadyExist = error instanceof APIError && error.statusCode === 409;
+          if (doesAccountAlreadyExist) {
+            throw new Error("Failed to create account");
+          }
+          throw error;
+        }
       }
 
       throw error;

--- a/typescript/src/client/evm/evm.ts
+++ b/typescript/src/client/evm/evm.ts
@@ -254,7 +254,8 @@ export class EvmClient implements EvmClientInterface {
           // If it failed because the account already exists, throw an error
           const doesAccountAlreadyExist = error instanceof APIError && error.statusCode === 409;
           if (doesAccountAlreadyExist) {
-            throw new Error("Failed to create account");
+            const account = await this.getAccount(options);
+            return account;
           }
           throw error;
         }

--- a/typescript/src/client/evm/evm.types.ts
+++ b/typescript/src/client/evm/evm.types.ts
@@ -42,6 +42,7 @@ export type EvmClientInterface = Omit<
   createSmartAccount: (options: CreateSmartAccountOptions) => Promise<SmartAccount>;
   getAccount: (options: GetServerAccountOptions) => Promise<ServerAccount>;
   getSmartAccount: (options: GetSmartAccountOptions) => Promise<SmartAccount>;
+  getOrCreateAccount: (options: GetOrCreateServerAccountOptions) => Promise<ServerAccount>;
   getUserOperation: (options: GetUserOperationOptions) => Promise<UserOperation>;
   listAccounts: (options: ListServerAccountsOptions) => Promise<ListServerAccountResult>;
   listSmartAccounts: (options: ListSmartAccountsOptions) => Promise<ListSmartAccountResult>;
@@ -145,6 +146,14 @@ export interface GetSmartAccountOptions {
   address: Address;
   /** The owner of the account. */
   owner: Account;
+}
+
+/**
+ * Options for getting an EVM account, or creating one if it doesn't exist.
+ */
+export interface GetOrCreateServerAccountOptions {
+  /** The name of the account. */
+  name: string;
 }
 
 /**

--- a/typescript/src/client/solana/solana.ts
+++ b/typescript/src/client/solana/solana.ts
@@ -119,7 +119,8 @@ export class SolanaClient implements SolanaClientInterface {
           // If it failed because the account already exists, throw an error
           const doesAccountAlreadyExist = error instanceof APIError && error.statusCode === 409;
           if (doesAccountAlreadyExist) {
-            throw new Error("Failed to create account");
+            const account = await this.getAccount(options);
+            return account;
           }
           throw error;
         }

--- a/typescript/src/client/solana/solana.ts
+++ b/typescript/src/client/solana/solana.ts
@@ -112,7 +112,17 @@ export class SolanaClient implements SolanaClientInterface {
       // If it failed because the account doesn't exist, create it
       const doesAccountNotExist = error instanceof APIError && error.statusCode === 404;
       if (doesAccountNotExist) {
-        return await this.createAccount(options);
+        try {
+          const account = await this.createAccount(options);
+          return account;
+        } catch (error) {
+          // If it failed because the account already exists, throw an error
+          const doesAccountAlreadyExist = error instanceof APIError && error.statusCode === 409;
+          if (doesAccountAlreadyExist) {
+            throw new Error("Failed to create account");
+          }
+          throw error;
+        }
       }
 
       throw error;

--- a/typescript/src/client/solana/solana.ts
+++ b/typescript/src/client/solana/solana.ts
@@ -9,7 +9,9 @@ import {
   SignatureResult,
   SignMessageOptions,
   SignTransactionOptions,
+  GetOrCreateAccountOptions,
 } from "./solana.types.js";
+import { APIError } from "../../openapi-client/errors.js";
 import { CdpOpenApiClient } from "../../openapi-client/index.js";
 
 /**
@@ -85,6 +87,36 @@ export class SolanaClient implements SolanaClientInterface {
     }
 
     throw new Error("Either address or name must be provided");
+  }
+
+  /**
+   * Gets a Solana account by its address.
+   *
+   * @param {GetOrCreateAccountOptions} options - Parameters for getting or creating the Solana account.
+   * @param {string} options.name - The name of the account.
+   *
+   * @returns A promise that resolves to the account.
+   *
+   * @example
+   * ```ts
+   * const account = await cdp.solana.getOrCreateAccount({
+   *   name: "MyAccount",
+   * });
+   * ```
+   */
+  async getOrCreateAccount(options: GetOrCreateAccountOptions): Promise<Account> {
+    try {
+      const account = await this.getAccount(options);
+      return account;
+    } catch (error) {
+      // If it failed because the account doesn't exist, create it
+      const doesAccountNotExist = error instanceof APIError && error.statusCode === 404;
+      if (doesAccountNotExist) {
+        return await this.createAccount(options);
+      }
+
+      throw error;
+    }
   }
 
   /**

--- a/typescript/src/client/solana/solana.types.ts
+++ b/typescript/src/client/solana/solana.types.ts
@@ -17,6 +17,7 @@ export type SolanaClientInterface = Omit<
 > & {
   createAccount: (options: CreateAccountOptions) => Promise<Account>;
   getAccount: (options: GetAccountOptions) => Promise<Account>;
+  getOrCreateAccount: (options: GetOrCreateAccountOptions) => Promise<Account>;
   listAccounts: (options: ListAccountsOptions) => Promise<ListAccountsResult>;
   requestFaucet: (options: RequestFaucetOptions) => Promise<SignatureResult>;
   signMessage: (options: SignMessageOptions) => Promise<SignatureResult>;
@@ -45,6 +46,14 @@ export interface GetAccountOptions {
   address?: string;
   /** The name of the account. */
   name?: string;
+}
+
+/**
+ * Options for getting a Solana account.
+ */
+export interface GetOrCreateAccountOptions {
+  /** The name of the account. */
+  name: string;
 }
 
 /**

--- a/typescript/src/e2e.test.ts
+++ b/typescript/src/e2e.test.ts
@@ -59,7 +59,7 @@ describe("CDP Client E2E Tests", () => {
 
     testAccount = await cdp.evm.getOrCreateAccount({ name: testAccountName });
     testSmartAccount = await cdp.evm.getSmartAccount({
-      address: '0x4a743D054E357592E02065Cfe54db95D66B7575b',
+      address: testSmartAccountAddress,
       owner: testAccount,
     });
   });
@@ -375,7 +375,7 @@ describe("CDP Client E2E Tests", () => {
       });
     });
   });
-  
+
   describe("get or create account", () => {
     it("should get or create an evm account", async () => {
       const randomName = generateRandomName();

--- a/typescript/src/e2e.test.ts
+++ b/typescript/src/e2e.test.ts
@@ -57,9 +57,9 @@ describe("CDP Client E2E Tests", () => {
       transport: http(),
     });
 
-    testAccount = await cdp.evm.getAccount({ name: testAccountName });
+    testAccount = await cdp.evm.getOrCreateAccount({ name: testAccountName });
     testSmartAccount = await cdp.evm.getSmartAccount({
-      address: testSmartAccountAddress,
+      address: '0x4a743D054E357592E02065Cfe54db95D66B7575b',
       owner: testAccount,
     });
   });
@@ -373,6 +373,34 @@ describe("CDP Client E2E Tests", () => {
 
         expect(status).toBe("success");
       });
+    });
+  });
+  
+  describe("get or create account", () => {
+    it("should get or create an evm account", async () => {
+      const randomName = generateRandomName();
+      const account = await cdp.evm.getOrCreateAccount({ name: randomName });
+      expect(account.name).toBe(randomName);
+      const account2 = await cdp.evm.getOrCreateAccount({ name: randomName });
+      expect(account2.name).toBe(randomName);
+      expect(account.address).toBe(account2.address);
+    });
+
+    it("should get or create a solana account", async () => {
+      const randomName = generateRandomName();
+      const account = await cdp.solana.getOrCreateAccount({ name: randomName });
+      expect(account.name).toBe(randomName);
+      const account2 = await cdp.solana.getOrCreateAccount({ name: randomName });
+      expect(account2.name).toBe(randomName);
+      expect(account.address).toBe(account2.address);
+    });
+
+    it("should handle race condition", async () => {
+      const randomName = generateRandomName();
+      const accountPromise1 = cdp.evm.getOrCreateAccount({ name: randomName });
+      const accountPromise2 = cdp.evm.getOrCreateAccount({ name: randomName });
+      const [account1, account2] = await Promise.all([accountPromise1, accountPromise2]);
+      expect(account1.address).toBe(account2.address);
     });
   });
 });


### PR DESCRIPTION
<!--
Thanks for contributing to CDP SDK!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

Add `getOrCreateAccount` functions to both the evm and solana sdks to combine the account existence check with conditional account creation, for faster and better devx.

There was discussion around including an additional `created` bool field to the account to denote whether the account was created by the function, or whether it previously existed. However, on further thought, that field is omitted because it would likely cause more pain than not because it changes the structure returned to consumers who may be simply expecting the normal `Account` type. In the scenario devs really want it, they may just use the separate get and create functions Let me know if you still strongly believe we should add it.

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
 -->

## Tests

Added unit tests and examples
<!--
When adding new functionality or fixing a bug, you should be testing your changes with one or more
API method examples in the examples directory.

Please provide samples of the methods you tested with, the outputs for each method,
and any other relevant context, like which network was used.

Use the following format if helpful:

```
Method: <name of method used>
Network: <network used>
Setup: <any other relevant context>

Output:
<example output>
```

For example:

```
Method: createAccount
Network: Base Sepolia

Output:
EVM Account Address:  0xC2c7D554292Bb6AE502fafc3F5c0C46B534d6f31
```
 -->

## Checklist

A couple of things to include in your PR for completeness:

- [x] Updated the [typescript README](https://github.com/coinbase/cdp-sdk/blob/main/typescript/src/README.md)
- [x] Added a changelog entry
- [x] Added e2e tests

<!--
For instructions on adding changelog entries:
See here for TypeScript: https://github.com/coinbase/cdp-sdk/blob/main/typescript/CONTRIBUTING.md#changelog
and here for Python: https://github.com/coinbase/cdp-sdk/blob/main/python/CONTRIBUTING.md#changelog
-->
