### PR TITLE
chore(typescript): automate release process

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -1,9 +1,15 @@
 name: Deploy CDP SDK documentation to GitHub Pages
 
 on:
+  workflow_call:
+    inputs:
+      language:
+        required: true
+        type: string
+
   workflow_dispatch:
     inputs:
-      choice:
+      language:
         description: "SDK language to deploy"
         required: true
         type: choice
@@ -20,7 +26,7 @@ permissions:
 
 jobs:
   deploy-typescript-docs:
-    if: inputs.choice == 'typescript'
+    if: inputs.language == 'typescript'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -95,7 +101,7 @@ jobs:
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
 
   deploy-python-docs:
-    if: inputs.choice == 'python'
+    if: inputs.language == 'python'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -175,7 +181,7 @@ jobs:
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
 
   deploy-go-docs:
-    if: inputs.choice == 'go'
+    if: inputs.language == 'go'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/typescript_publish.yml
+++ b/.github/workflows/typescript_publish.yml
@@ -2,20 +2,26 @@ name: Publish @coinbase/cdp-sdk
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read
   id-token: write
+  pull-requests: write
 
 defaults:
   run:
     working-directory: ./typescript
 
 jobs:
-  publish:
-    name: Publish
+  changeset:
+    name: Version or Publish
     runs-on: ubuntu-latest
     environment: npm
+    outputs:
+      published: ${{ steps.changesets.outputs.published }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -36,12 +42,24 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build
-        run: pnpm run build
-
-      - name: Publish
-        run: |
-          pnpm run prepublish
-          pnpm publish --recursive --no-git-checks --provenance --access public
+      - name: Version or Publish
+        id: changesets
+        uses: changesets/action@746c25e23caa47dceb6a48ee85b4cbc5a9f5f293 # v1.5.0
+        with:
+          commit: "chore: bump @coinbase/cdp-sdk"
+          title: "chore: bump @coinbase/cdp-sdk"
+          commitMode: "github-api"
+          publish: pnpm run changeset:publish
+          version: pnpm run changeset:version
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  deploy-docs:
+    name: Deploy docs
+    needs: changeset
+    if: needs.changeset.outputs.published == 'true'
+    uses: ./.github/workflows/deploy-gh-pages.yml
+    with:
+      language: typescript
+    secrets: inherit

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,30 +15,14 @@ This section contains step-by-step instructions for publishing new versions of t
 
 ### TypeScript
 
-#### First time setup
-
-For PR linking and author attribution, you'll need a GitHub Personal Access Token.
-
-1. Go to https://github.com/settings/tokens and create a GitHub PAT with `read:user` and `repo:status` scopes. This is for author attribution
-2. Export your token in your shell (`export GITHUB_TOKEN={YOUR_TOKEN}`), and optionally save it to your shell profile (`echo "\nexport GITHUB_TOKEN={YOUR_TOKEN}" >> ~/.zshrc`)
-
-#### Publishing
-
 Follow these steps to publish a new version of the TypeScript CDP SDK.
 
-1. Ensure you are on the `main` branch and have the latest changes
-1. Create a new branch for your changes, e.g. `bump/ts`. The branch name doesn't matter, and you will delete this branch after the release
-1. From the `typescript` folder, run `pnpm changeset:version` to automatically bump the version and create a new changelog. Make note of the new version, as this will be used in subsequent steps
-1. Manually update `src/version.ts` with the new version
-1. Add and commit the changes with the message: `chore: bump @coinbase/cdp-sdk to {NEW_VERSION}`
-1. Push your branch, create a PR and get an approval
-1. Once approved, merge your PR
-1. Once merged, manually trigger the [Publish @coinbase/cdp-sdk](https://github.com/coinbase/cdp-sdk/actions/workflows/typescript_publish.yml) workflow
-1. Once the workflow has completed, go back to the `main` branch and pull the latest changes
-1. Tag the new version with `git tag -s @coinbase/cdp-sdk@v{NEW_VERSION} -m "Release @coinbase/cdp-sdk {NEW_VERSION}"`
-1. Push the tag with `git push origin @coinbase/cdp-sdk@v{NEW_VERSION}`
-1. Delete your release branch
-1. Trigger the [Deploy CDP SDK documentation to GitHub Pages](https://github.com/coinbase/cdp-sdk/actions/workflows/deploy-gh-pages.yml) action. Select `typescript` as the language to deploy
+1. Look for the auto-generated version bump PR titled `chore: bump @coinbase/cdp-sdk`
+1. Approve and merge the PR. The [publish workflow](https://github.com/coinbase/cdp-sdk/actions/workflows/typescript_publish.yml) will automatically kick off
+1. Done! The publish workflow takes care of everything. To verify, you can check the following:
+   - The [new package is on NPM](https://www.npmjs.com/package/@coinbase/cdp-sdk)
+   - The [deploy docs workflow](https://github.com/coinbase/cdp-sdk/actions/workflows/deploy-gh-pages.yml) has completed successfully
+   - The version is [tagged](https://github.com/coinbase/cdp-sdk/tags) and [released](https://github.com/coinbase/cdp-sdk/releases)
 
 ### Python
 

--- a/typescript/.eslintrc.json
+++ b/typescript/.eslintrc.json
@@ -18,7 +18,6 @@
     "sourceType": "module"
   },
   "rules": {
-    "multiline-comment-style": ["error", "starred-block"],
     "prettier/prettier": "error",
     "@typescript-eslint/member-ordering": "error",
     "jsdoc/tag-lines": ["error", "any", { "startLines": 1 }],

--- a/typescript/.npmrc
+++ b/typescript/.npmrc
@@ -1,0 +1,1 @@
+provenance=true

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -8,7 +8,8 @@
     "build:esm": "tsc --project ./tsconfig.esm.json && printf '{\"type\": \"module\",\"sideEffects\":false}' > ./src/_esm/package.json",
     "build:types": "tsc --project ./tsconfig.types.json",
     "changeset": "changeset",
-    "changeset:version": "changeset version",
+    "changeset:publish": "pnpm build && pnpm prepublish && changeset publish",
+    "changeset:version": "changeset version && pnpm version:update",
     "clean": "rm -rf src/_esm src/_cjs src/_types",
     "docs": "typedoc --entryPoints ./src --entryPointStrategy expand --exclude ./src/tests/**/*.ts",
     "format": "prettier -c .prettierrc --write \"**/*.{ts,js,cjs,json,md}\"",
@@ -21,7 +22,8 @@
     "test:coverage": "vitest --config=./vitest.config.ts run --coverage",
     "test:e2e": "pnpm build && vitest --config=./vitest.e2e.config.ts run",
     "test:e2e:watch": "vitest --config=./vitest.e2e.config.ts",
-    "test:watch": "vitest --config=./vitest.config.ts"
+    "test:watch": "vitest --config=./vitest.config.ts",
+    "version:update": "pnpm tsx scripts/updateVersion.ts"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.5.1",

--- a/typescript/scripts/updateVersion.ts
+++ b/typescript/scripts/updateVersion.ts
@@ -1,0 +1,10 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const versionFilePath = join(import.meta.dirname, "../src/version.ts");
+const packageJsonPath = join(import.meta.dirname, "../src/package.json");
+
+const packageJson = await readFile(packageJsonPath, "utf-8");
+const packageVersion = JSON.parse(packageJson).version;
+
+await writeFile(versionFilePath, `export const version = "${packageVersion}";\n`);


### PR DESCRIPTION
<!--
Thanks for contributing to CDP SDK!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

This PR uses a feature freshly added to `changesets/action` which allows us to use the action while requiring and enforcing signed commits. The TypeScript release process is now fully automated, except for needing to post to Discord, which will also be automated soon.
