### PR TITLE
feat(python) Add support for EIP-712 signing

### DIFF
--- a/examples/python/evm/account.sign_typed_data.py
+++ b/examples/python/evm/account.sign_typed_data.py
@@ -1,0 +1,38 @@
+# Usage: uv run python evm/sign_typed_data.py
+
+import asyncio
+
+from cdp import CdpClient
+from cdp.openapi_client.models.eip712_domain import EIP712Domain
+from cdp.openapi_client.models.eip712_message import EIP712Message
+
+
+async def main():
+    async with CdpClient() as cdp:
+        account = await cdp.evm.get_or_create_account(name="Account1")
+        signature = await account.sign_typed_data(
+            message=EIP712Message(
+                domain=EIP712Domain(
+                    name="EIP712Domain",
+                    chain_id=1,
+                    verifying_contract="0x0000000000000000000000000000000000000000",
+                ),
+                types={
+                    "EIP712Domain": [
+                        {"name": "name", "type": "string"},
+                        {"name": "chainId", "type": "uint256"},
+                        {"name": "verifyingContract", "type": "address"},
+                    ],
+                },
+                primary_type="EIP712Domain",
+                message={
+                    "name": "EIP712Domain",
+                    "chainId": 1,
+                    "verifyingContract": "0x0000000000000000000000000000000000000000",
+                },
+            ),
+        )
+        print("Signature: ", signature)
+
+
+asyncio.run(main())

--- a/examples/python/evm/account.sign_typed_data.py
+++ b/examples/python/evm/account.sign_typed_data.py
@@ -1,36 +1,36 @@
-# Usage: uv run python evm/sign_typed_data.py
+# Usage: uv run python evm/account.sign_typed_data.py
 
 import asyncio
 
 from cdp import CdpClient
-from cdp.openapi_client.models.eip712_domain import EIP712Domain
-from cdp.openapi_client.models.eip712_message import EIP712Message
-
+from cdp.evm_message_types import EIP712Domain
 
 async def main():
     async with CdpClient() as cdp:
         account = await cdp.evm.get_or_create_account(name="Account1")
+        domain = EIP712Domain(
+            name="EIP712Domain",
+            chain_id=1,
+            verifying_contract="0x0000000000000000000000000000000000000000",
+        ).as_dict()
+        types = {
+            "EIP712Domain": [
+                {"name": "name", "type": "string"},
+                {"name": "chainId", "type": "uint256"},
+                {"name": "verifyingContract", "type": "address"},
+            ],
+        }
+        primary_type = "EIP712Domain"
+        message = {
+            "name": "EIP712Domain",
+            "chainId": 1,
+            "verifyingContract": "0x0000000000000000000000000000000000000000",
+        }
         signature = await account.sign_typed_data(
-            message=EIP712Message(
-                domain=EIP712Domain(
-                    name="EIP712Domain",
-                    chain_id=1,
-                    verifying_contract="0x0000000000000000000000000000000000000000",
-                ),
-                types={
-                    "EIP712Domain": [
-                        {"name": "name", "type": "string"},
-                        {"name": "chainId", "type": "uint256"},
-                        {"name": "verifyingContract", "type": "address"},
-                    ],
-                },
-                primary_type="EIP712Domain",
-                message={
-                    "name": "EIP712Domain",
-                    "chainId": 1,
-                    "verifyingContract": "0x0000000000000000000000000000000000000000",
-                },
-            ),
+            domain=domain,
+            types=types,
+            primary_type=primary_type,
+            message=message,
         )
         print("Signature: ", signature)
 

--- a/examples/python/evm/sign_typed_data.py
+++ b/examples/python/evm/sign_typed_data.py
@@ -9,8 +9,9 @@ from cdp.openapi_client.models.eip712_message import EIP712Message
 
 async def main():
     async with CdpClient() as cdp:
+        account = await cdp.evm.get_or_create_account(name="MyAccount")
         signature = await cdp.evm.sign_typed_data(
-            address="0x1234567890123456789012345678901234567890",
+            address=account.address,
             message=EIP712Message(
                 domain=EIP712Domain(
                     name="EIP712Domain",

--- a/examples/python/evm/sign_typed_data.py
+++ b/examples/python/evm/sign_typed_data.py
@@ -3,35 +3,36 @@
 import asyncio
 
 from cdp import CdpClient
-from cdp.openapi_client.models.eip712_domain import EIP712Domain
-from cdp.openapi_client.models.eip712_message import EIP712Message
+from cdp.evm_message_types import EIP712Domain
 
 
 async def main():
     async with CdpClient() as cdp:
         account = await cdp.evm.get_or_create_account(name="MyAccount")
+        domain = EIP712Domain(
+            name="EIP712Domain",
+            chain_id=1,
+            verifying_contract="0x0000000000000000000000000000000000000000",
+        ).as_dict()
+        types = {
+            "EIP712Domain": [
+                {"name": "name", "type": "string"},
+                {"name": "chainId", "type": "uint256"},
+                {"name": "verifyingContract", "type": "address"},
+            ],
+        }
+        primary_type = "EIP712Domain"
+        message = {
+            "name": "EIP712Domain",
+            "chainId": 1,
+            "verifyingContract": "0x0000000000000000000000000000000000000000",
+        }
         signature = await cdp.evm.sign_typed_data(
             address=account.address,
-            message=EIP712Message(
-                domain=EIP712Domain(
-                    name="EIP712Domain",
-                    chain_id=1,
-                    verifying_contract="0x0000000000000000000000000000000000000000",
-                ),
-                types={
-                    "EIP712Domain": [
-                        {"name": "name", "type": "string"},
-                        {"name": "chainId", "type": "uint256"},
-                        {"name": "verifyingContract", "type": "address"},
-                    ],
-                },
-                primary_type="EIP712Domain",
-                message={
-                    "name": "EIP712Domain",
-                    "chainId": 1,
-                    "verifyingContract": "0x0000000000000000000000000000000000000000",
-                },
-            ),
+            domain=domain,
+            types=types,
+            primary_type=primary_type,
+            message=message,
         )
         print("Signature: ", signature)
 

--- a/examples/python/evm/sign_typed_data.py
+++ b/examples/python/evm/sign_typed_data.py
@@ -1,0 +1,38 @@
+# Usage: uv run python evm/sign_typed_data.py
+
+import asyncio
+
+from cdp import CdpClient
+from cdp.openapi_client.models.eip712_domain import EIP712Domain
+from cdp.openapi_client.models.eip712_message import EIP712Message
+
+
+async def main():
+    async with CdpClient() as cdp:
+        signature = await cdp.evm.sign_typed_data(
+            address="0x1234567890123456789012345678901234567890",
+            message=EIP712Message(
+                domain=EIP712Domain(
+                    name="EIP712Domain",
+                    chain_id=1,
+                    verifying_contract="0x0000000000000000000000000000000000000000",
+                ),
+                types={
+                    "EIP712Domain": [
+                        {"name": "name", "type": "string"},
+                        {"name": "chainId", "type": "uint256"},
+                        {"name": "verifyingContract", "type": "address"},
+                    ],
+                },
+                primary_type="EIP712Domain",
+                message={
+                    "name": "EIP712Domain",
+                    "chainId": 1,
+                    "verifyingContract": "0x0000000000000000000000000000000000000000",
+                },
+            ),
+        )
+        print("Signature: ", signature)
+
+
+asyncio.run(main())

--- a/python/cdp/evm_client.py
+++ b/python/cdp/evm_client.py
@@ -336,8 +336,16 @@ class EvmClient:
             message (EIP712Message): The message to sign.
             idempotency_key (str, optional): The idempotency key. Defaults to None.
 
+        Returns:
+            str: The signature.
+
         """
-        raise NotImplementedError("Signing typed data is not yet implemented")
+        response = await self.api_clients.evm_accounts.sign_evm_typed_data(
+            address=address,
+            eip712_message=message,
+            x_idempotency_key=idempotency_key,
+        )
+        return response.signature
 
     async def sign_transaction(
         self, address: str, transaction: str, idempotency_key: str | None = None

--- a/python/cdp/evm_client.py
+++ b/python/cdp/evm_client.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from eth_account.signers.base import BaseAccount
 from eth_account.typed_transactions import DynamicFeeTransaction
 
@@ -19,6 +21,7 @@ from cdp.openapi_client.models.create_evm_account_request import CreateEvmAccoun
 from cdp.openapi_client.models.create_evm_smart_account_request import (
     CreateEvmSmartAccountRequest,
 )
+from cdp.openapi_client.models.eip712_domain import EIP712Domain
 from cdp.openapi_client.models.eip712_message import EIP712Message
 from cdp.openapi_client.models.evm_call import EvmCall
 from cdp.openapi_client.models.evm_user_operation import EvmUserOperation as EvmUserOperationModel
@@ -327,22 +330,37 @@ class EvmClient:
         return response.signature
 
     async def sign_typed_data(
-        self, address: str, message: EIP712Message, idempotency_key: str | None = None
+        self,
+        address: str,
+        domain: EIP712Domain,
+        types: dict[str, Any],
+        primary_type: str,
+        message: dict[str, Any],
+        idempotency_key: str | None = None,
     ) -> str:
         """Sign an EVM typed data.
 
         Args:
             address (str): The address of the account.
-            message (EIP712Message): The message to sign.
+            domain (EIP712Domain): The domain of the message.
+            types (Dict[str, Any]): The types of the message.
+            primary_type (str): The primary type of the message.
+            message (Dict[str, Any]): The message to sign.
             idempotency_key (str, optional): The idempotency key. Defaults to None.
 
         Returns:
             str: The signature.
 
         """
+        eip712_message = EIP712Message(
+            domain=domain,
+            types=types,
+            primary_type=primary_type,
+            message=message,
+        )
         response = await self.api_clients.evm_accounts.sign_evm_typed_data(
             address=address,
-            eip712_message=message,
+            eip712_message=eip712_message,
             x_idempotency_key=idempotency_key,
         )
         return response.signature

--- a/python/cdp/evm_message_types.py
+++ b/python/cdp/evm_message_types.py
@@ -1,0 +1,30 @@
+# flake8: noqa: N815
+# Ignoring mixed case because underlying library type uses camelCase
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class EIP712Domain(BaseModel):
+    """The domain of the EIP-712 typed data."""
+
+    model_config = {"populate_by_name": True}
+
+    name: str | None = Field(default=None, description="The name of the DApp or protocol.")
+    version: str | None = Field(default=None, description="The version of the DApp or protocol.")
+    chain_id: int | None = Field(
+        default=None, description="The chain ID of the EVM network.", alias="chainId"
+    )
+    verifying_contract: str | None = Field(
+        default=None,
+        description="The 0x-prefixed EVM address of the verifying smart contract.",
+        alias="verifyingContract",
+    )
+    salt: str | None = Field(
+        default=None, description="The optional 32-byte 0x-prefixed hex salt for domain separation."
+    )
+
+    def as_dict(self) -> dict[str, Any]:
+        """Serialize the EIP712Domain object to a dictionary."""
+        return self.model_dump(by_alias=True)

--- a/python/cdp/evm_server_account.py
+++ b/python/cdp/evm_server_account.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from eth_account.datastructures import (
     SignedMessage,
     SignedTransaction,
@@ -25,6 +27,7 @@ from cdp.api_clients import ApiClients
 from cdp.evm_token_balances import ListTokenBalancesResult
 from cdp.evm_transaction_types import TransactionRequestEIP1559
 from cdp.openapi_client.api.evm_accounts_api import EVMAccountsApi
+from cdp.openapi_client.models.eip712_domain import EIP712Domain
 from cdp.openapi_client.models.eip712_message import EIP712Message
 from cdp.openapi_client.models.evm_account import EvmAccount as EvmServerAccountModel
 from cdp.openapi_client.models.sign_evm_hash_request import SignEvmHashRequest
@@ -327,21 +330,35 @@ class EvmServerAccount(BaseAccount, BaseModel):
         )
 
     async def sign_typed_data(
-        self, message: EIP712Message, idempotency_key: str | None = None
+        self,
+        domain: EIP712Domain,
+        types: dict[str, Any],
+        primary_type: str,
+        message: dict[str, Any],
+        idempotency_key: str | None = None,
     ) -> str:
         """Sign an EVM typed data.
 
         Args:
-            message (EIP712Message): The message to sign.
+            domain (EIP712Domain): The domain of the message.
+            types (Dict[str, Any]): The types of the message.
+            primary_type (str): The primary type of the message.
+            message (Dict[str, Any]): The message to sign.
             idempotency_key (str, optional): The idempotency key. Defaults to None.
 
         Returns:
             str: The signature.
 
         """
+        eip712_message = EIP712Message(
+            domain=domain,
+            types=types,
+            primary_type=primary_type,
+            message=message,
+        )
         response = await self.__evm_accounts_api.sign_evm_typed_data(
             address=self.address,
-            eip712_message=message,
+            eip712_message=eip712_message,
             x_idempotency_key=idempotency_key,
         )
         return response.signature

--- a/python/cdp/evm_server_account.py
+++ b/python/cdp/evm_server_account.py
@@ -25,6 +25,7 @@ from cdp.api_clients import ApiClients
 from cdp.evm_token_balances import ListTokenBalancesResult
 from cdp.evm_transaction_types import TransactionRequestEIP1559
 from cdp.openapi_client.api.evm_accounts_api import EVMAccountsApi
+from cdp.openapi_client.models.eip712_message import EIP712Message
 from cdp.openapi_client.models.evm_account import EvmAccount as EvmServerAccountModel
 from cdp.openapi_client.models.sign_evm_hash_request import SignEvmHashRequest
 from cdp.openapi_client.models.sign_evm_message_request import SignEvmMessageRequest
@@ -324,6 +325,26 @@ class EvmServerAccount(BaseAccount, BaseModel):
             network,
             token,
         )
+
+    async def sign_typed_data(
+        self, message: EIP712Message, idempotency_key: str | None = None
+    ) -> str:
+        """Sign an EVM typed data.
+
+        Args:
+            message (EIP712Message): The message to sign.
+            idempotency_key (str, optional): The idempotency key. Defaults to None.
+
+        Returns:
+            str: The signature.
+
+        """
+        response = await self.__evm_accounts_api.sign_evm_typed_data(
+            address=self.address,
+            eip712_message=message,
+            x_idempotency_key=idempotency_key,
+        )
+        return response.signature
 
     async def list_token_balances(
         self,

--- a/python/cdp/openapi_client/models/eip712_message.py
+++ b/python/cdp/openapi_client/models/eip712_message.py
@@ -80,7 +80,7 @@ class EIP712Message(BaseModel):
 
     @classmethod
     def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
-        """Create an instance of EIP712Message from a dict"""
+        """Create an instance of EIP712Message from a dict."""
         if obj is None:
             return None
 

--- a/python/cdp/test/test_e2e.py
+++ b/python/cdp/test/test_e2e.py
@@ -14,7 +14,6 @@ from cdp.actions.evm.transfer.types import TransferOptions
 from cdp.evm_call_types import EncodedCall
 from cdp.evm_transaction_types import TransactionRequestEIP1559
 from cdp.openapi_client.models.eip712_domain import EIP712Domain
-from cdp.openapi_client.models.eip712_message import EIP712Message
 
 load_dotenv()
 
@@ -415,26 +414,24 @@ async def test_evm_sign_typed_data(cdp_client):
 
     signature = await cdp_client.evm.sign_typed_data(
         address=account.address,
-        message=EIP712Message(
-            domain=EIP712Domain(
-                name="EIP712Domain",
-                chain_id=1,
-                verifying_contract="0x0000000000000000000000000000000000000000",
-            ),
-            types={
-                "EIP712Domain": [
-                    {"name": "name", "type": "string"},
-                    {"name": "chainId", "type": "uint256"},
-                    {"name": "verifyingContract", "type": "address"},
-                ],
-            },
-            primary_type="EIP712Domain",
-            message={
-                "name": "EIP712Domain",
-                "chainId": 1,
-                "verifyingContract": "0x0000000000000000000000000000000000000000",
-            },
+        domain=EIP712Domain(
+            name="EIP712Domain",
+            chain_id=1,
+            verifying_contract="0x0000000000000000000000000000000000000000",
         ),
+        types={
+            "EIP712Domain": [
+                {"name": "name", "type": "string"},
+                {"name": "chainId", "type": "uint256"},
+                {"name": "verifyingContract", "type": "address"},
+            ],
+        },
+        primary_type="EIP712Domain",
+        message={
+            "name": "EIP712Domain",
+            "chainId": 1,
+            "verifyingContract": "0x0000000000000000000000000000000000000000",
+        },
     )
     assert signature is not None
 
@@ -447,26 +444,24 @@ async def test_evm_sign_typed_data_for_account(cdp_client):
     assert account is not None
 
     signature = await account.sign_typed_data(
-        message=EIP712Message(
-            domain=EIP712Domain(
-                name="EIP712Domain",
-                chain_id=1,
-                verifying_contract="0x0000000000000000000000000000000000000000",
-            ),
-            types={
-                "EIP712Domain": [
-                    {"name": "name", "type": "string"},
-                    {"name": "chainId", "type": "uint256"},
-                    {"name": "verifyingContract", "type": "address"},
-                ],
-            },
-            primary_type="EIP712Domain",
-            message={
-                "name": "EIP712Domain",
-                "chainId": 1,
-                "verifyingContract": "0x0000000000000000000000000000000000000000",
-            },
+        domain=EIP712Domain(
+            name="EIP712Domain",
+            chain_id=1,
+            verifying_contract="0x0000000000000000000000000000000000000000",
         ),
+        types={
+            "EIP712Domain": [
+                {"name": "name", "type": "string"},
+                {"name": "chainId", "type": "uint256"},
+                {"name": "verifyingContract", "type": "address"},
+            ],
+        },
+        primary_type="EIP712Domain",
+        message={
+            "name": "EIP712Domain",
+            "chainId": 1,
+            "verifyingContract": "0x0000000000000000000000000000000000000000",
+        },
     )
     assert signature is not None
 

--- a/python/cdp/test/test_e2e.py
+++ b/python/cdp/test/test_e2e.py
@@ -7,14 +7,14 @@ import pytest
 import pytest_asyncio
 from dotenv import load_dotenv
 from eth_account.account import Account
-from cdp.openapi_client.models.eip712_domain import EIP712Domain
-from cdp.openapi_client.models.eip712_message import EIP712Message
 from web3 import Web3
 
 from cdp import CdpClient
 from cdp.actions.evm.transfer.types import TransferOptions
 from cdp.evm_call_types import EncodedCall
 from cdp.evm_transaction_types import TransactionRequestEIP1559
+from cdp.openapi_client.models.eip712_domain import EIP712Domain
+from cdp.openapi_client.models.eip712_message import EIP712Message
 
 load_dotenv()
 
@@ -577,9 +577,9 @@ async def _ensure_sufficient_eth_balance(cdp_client, account):
 
         # Verify the balance is now sufficient
         new_balance = w3.eth.get_balance(account.address)
-        assert new_balance >= min_required_balance, (
-            f"Balance still insufficient after faucet request: {w3.from_wei(new_balance, 'ether')} ETH"
-        )
+        assert (
+            new_balance >= min_required_balance
+        ), f"Balance still insufficient after faucet request: {w3.from_wei(new_balance, 'ether')} ETH"
         return new_balance
     else:
         print(f"ETH balance is sufficient: {w3.from_wei(eth_balance, 'ether')} ETH")

--- a/python/cdp/test/test_evm_client.py
+++ b/python/cdp/test/test_evm_client.py
@@ -19,6 +19,8 @@ from cdp.openapi_client.models.create_evm_account_request import CreateEvmAccoun
 from cdp.openapi_client.models.create_evm_smart_account_request import (
     CreateEvmSmartAccountRequest,
 )
+from cdp.openapi_client.models.eip712_domain import EIP712Domain
+from cdp.openapi_client.models.eip712_message import EIP712Message
 from cdp.openapi_client.models.request_evm_faucet_request import RequestEvmFaucetRequest
 from cdp.openapi_client.models.send_evm_transaction200_response import SendEvmTransaction200Response
 from cdp.openapi_client.models.send_evm_transaction_request import SendEvmTransactionRequest
@@ -27,6 +29,7 @@ from cdp.openapi_client.models.sign_evm_message_request import SignEvmMessageReq
 from cdp.openapi_client.models.sign_evm_transaction_request import (
     SignEvmTransactionRequest,
 )
+from cdp.openapi_client.models.sign_evm_typed_data200_response import SignEvmTypedData200Response
 
 
 def test_init():
@@ -439,6 +442,55 @@ async def test_sign_message():
     mock_evm_accounts_api.sign_evm_message.assert_called_once_with(
         address=test_address,
         sign_evm_message_request=SignEvmMessageRequest(message=test_message),
+        x_idempotency_key=test_idempotency_key,
+    )
+
+    assert result == "0x123"
+
+
+@pytest.mark.asyncio
+async def test_sign_typed_data():
+    """Test signing an EVM typed data."""
+    mock_evm_accounts_api = AsyncMock()
+    mock_api_clients = AsyncMock()
+    mock_api_clients.evm_accounts = mock_evm_accounts_api
+
+    test_address = "0x1234567890123456789012345678901234567890"
+    test_message = EIP712Message(
+        domain=EIP712Domain(
+            name="Test",
+            chain_id=1,
+            verifying_contract="0x0000000000000000000000000000000000000000",
+        ),
+        types={
+            "EIP712Domain": [
+                {"name": "name", "type": "string"},
+                {"name": "chainId", "type": "uint256"},
+                {"name": "verifyingContract", "type": "address"},
+            ],
+        },
+        primary_type="EIP712Domain",
+        message={
+            "name": "EIP712Domain",
+            "chainId": 1,
+            "verifyingContract": "0x0000000000000000000000000000000000000000",
+        },
+    )
+    test_idempotency_key = "test-idempotency-key"
+
+    mock_evm_accounts_api.sign_evm_typed_data = AsyncMock(
+        return_value=SignEvmTypedData200Response(signature="0x123")
+    )
+
+    client = EvmClient(api_clients=mock_api_clients)
+
+    result = await client.sign_typed_data(
+        address=test_address, message=test_message, idempotency_key=test_idempotency_key
+    )
+
+    mock_evm_accounts_api.sign_evm_typed_data.assert_called_once_with(
+        address=test_address,
+        eip712_message=test_message,
         x_idempotency_key=test_idempotency_key,
     )
 

--- a/python/cdp/test/test_evm_client.py
+++ b/python/cdp/test/test_evm_client.py
@@ -456,26 +456,24 @@ async def test_sign_typed_data():
     mock_api_clients.evm_accounts = mock_evm_accounts_api
 
     test_address = "0x1234567890123456789012345678901234567890"
-    test_message = EIP712Message(
-        domain=EIP712Domain(
-            name="Test",
-            chain_id=1,
-            verifying_contract="0x0000000000000000000000000000000000000000",
-        ),
-        types={
-            "EIP712Domain": [
-                {"name": "name", "type": "string"},
-                {"name": "chainId", "type": "uint256"},
-                {"name": "verifyingContract", "type": "address"},
-            ],
-        },
-        primary_type="EIP712Domain",
-        message={
-            "name": "EIP712Domain",
-            "chainId": 1,
-            "verifyingContract": "0x0000000000000000000000000000000000000000",
-        },
+    domain = EIP712Domain(
+        name="Test",
+        chain_id=1,
+        verifying_contract="0x0000000000000000000000000000000000000000",
     )
+    types = {
+        "EIP712Domain": [
+            {"name": "name", "type": "string"},
+            {"name": "chainId", "type": "uint256"},
+            {"name": "verifyingContract", "type": "address"},
+        ],
+    }
+    primary_type = "EIP712Domain"
+    message = {
+        "name": "EIP712Domain",
+        "chainId": 1,
+        "verifyingContract": "0x0000000000000000000000000000000000000000",
+    }
     test_idempotency_key = "test-idempotency-key"
 
     mock_evm_accounts_api.sign_evm_typed_data = AsyncMock(
@@ -485,12 +483,22 @@ async def test_sign_typed_data():
     client = EvmClient(api_clients=mock_api_clients)
 
     result = await client.sign_typed_data(
-        address=test_address, message=test_message, idempotency_key=test_idempotency_key
+        address=test_address,
+        domain=domain,
+        types=types,
+        primary_type=primary_type,
+        message=message,
+        idempotency_key=test_idempotency_key,
     )
 
     mock_evm_accounts_api.sign_evm_typed_data.assert_called_once_with(
         address=test_address,
-        eip712_message=test_message,
+        eip712_message=EIP712Message(
+            domain=domain,
+            types=types,
+            primary_type=primary_type,
+            message=message,
+        ),
         x_idempotency_key=test_idempotency_key,
     )
 

--- a/python/changelog.d/132.feature.md
+++ b/python/changelog.d/132.feature.md
@@ -1,0 +1,1 @@
+Added support for eip-712 signing


### PR DESCRIPTION
<!--
Thanks for contributing to CDP SDK!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

With this PR, the cdp client and server accounts may now sign EIP-712 typed data.

For example:

```py
signature = await cdp.evm.sign_typed_data(
    address=account.address
    message=<eip-712-message>
)
```

or

```py
signature = await account.sign_typed_data(
    message=<eip-712-message>
)
```

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
 -->

## Tests

Added examples and unit tests.
- [x] E2E tests

<!--
When adding new functionality or fixing a bug, you should be testing your changes with one or more
API method examples in the examples directory.

Please provide samples of the methods you tested with, the outputs for each method,
and any other relevant context, like which network was used.

Use the following format if helpful:

```
Method: <name of method used>
Network: <network used>
Setup: <any other relevant context>

Output:
<example output>
```

For example:

```
Method: createAccount
Network: Base Sepolia

Output:
EVM Account Address:  0xC2c7D554292Bb6AE502fafc3F5c0C46B534d6f31
```
 -->

## Checklist

A couple of things to include in your PR for completeness:

- [ ] Updated the [python README](https://github.com/coinbase/cdp-sdk/blob/main/python/README.md) if relevant
- [x] Added a changelog entry

<!--
For instructions on adding changelog entries:
See here for TypeScript: https://github.com/coinbase/cdp-sdk/blob/main/typescript/CONTRIBUTING.md#changelog
and here for Python: https://github.com/coinbase/cdp-sdk/blob/main/python/CONTRIBUTING.md#changelog
-->
