### PR TITLE
patch(python): Improve policy response model

### DIFF
--- a/examples/python/policies/apply_policy_to_account.py
+++ b/examples/python/policies/apply_policy_to_account.py
@@ -10,8 +10,8 @@ from cdp.policies.types import (
     SignEvmTransactionRule,
     EvmNetworkCriterion,
     SendEvmTransactionRule,
-    SolAddressCriterion,
-    SignSolTransactionRule,
+    SolanaAddressCriterion,
+    SignSolanaTransactionRule,
 )
 from dotenv import load_dotenv
 
@@ -46,10 +46,10 @@ async def main():
                         ),
                     ],
                 ),
-                SignSolTransactionRule(
+                SignSolanaTransactionRule(
                     action="accept",
                     criteria=[
-                        SolAddressCriterion(
+                        SolanaAddressCriterion(
                             addresses=["123456789abcdef123456789abcdef12"],
                             operator="in",
                         ),

--- a/python/cdp/policies_client.py
+++ b/python/cdp/policies_client.py
@@ -8,7 +8,10 @@ from cdp.policies.types import (
     PolicyScope,
     UpdatePolicyOptions,
 )
-from cdp.policies.utils import map_policy_rules_to_openapi_format
+from cdp.policies.utils import (
+    map_openapi_rules_to_response_format,
+    map_request_rules_to_openapi_format,
+)
 
 
 class PoliciesClient:
@@ -32,13 +35,21 @@ class PoliciesClient:
             Policy: The created policy.
 
         """
-        return await self.api_clients.policies.create_policy(
+        openapi_policy = await self.api_clients.policies.create_policy(
             create_policy_request=CreatePolicyRequest(
                 scope=policy.scope,
                 description=policy.description,
-                rules=map_policy_rules_to_openapi_format(policy.rules),
+                rules=map_request_rules_to_openapi_format(policy.rules),
             ),
             x_idempotency_key=idempotency_key,
+        )
+        return Policy(
+            id=openapi_policy.id,
+            description=openapi_policy.description,
+            scope=openapi_policy.scope,
+            rules=map_openapi_rules_to_response_format(openapi_policy.rules),
+            created_at=openapi_policy.created_at,
+            updated_at=openapi_policy.updated_at,
         )
 
     async def update_policy(
@@ -60,13 +71,21 @@ class PoliciesClient:
             Policy: The updated policy.
 
         """
-        return await self.api_clients.policies.update_policy(
+        openapi_policy = await self.api_clients.policies.update_policy(
             policy_id=id,
             update_policy_request=UpdatePolicyRequest(
                 description=policy.description,
-                rules=map_policy_rules_to_openapi_format(policy.rules),
+                rules=map_request_rules_to_openapi_format(policy.rules),
             ),
             x_idempotency_key=idempotency_key,
+        )
+        return Policy(
+            id=openapi_policy.id,
+            description=openapi_policy.description,
+            scope=openapi_policy.scope,
+            rules=map_openapi_rules_to_response_format(openapi_policy.rules),
+            created_at=openapi_policy.created_at,
+            updated_at=openapi_policy.updated_at,
         )
 
     async def delete_policy(
@@ -98,8 +117,16 @@ class PoliciesClient:
             Policy: The requested policy.
 
         """
-        return await self.api_clients.policies.get_policy_by_id(
+        openapi_policy = await self.api_clients.policies.get_policy_by_id(
             policy_id=id,
+        )
+        return Policy(
+            id=openapi_policy.id,
+            description=openapi_policy.description,
+            scope=openapi_policy.scope,
+            rules=map_openapi_rules_to_response_format(openapi_policy.rules),
+            created_at=openapi_policy.created_at,
+            updated_at=openapi_policy.updated_at,
         )
 
     async def list_policies(
@@ -121,8 +148,22 @@ class PoliciesClient:
             ListPoliciesResult: A paginated list of policies.
 
         """
-        return await self.api_clients.policies.list_policies(
+        openapi_policies = await self.api_clients.policies.list_policies(
             page_size=page_size,
             page_token=page_token,
             scope=scope,
+        )
+        return ListPoliciesResult(
+            policies=[
+                Policy(
+                    id=openapi_policy.id,
+                    description=openapi_policy.description,
+                    scope=openapi_policy.scope,
+                    rules=map_openapi_rules_to_response_format(openapi_policy.rules),
+                    created_at=openapi_policy.created_at,
+                    updated_at=openapi_policy.updated_at,
+                )
+                for openapi_policy in openapi_policies.policies
+            ],
+            next_page_token=openapi_policies.next_page_token,
         )

--- a/python/cdp/test/factories/policy_factory.py
+++ b/python/cdp/test/factories/policy_factory.py
@@ -1,6 +1,59 @@
 import pytest
 
-from cdp.policies.types import Policy as PolicyModel
+from cdp.openapi_client.models.evm_address_criterion import EvmAddressCriterion
+from cdp.openapi_client.models.policy import Policy as OpenApiPolicyModel
+from cdp.openapi_client.models.rule import Rule
+from cdp.openapi_client.models.sign_evm_transaction_criteria_inner import (
+    SignEvmTransactionCriteriaInner,
+)
+from cdp.openapi_client.models.sign_evm_transaction_rule import SignEvmTransactionRule
+from cdp.policies.types import (
+    EvmAddressCriterion as EvmAddressCriterionModel,
+    Policy as PolicyModel,
+    SignEvmTransactionRule as SignEvmTransactionRuleModel,
+)
+
+
+@pytest.fixture
+def openapi_policy_model_factory():
+    """Create and return a factory for OpenApi Policy fixtures."""
+
+    def _create_openapi_policy_model(
+        id="12345678-abcd-9012-efab-345678901234",
+        scope="account",
+        description="Account Allowlist Example",
+        created_at="2025-01-01T00:00:00Z",
+        updated_at="2025-01-01T00:00:00Z",
+        rules=None,  # python does not like mutable default arguments
+    ):
+        if rules is None:
+            rules = [
+                Rule(
+                    actual_instance=SignEvmTransactionRule(
+                        action="accept",
+                        operation="signEvmTransaction",
+                        criteria=[
+                            SignEvmTransactionCriteriaInner(
+                                actual_instance=EvmAddressCriterion(
+                                    type="evmAddress",
+                                    addresses=["0x000000000000000000000000000000000000dEaD"],
+                                    operator="in",
+                                ),
+                            ),
+                        ],
+                    ),
+                )
+            ]
+        return OpenApiPolicyModel(
+            id=id,
+            scope=scope,
+            description=description,
+            rules=rules,
+            created_at=created_at,
+            updated_at=updated_at,
+        )
+
+    return _create_openapi_policy_model
 
 
 @pytest.fixture
@@ -17,17 +70,15 @@ def policy_model_factory():
     ):
         if rules is None:
             rules = [
-                {
-                    "action": "accept",
-                    "operation": "signEvmTransaction",
-                    "criteria": [
-                        {
-                            "type": "evmAddress",
-                            "addresses": ["0x000000000000000000000000000000000000dEaD"],
-                            "operator": "in",
-                        }
+                SignEvmTransactionRuleModel(
+                    action="accept",
+                    criteria=[
+                        EvmAddressCriterionModel(
+                            addresses=["0x000000000000000000000000000000000000dEaD"],
+                            operator="in",
+                        ),
                     ],
-                }
+                ),
             ]
         return PolicyModel(
             id=id,

--- a/python/cdp/test/test_e2e.py
+++ b/python/cdp/test/test_e2e.py
@@ -799,40 +799,33 @@ async def test_create_account_policy(cdp_client):
     assert policy.description == "E2E Test Policy"
     assert policy.rules is not None
     assert len(policy.rules) == 3
-    assert policy.rules[0].actual_instance.action == "accept"
-    assert policy.rules[0].actual_instance.operation == "signEvmTransaction"
-    assert policy.rules[0].actual_instance.criteria is not None
-    assert len(policy.rules[0].actual_instance.criteria) == 2
-    assert policy.rules[0].actual_instance.criteria[0].actual_instance.type == "ethValue"
-    assert (
-        policy.rules[0].actual_instance.criteria[0].actual_instance.eth_value
-        == "1000000000000000000"
-    )
-    assert policy.rules[0].actual_instance.criteria[0].actual_instance.operator == "<="
-    assert policy.rules[0].actual_instance.criteria[1].actual_instance.type == "evmAddress"
-    assert policy.rules[0].actual_instance.criteria[1].actual_instance.addresses == [
-        "0x000000000000000000000000000000000000dEaD"
-    ]
-    assert policy.rules[0].actual_instance.criteria[1].actual_instance.operator == "in"
-    assert policy.rules[1].actual_instance.action == "accept"
-    assert policy.rules[1].actual_instance.operation == "sendEvmTransaction"
-    assert policy.rules[1].actual_instance.criteria is not None
-    assert len(policy.rules[1].actual_instance.criteria) == 1
-    assert policy.rules[1].actual_instance.criteria[0].actual_instance.type == "evmNetwork"
-    assert policy.rules[1].actual_instance.criteria[0].actual_instance.networks == [
+    assert policy.rules[0].action == "accept"
+    assert policy.rules[0].operation == "signEvmTransaction"
+    assert policy.rules[0].criteria is not None
+    assert len(policy.rules[0].criteria) == 2
+    assert policy.rules[0].criteria[0].type == "ethValue"
+    assert policy.rules[0].criteria[0].ethValue == "1000000000000000000"
+    assert policy.rules[0].criteria[0].operator == "<="
+    assert policy.rules[0].criteria[1].type == "evmAddress"
+    assert policy.rules[0].criteria[1].addresses == ["0x000000000000000000000000000000000000dEaD"]
+    assert policy.rules[0].criteria[1].operator == "in"
+    assert policy.rules[1].action == "accept"
+    assert policy.rules[1].operation == "sendEvmTransaction"
+    assert policy.rules[1].criteria is not None
+    assert len(policy.rules[1].criteria) == 1
+    assert policy.rules[1].criteria[0].type == "evmNetwork"
+    assert policy.rules[1].criteria[0].networks == [
         "base-sepolia",
         "base",
     ]
-    assert policy.rules[1].actual_instance.criteria[0].actual_instance.operator == "in"
-    assert policy.rules[2].actual_instance.action == "accept"
-    assert policy.rules[2].actual_instance.operation == "signSolTransaction"
-    assert policy.rules[2].actual_instance.criteria is not None
-    assert len(policy.rules[2].actual_instance.criteria) == 1
-    assert policy.rules[2].actual_instance.criteria[0].actual_instance.type == "solAddress"
-    assert policy.rules[2].actual_instance.criteria[0].actual_instance.addresses == [
-        "123456789abcdef123456789abcdef12"
-    ]
-    assert policy.rules[2].actual_instance.criteria[0].actual_instance.operator == "in"
+    assert policy.rules[1].criteria[0].operator == "in"
+    assert policy.rules[2].action == "accept"
+    assert policy.rules[2].operation == "signSolTransaction"
+    assert policy.rules[2].criteria is not None
+    assert len(policy.rules[2].criteria) == 1
+    assert policy.rules[2].criteria[0].type == "solAddress"
+    assert policy.rules[2].criteria[0].addresses == ["123456789abcdef123456789abcdef12"]
+    assert policy.rules[2].criteria[0].operator == "in"
 
     # Delete the policy
     await cdp_client.policies.delete_policy(id=policy.id)
@@ -902,16 +895,13 @@ async def test_create_project_policy(cdp_client):
     assert policy.description == "E2E Test Policy"
     assert policy.rules is not None
     assert len(policy.rules) == 1
-    assert policy.rules[0].actual_instance.action == "accept"
-    assert policy.rules[0].actual_instance.operation == "signEvmTransaction"
-    assert policy.rules[0].actual_instance.criteria is not None
-    assert len(policy.rules[0].actual_instance.criteria) == 1
-    assert policy.rules[0].actual_instance.criteria[0].actual_instance.type == "ethValue"
-    assert (
-        policy.rules[0].actual_instance.criteria[0].actual_instance.eth_value
-        == "1000000000000000000"
-    )
-    assert policy.rules[0].actual_instance.criteria[0].actual_instance.operator == "<="
+    assert policy.rules[0].action == "accept"
+    assert policy.rules[0].operation == "signEvmTransaction"
+    assert policy.rules[0].criteria is not None
+    assert len(policy.rules[0].criteria) == 1
+    assert policy.rules[0].criteria[0].type == "ethValue"
+    assert policy.rules[0].criteria[0].ethValue == "1000000000000000000"
+    assert policy.rules[0].criteria[0].operator == "<="
 
     # Delete the policy
     await cdp_client.policies.delete_policy(id=policy.id)
@@ -968,15 +958,15 @@ async def test_update_policy(cdp_client):
     assert updated_policy.description == "Updated E2E Test Policy"
     assert updated_policy.rules is not None
     assert len(updated_policy.rules) == 1
-    assert updated_policy.rules[0].actual_instance.action == "accept"
-    assert updated_policy.rules[0].actual_instance.operation == "signEvmTransaction"
-    assert updated_policy.rules[0].actual_instance.criteria is not None
-    assert len(updated_policy.rules[0].actual_instance.criteria) == 1
-    assert updated_policy.rules[0].actual_instance.criteria[0].actual_instance.type == "evmAddress"
-    assert updated_policy.rules[0].actual_instance.criteria[0].actual_instance.addresses == [
+    assert updated_policy.rules[0].action == "accept"
+    assert updated_policy.rules[0].operation == "signEvmTransaction"
+    assert updated_policy.rules[0].criteria is not None
+    assert len(updated_policy.rules[0].criteria) == 1
+    assert updated_policy.rules[0].criteria[0].type == "evmAddress"
+    assert updated_policy.rules[0].criteria[0].addresses == [
         "0x000000000000000000000000000000000000dEaD"
     ]
-    assert updated_policy.rules[0].actual_instance.criteria[0].actual_instance.operator == "in"
+    assert updated_policy.rules[0].criteria[0].operator == "in"
 
     # Delete the policy
     await cdp_client.policies.delete_policy(id=updated_policy.id)


### PR DESCRIPTION
The OpenApi generate client models for the Policy engine have a weirdness due to how the `oneOf` types from `openapi.yaml` are interpreted.

This PR transforms that response into a simplified one to give users what they expect and remove confusion.

<!--
Thanks for contributing to CDP SDK!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
 -->

## Tests

Updated examples, unit tests, and e2e tests.

<!--
When adding new functionality or fixing a bug, you should be testing your changes with one or more
API method examples in the examples directory.

Please provide samples of the methods you tested with, the outputs for each method,
and any other relevant context, like which network was used.

Use the following format if helpful:

```
Method: <name of method used>
Network: <network used>
Setup: <any other relevant context>

Output:
<example output>
```

For example:

```
Method: createAccount
Network: Base Sepolia

Output:
EVM Account Address:  0xC2c7D554292Bb6AE502fafc3F5c0C46B534d6f31
```
 -->

## Checklist

A couple of things to include in your PR for completeness:

- [ ] Added a changelog entry

<!--
For instructions on adding changelog entries:
See here for TypeScript: https://github.com/coinbase/cdp-sdk/blob/main/typescript/CONTRIBUTING.md#changelog
and here for Python: https://github.com/coinbase/cdp-sdk/blob/main/python/CONTRIBUTING.md#changelog
-->
