### PR TITLE
chore: Support E2E test with configure base path

### DIFF
--- a/python/cdp/test/test_e2e.py
+++ b/python/cdp/test/test_e2e.py
@@ -37,11 +37,18 @@ w3 = Web3(Web3.HTTPProvider("https://sepolia.base.org"))
 
 test_account_name = "E2EServerAccount2"
 
+e2e_base_path = os.getenv("E2E_BASE_PATH")
+
+client_args = {}
+
+if e2e_base_path:
+    client_args["base_path"] = e2e_base_path
+
 
 @pytest_asyncio.fixture(scope="function")
 async def cdp_client():
     """Create and configure CDP client for all tests."""
-    client = CdpClient()
+    client = CdpClient(**client_args)
     yield client
     await client.close()
 
@@ -49,10 +56,10 @@ async def cdp_client():
 @pytest_asyncio.fixture(scope="function")
 async def solana_account():
     """Create and configure a shared Solana account for all tests."""
-    cdp = CdpClient()
-    account = await cdp.solana.get_or_create_account(name=test_account_name)
+    client = CdpClient(**client_args)
+    account = await client.solana.get_or_create_account(name=test_account_name)
     yield account
-    await cdp.close()
+    await client.close()
 
 
 @pytest.mark.e2e

--- a/typescript/src/e2e.test.ts
+++ b/typescript/src/e2e.test.ts
@@ -14,7 +14,7 @@ import {
   formatEther,
 } from "viem";
 import { baseSepolia } from "viem/chains";
-import { CdpClient } from "./client/cdp.js";
+import { CdpClient, CdpClientOptions } from "./client/cdp.js";
 import type { ServerAccount as Account, SmartAccount } from "./client/evm/evm.types.js";
 import {
   Keypair,
@@ -113,6 +113,7 @@ async function ensureSufficientSolBalance(cdp: CdpClient, account: SolanaAccount
 }
 
 describe("CDP Client E2E Tests", () => {
+  let cdpOptions: CdpClientOptions;
   let cdp: CdpClient;
   let publicClient: PublicClient<Transport, Chain>;
 
@@ -122,7 +123,13 @@ describe("CDP Client E2E Tests", () => {
   let testPolicyId: string;
 
   beforeAll(async () => {
-    cdp = new CdpClient();
+    cdpOptions = {};
+
+    if (process.env.E2E_BASE_PATH) {
+      cdpOptions.basePath = process.env.E2E_BASE_PATH;
+    }
+
+    cdp = new CdpClient(cdpOptions);
     publicClient = createPublicClient<Transport, Chain>({
       chain: baseSepolia,
       transport: http(),


### PR DESCRIPTION

<!--
Thanks for contributing to CDP SDK!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description
This supports our E2E tests running with a specified E2E_BASE_PATH, or defaulting to the existing API path when omitted.

## Checklist

N/A
