### PR TITLE
chore: Use known address for E2E List Evm Balances test

### DIFF
--- a/python/cdp/test/test_e2e.py
+++ b/python/cdp/test/test_e2e.py
@@ -346,12 +346,14 @@ async def test_evm_request_faucet_for_account(cdp_client):
 @pytest.mark.asyncio
 async def test_list_evm_token_balances_for_account(cdp_client):
     """Test listing evm token balances for a server account."""
-    account = await cdp_client.evm.get_or_create_account(name="E2ETestAccount")
+    account = await cdp_client.evm.get_or_create_account(name=test_account_name)
     assert account is not None
 
-    first_page = await account.list_token_balances(network="base-sepolia", page_size=1)
-    assert first_page is not None
-    assert len(first_page.balances) > 0
+    result = await account.list_token_balances(
+        network="base-sepolia",
+    )
+    assert result is not None
+    assert len(result.balances) > 0
 
 
 @pytest.mark.e2e
@@ -1338,7 +1340,7 @@ async def test_create_solana_account_with_policy(cdp_client):
 async def test_update_solana_account(cdp_client):
     """Test updating a Solana account."""
     original_name = generate_random_name()
-    account_to_update = await cdp_client.solana.create_account(name=original_name)
+    account_to_update = await cdp_client.solana.get_or_create_account(name=original_name)
     assert account_to_update is not None
     assert account_to_update.name == original_name
 


### PR DESCRIPTION
<!--
Thanks for contributing to CDP SDK!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
 -->

## Tests

<!--
When adding new functionality or fixing a bug, you should be testing your changes with one or more
API method examples in the examples directory.

Please provide samples of the methods you tested with, the outputs for each method,
and any other relevant context, like which network was used.

Use the following format if helpful:

```
Method: <name of method used>
Network: <network used>
Setup: <any other relevant context>

Output:
<example output>
```

For example:

```
Method: createAccount
Network: Base Sepolia

Output:
EVM Account Address:  0xC2c7D554292Bb6AE502fafc3F5c0C46B534d6f31
```
 -->

## Checklist

A couple of things to include in your PR for completeness:

- [ ] Updated the [typescript README](https://github.com/coinbase/cdp-sdk/blob/main/typescript/src/README.md) if relevant
- [ ] Updated the [python README](https://github.com/coinbase/cdp-sdk/blob/main/python/README.md) if relevant
- [ ] Added a changelog entry

<!--
For instructions on adding changelog entries:
See here for TypeScript: https://github.com/coinbase/cdp-sdk/blob/main/typescript/CONTRIBUTING.md#changelog
and here for Python: https://github.com/coinbase/cdp-sdk/blob/main/python/CONTRIBUTING.md#changelog
-->
