### PR TITLE
fix(typescript): Fixed signTypedData to automatically infer EIP712Domain

### DIFF
--- a/typescript/.changeset/polite-owls-ask.md
+++ b/typescript/.changeset/polite-owls-ask.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/cdp-sdk": patch
+---
+
+Fixed signTypedData to automatically infer EIP712Domain

--- a/typescript/src/accounts/evm/toEvmServerAccount.test.ts
+++ b/typescript/src/accounts/evm/toEvmServerAccount.test.ts
@@ -184,31 +184,63 @@ describe("toEvmServerAccount", () => {
     });
   });
 
-  it("should call apiClient.signEvmTypedData when signTypedData is called", async () => {
-    const message = {
-      domain: {
-        name: "EIP712Domain",
-        chainId: 1,
-        verifyingContract: "0x0000000000000000000000000000000000000000" as `0x${string}`,
-      },
-      types: {
-        EIP712Domain: [
-          { name: "name", type: "string" },
-          { name: "chainId", type: "uint256" },
-          { name: "verifyingContract", type: "address" },
-        ],
-      },
-      primaryType: "EIP712Domain",
-      message: {
-        name: "EIP712Domain",
-        chainId: 1,
-        verifyingContract: "0x0000000000000000000000000000000000000000",
-      },
-    };
+  describe("signTypedData", () => {
+    it("should call apiClient.signEvmTypedData when signTypedData is called", async () => {
+      const message = {
+        domain: {
+          name: "EIP712Domain",
+          chainId: 1,
+          verifyingContract: "0x0000000000000000000000000000000000000000" as `0x${string}`,
+        },
+        types: {
+          EIP712Domain: [
+            { name: "name", type: "string" },
+            { name: "chainId", type: "uint256" },
+            { name: "verifyingContract", type: "address" },
+          ],
+        },
+        primaryType: "EIP712Domain",
+        message: {
+          name: "EIP712Domain",
+          chainId: 1,
+          verifyingContract: "0x0000000000000000000000000000000000000000",
+        },
+      };
 
-    await serverAccount.signTypedData(message);
+      await serverAccount.signTypedData(message);
 
-    expect(mockApiClient.signEvmTypedData).toHaveBeenCalledWith(mockAddress, message);
+      expect(mockApiClient.signEvmTypedData).toHaveBeenCalledWith(mockAddress, message);
+    });
+
+    it("should include the EIP712Domain type if it is not provided", async () => {
+      const message = {
+        domain: {
+          name: "EIP712Domain",
+          chainId: 1,
+          verifyingContract: "0x0000000000000000000000000000000000000000" as `0x${string}`,
+        },
+        types: {},
+        primaryType: "EIP712Domain",
+        message: {
+          name: "EIP712Domain",
+          chainId: 1,
+          verifyingContract: "0x0000000000000000000000000000000000000000",
+        },
+      };
+
+      await serverAccount.signTypedData(message);
+
+      expect(mockApiClient.signEvmTypedData).toHaveBeenCalledWith(mockAddress, {
+        ...message,
+        types: {
+          EIP712Domain: [
+            { name: "name", type: "string" },
+            { name: "chainId", type: "uint256" },
+            { name: "verifyingContract", type: "address" },
+          ],
+        },
+      });
+    });
   });
 
   it("should call transfer action when transfer is called", async () => {

--- a/typescript/src/accounts/evm/toEvmServerAccount.ts
+++ b/typescript/src/accounts/evm/toEvmServerAccount.ts
@@ -1,4 +1,4 @@
-import { type TransactionSerializable, serializeTransaction } from "viem";
+import { type TransactionSerializable, getTypesForEIP712Domain, serializeTransaction } from "viem";
 
 import { FundOptions, fund } from "../../actions/evm/fund/fund.js";
 import { Quote } from "../../actions/evm/fund/Quote.js";
@@ -84,6 +84,11 @@ export function toEvmServerAccount(
     },
 
     async signTypedData(message: EIP712Message) {
+      if (!message.types.EIP712Domain) {
+        message.types.EIP712Domain = getTypesForEIP712Domain({
+          domain: message.domain,
+        });
+      }
       const result = await apiClient.signEvmTypedData(options.account.address, message);
       return result.signature as Hex;
     },


### PR DESCRIPTION
<!--
Thanks for contributing to CDP SDK!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

Similar to what viem does: https://github.com/wevm/viem/blob/main/src/utils/signature/hashTypedData.ts#L53
This fixes an issue with x402 integrators where signTypedData without explicitly EIP712Domain would not work

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
 -->

## Tests

<!--
When adding new functionality or fixing a bug, you should be testing your changes with one or more
API method examples in the examples directory.

Please provide samples of the methods you tested with, the outputs for each method,
and any other relevant context, like which network was used.

Use the following format if helpful:

```
Method: <name of method used>
Network: <network used>
Setup: <any other relevant context>

Output:
<example output>
```

For example:

```
Method: createAccount
Network: Base Sepolia

Output:
EVM Account Address:  0xC2c7D554292Bb6AE502fafc3F5c0C46B534d6f31
```
 -->

## Checklist

A couple of things to include in your PR for completeness:

- [ ] Updated the [typescript README](https://github.com/coinbase/cdp-sdk/blob/main/typescript/src/README.md) if relevant
- [ ] Updated the [python README](https://github.com/coinbase/cdp-sdk/blob/main/python/README.md) if relevant
- [x] Added a changelog entry

<!--
For instructions on adding changelog entries:
See here for TypeScript: https://github.com/coinbase/cdp-sdk/blob/main/typescript/CONTRIBUTING.md#changelog
and here for Python: https://github.com/coinbase/cdp-sdk/blob/main/python/CONTRIBUTING.md#changelog
-->
