### PR TITLE
Update http.ts (Fix TS7053)

### DIFF
--- a/typescript/src/auth/utils/http.ts
+++ b/typescript/src/auth/utils/http.ts
@@ -138,15 +138,20 @@ function requiresWalletAuth(requestMethod: string, requestPath: string): boolean
  * @returns Encoded correlation data as a query string
  */
 export function getCorrelationData(source?: string, sourceVersion?: string): string {
-  const data = {
+    const data: {
+    sdk_version: string;
+    sdk_language: string;
+    source: string;
+    source_version?: string;
+  } = {
     sdk_version: version,
     sdk_language: "typescript",
     source: source || "sdk-auth",
-  };
+  }; 
   if (sourceVersion) {
     data["source_version"] = sourceVersion;
   }
-  return Object.keys(data)
-    .map(key => `${key}=${encodeURIComponent(data[key])}`)
+  return (Object.keys(data) as Array<keyof typeof data>)
+    .map(key => `${key}=${encodeURIComponent(data[key] ?? "")}`)
     .join(",");
 }


### PR DESCRIPTION
Fixes type issues in getCorrelationData

## Description

Fixes TS7053: `Element implicitly has an 'any' type` on the http.ts file.

## Checklist

A couple of things to include in your PR for completeness:

- [ ] Updated the [typescript README](https://github.com/coinbase/cdp-sdk/blob/main/typescript/src/README.md) if relevant
- [ ] Updated the [python README](https://github.com/coinbase/cdp-sdk/blob/main/python/README.md) if relevant
- [ ] Added a changelog entry

<!--
For instructions on adding changelog entries:
See here for TypeScript: https://github.com/coinbase/cdp-sdk/blob/main/typescript/CONTRIBUTING.md#changelog
and here for Python: https://github.com/coinbase/cdp-sdk/blob/main/python/CONTRIBUTING.md#changelog
-->
