### PR TITLE
chore: Support importing with different encryption keys

### DIFF
--- a/typescript/src/e2e.test.ts
+++ b/typescript/src/e2e.test.ts
@@ -226,10 +226,16 @@ describe("CDP Client E2E Tests", () => {
   it("should export an evm server account", async () => {
     const privateKey = generatePrivateKey();
     const randomName = generateRandomName();
-    const importedAccount = await cdp.evm.importAccount({
+    const importAccountOptions: ImportServerAccountOptions = {
       privateKey,
       name: randomName,
-    });
+    };
+
+    if (process.env.CDP_E2E_ENCRYPTION_PUBLIC_KEY) {
+      importAccountOptions.encryptionPublicKey = process.env.CDP_E2E_ENCRYPTION_PUBLIC_KEY;
+    }
+
+    const importedAccount = await cdp.evm.importAccount(importAccountOptions);
 
     const exportedPrivateKeyByName = await cdp.evm.exportAccount({
       name: randomName,


### PR DESCRIPTION
<!--
Thanks for contributing to CDP SDK!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description
This updates the E2E tests to import with a different encryption key to suport testing against different environments.

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
 -->

## Tests

* Updated E2E test
<!--
When adding new functionality or fixing a bug, you should be testing your changes with one or more
API method examples in the examples directory.

Please provide samples of the methods you tested with, the outputs for each method,
and any other relevant context, like which network was used.

Use the following format if helpful:

```
Method: <name of method used>
Network: <network used>
Setup: <any other relevant context>

Output:
<example output>
```

For example:

```
Method: createAccount
Network: Base Sepolia

Output:
EVM Account Address:  0xC2c7D554292Bb6AE502fafc3F5c0C46B534d6f31
```
 -->

## Checklist

A couple of things to include in your PR for completeness:

- [ ] Updated the [typescript README](https://github.com/coinbase/cdp-sdk/blob/main/typescript/src/README.md) if relevant
- [ ] Updated the [python README](https://github.com/coinbase/cdp-sdk/blob/main/python/README.md) if relevant
- [ ] Added a changelog entry

<!--
For instructions on adding changelog entries:
See here for TypeScript: https://github.com/coinbase/cdp-sdk/blob/main/typescript/CONTRIBUTING.md#changelog
and here for Python: https://github.com/coinbase/cdp-sdk/blob/main/python/CONTRIBUTING.md#changelog
-->
