### PR TITLE
feat: implement send and wait functions on scoped evm server account

### DIFF
--- a/examples/typescript/evm/scopedAccount.customNode.ts
+++ b/examples/typescript/evm/scopedAccount.customNode.ts
@@ -16,9 +16,7 @@ const account = await cdp.evm.getOrCreateAccount({
   name: "Playground-Account",
 });
 
-const baseAccount = await account.__experimental_useNetwork(
-  process.env.NODE_RPC_URL
-);
+const baseAccount = await account.useNetwork(process.env.NODE_RPC_URL);
 
 const { transactionHash: faucetTransactionHash } =
   await baseAccount.requestFaucet({

--- a/examples/typescript/evm/scopedAccount.customNode.ts
+++ b/examples/typescript/evm/scopedAccount.customNode.ts
@@ -1,0 +1,47 @@
+// Usage: pnpm tsx evm/scopedAccount.customNode.ts
+// Make sure to set NODE_RPC_URL in your .env file
+
+import { CdpClient } from "@coinbase/cdp-sdk";
+import "dotenv/config";
+import { parseEther } from "viem";
+
+if (!process.env.NODE_RPC_URL) {
+  console.log("NODE_RPC_URL is not set");
+  process.exit(1);
+}
+
+const cdp = new CdpClient();
+
+const account = await cdp.evm.getOrCreateAccount({
+  name: "Playground-Account",
+});
+
+const baseAccount = await account.__experimental_useNetwork(
+  process.env.NODE_RPC_URL
+);
+
+const { transactionHash: faucetTransactionHash } =
+  await baseAccount.requestFaucet({
+    token: "eth",
+  });
+
+await baseAccount.waitForTransactionReceipt({
+  hash: faucetTransactionHash,
+});
+
+console.log("Faucet transaction receipt:", faucetTransactionHash);
+
+const hash = await baseAccount.sendTransaction({
+  transaction: {
+    to: "0x4252e0c9A3da5A2700e7d91cb50aEf522D0C6Fe8",
+    value: parseEther("0.000001"),
+  },
+});
+
+console.log("Transaction hash:", hash);
+
+const receipt = await baseAccount.waitForTransactionReceipt({
+  hash: hash.transactionHash,
+});
+
+console.log("Transaction receipt:", receipt);

--- a/typescript/.changeset/calm-impalas-rule.md
+++ b/typescript/.changeset/calm-impalas-rule.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/cdp-sdk": minor
+---
+
+Added useNetwork function on EvmServerAccount to enable node management and network hoisting

--- a/typescript/src/accounts/evm/toEvmServerAccount.test.ts
+++ b/typescript/src/accounts/evm/toEvmServerAccount.test.ts
@@ -69,7 +69,7 @@ describe("toEvmServerAccount", () => {
   let mockTransfer: Transfer;
 
   beforeEach(() => {
-    mockAddress = "0x123456789abcdef" as Address;
+    mockAddress = "0x0000000000000000000000000000000000000000" as Address;
     mockPaymentMethods = [
       {
         id: "0xmockpaymentmethodid",
@@ -147,7 +147,7 @@ describe("toEvmServerAccount", () => {
       transfer: expect.any(Function),
       type: "evm-server",
       waitForFundOperationReceipt: expect.any(Function),
-      __experimental_useNetwork: expect.any(Function),
+      useNetwork: expect.any(Function),
     });
   });
 
@@ -234,9 +234,9 @@ describe("toEvmServerAccount", () => {
     });
   });
 
-  describe("__experimental_useNetwork", () => {
+  describe("useNetwork", () => {
     it("should return a NetworkScopedEvmServerAccount", async () => {
-      const result = await serverAccount.__experimental_useNetwork("base-sepolia");
+      const result = await serverAccount.useNetwork("base-sepolia");
       expect(result.network).toBe("base-sepolia");
     });
   });

--- a/typescript/src/accounts/evm/toEvmServerAccount.ts
+++ b/typescript/src/accounts/evm/toEvmServerAccount.ts
@@ -169,7 +169,7 @@ export function toEvmServerAccount(
     name: options.account.name,
     type: "evm-server",
     policies: options.account.policies,
-    __experimental_useNetwork: async (networkOrRpcUrl: string) => {
+    useNetwork: async (networkOrRpcUrl: string) => {
       return toNetworkScopedEvmServerAccount(apiClient, {
         account,
         network: networkOrRpcUrl,

--- a/typescript/src/accounts/evm/toNetworkScopedEvmServerAccount.test.ts
+++ b/typescript/src/accounts/evm/toNetworkScopedEvmServerAccount.test.ts
@@ -105,7 +105,7 @@ describe("toNetworkScopedEvmServerAccount", () => {
     sendTransaction: vi.fn().mockResolvedValue({
       transactionHash: "0xtxhash",
     }),
-    __experimental_useNetwork: vi.fn().mockResolvedValue({}),
+    useNetwork: vi.fn().mockResolvedValue({}),
   });
 
   beforeEach(async () => {

--- a/typescript/src/accounts/evm/types.ts
+++ b/typescript/src/accounts/evm/types.ts
@@ -47,8 +47,8 @@ export type EvmServerAccount = Prettify<
       name?: string;
       /** Indicates this is a server-managed account. */
       type: "evm-server";
-      /** Subject to breaking changes. A function that returns a network-scoped server-managed account. */
-      __experimental_useNetwork: (network: string) => Promise<NetworkScopedEvmServerAccount>;
+      /** A function that returns a network-scoped server-managed account. */
+      useNetwork: (network: string) => Promise<NetworkScopedEvmServerAccount>;
     }
 >;
 
@@ -93,7 +93,7 @@ type NetworkScopedAccountActions = Prettify<{
  * A network-scoped server-managed ethereum account
  */
 export type NetworkScopedEvmServerAccount = Prettify<
-  Omit<EvmServerAccount, keyof AccountActions | "__experimental_useNetwork"> &
+  Omit<EvmServerAccount, keyof AccountActions | "useNetwork"> &
     NetworkScopedAccountActions & {
       /** The network this account is scoped to */
       network: string;

--- a/typescript/src/accounts/evm/types.ts
+++ b/typescript/src/accounts/evm/types.ts
@@ -1,11 +1,16 @@
+import { RequestFaucetOptions, RequestFaucetResult } from "../../actions/evm/requestFaucet.js";
+import { TransactionResult, SendTransactionOptions } from "../../actions/evm/sendTransaction.js";
+
 import type { AccountActions, SmartAccountActions } from "../../actions/evm/types.js";
 import type { Address, Hash, Hex } from "../../types/misc.js";
 import type { Prettify } from "../../types/utils.js";
 import type {
   SignableMessage,
+  TransactionReceipt,
   TransactionSerializable,
   TypedData,
   TypedDataDefinition,
+  WaitForTransactionReceiptParameters,
 } from "viem";
 
 /**
@@ -72,12 +77,25 @@ export type NetworkScopedEvmSmartAccount = Prettify<
   }
 >;
 
+type NetworkScopedAccountActions = Prettify<{
+  requestFaucet: (
+    options: Omit<RequestFaucetOptions, "address" | "network">,
+  ) => Promise<RequestFaucetResult>;
+  sendTransaction: (
+    options: Omit<SendTransactionOptions, "address" | "network">,
+  ) => Promise<TransactionResult>;
+  waitForTransactionReceipt: (
+    options: WaitForTransactionReceiptParameters,
+  ) => Promise<TransactionReceipt>;
+}>;
+
 /**
  * A network-scoped server-managed ethereum account
  */
 export type NetworkScopedEvmServerAccount = Prettify<
-  Omit<EvmServerAccount, keyof AccountActions | "__experimental_useNetwork"> & {
-    /** The network this account is scoped to */
-    network: string;
-  }
+  Omit<EvmServerAccount, keyof AccountActions | "__experimental_useNetwork"> &
+    NetworkScopedAccountActions & {
+      /** The network this account is scoped to */
+      network: string;
+    }
 >;

--- a/typescript/src/e2e.test.ts
+++ b/typescript/src/e2e.test.ts
@@ -1358,6 +1358,32 @@ describe("CDP Client E2E Tests", () => {
       }
     });
   });
+
+  describe("network-scoped evm server accounts", () => {
+    it.only("should use provided node when waiting for transaction receipt", async () => {
+      if (!process.env.CDP_E2E_BASE_SEPOLIA_RPC_URL) {
+        logger.log("BASE_SEPOLIA_RPC_URL is not set, skipping test");
+        return;
+      }
+
+      const scopedAccount = await testAccount.__experimental_useNetwork(
+        process.env.CDP_E2E_BASE_SEPOLIA_RPC_URL,
+      );
+
+      const { transactionHash } = await scopedAccount.sendTransaction({
+        transaction: {
+          to: "0x4252e0c9A3da5A2700e7d91cb50aEf522D0C6Fe8",
+          value: parseEther("0"),
+        },
+      });
+
+      const receipt = await scopedAccount.waitForTransactionReceipt({
+        hash: transactionHash,
+      });
+
+      expect(receipt).toBeDefined();
+    });
+  });
 });
 
 function timeout(ms: number) {

--- a/typescript/src/e2e.test.ts
+++ b/typescript/src/e2e.test.ts
@@ -1360,15 +1360,13 @@ describe("CDP Client E2E Tests", () => {
   });
 
   describe("network-scoped evm server accounts", () => {
-    it.only("should use provided node when waiting for transaction receipt", async () => {
+    it("should use provided node when waiting for transaction receipt", async () => {
       if (!process.env.CDP_E2E_BASE_SEPOLIA_RPC_URL) {
         logger.log("BASE_SEPOLIA_RPC_URL is not set, skipping test");
         return;
       }
 
-      const scopedAccount = await testAccount.__experimental_useNetwork(
-        process.env.CDP_E2E_BASE_SEPOLIA_RPC_URL,
-      );
+      const scopedAccount = await testAccount.useNetwork(process.env.CDP_E2E_BASE_SEPOLIA_RPC_URL);
 
       const { transactionHash } = await scopedAccount.sendTransaction({
         transaction: {


### PR DESCRIPTION
<!--
Thanks for contributing to CDP SDK!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

This PRs adds a managed requestFaucet, sendTransaction and waitForTransactionReceipt to EvmServerAccount.

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
 -->

## Tests

Added e2e and unit tests, as well as a new example script showcasing the network scoping feature.

<!--
When adding new functionality or fixing a bug, you should be testing your changes with one or more
API method examples in the examples directory.

Please provide samples of the methods you tested with, the outputs for each method,
and any other relevant context, like which network was used.

Use the following format if helpful:

```
Method: <name of method used>
Network: <network used>
Setup: <any other relevant context>

Output:
<example output>
```

For example:

```
Method: createAccount
Network: Base Sepolia

Output:
EVM Account Address:  0xC2c7D554292Bb6AE502fafc3F5c0C46B534d6f31
```
 -->

## Checklist

A couple of things to include in your PR for completeness:

- [ ] Updated the [typescript README](https://github.com/coinbase/cdp-sdk/blob/main/typescript/src/README.md) if relevant
- [ ] Updated the [python README](https://github.com/coinbase/cdp-sdk/blob/main/python/README.md) if relevant
- [x] Added a changelog entry

<!--
For instructions on adding changelog entries:
See here for TypeScript: https://github.com/coinbase/cdp-sdk/blob/main/typescript/CONTRIBUTING.md#changelog
and here for Python: https://github.com/coinbase/cdp-sdk/blob/main/python/CONTRIBUTING.md#changelog
-->
