### PR TITLE
fix(python): Update evm local account sign typed data

### DIFF
--- a/examples/python/evm/evm_local_account.py
+++ b/examples/python/evm/evm_local_account.py
@@ -88,6 +88,56 @@ async def main():
         )
         print("Signed typed data full message: ", signed_typed_data)
 
+        print("\nSigning typed data with bytes32 type...")
+        typed_data = {
+            "domain": {
+                "name": "MyDomain",
+                "version": "1",
+            },
+            "types": {
+                "Person": [
+                    {"name": "name", "type": "string"},
+                    {"name": "wallet", "type": "address"},
+                    {"name": "nonce", "type": "bytes32"},
+                ],
+            },
+            "primaryType": "Person",
+            "message": {
+                "name": "John Doe",
+                "wallet": "0x1234567890123456789012345678901234567890",
+                "nonce": bytes.fromhex(
+                    "0000000000000000000000001234567890123456789012345678901234567890"
+                ),
+            },
+        }
+        signed_typed_data = evm_local_account.sign_typed_data(
+            full_message=typed_data,
+        )
+        print("Signed typed data with bytes32 type: ", signed_typed_data)
+
+        print("\nSigning typed data with without EIP712Domain type...")
+        typed_data = {
+            "domain": {
+                "name": "MyDomain",
+                "version": "1",
+            },
+            "types": {
+                "Person": [
+                    {"name": "name", "type": "string"},
+                    {"name": "wallet", "type": "address"},
+                ],
+            },
+            "primaryType": "Person",
+            "message": {
+                "name": "John Doe",
+                "wallet": "0x1234567890123456789012345678901234567890",
+            },
+        }
+        signed_typed_data = evm_local_account.sign_typed_data(
+            full_message=typed_data,
+        )
+        print("Signed typed data without EIP712Domain type: ", signed_typed_data)
+
         print("\nSigning transaction...")
         w3 = Web3(Web3.HTTPProvider("https://sepolia.base.org"))
         nonce = w3.eth.get_transaction_count(evm_local_account.address)

--- a/python/cdp/evm_local_account.py
+++ b/python/cdp/evm_local_account.py
@@ -9,7 +9,6 @@ from eth_account.types import TransactionDictType
 from eth_typing import Hash32
 
 from cdp.evm_server_account import EvmServerAccount
-from cdp.openapi_client.models.eip712_domain import EIP712Domain
 
 # Apply nest-asyncio to allow nested event loops
 nest_asyncio.apply()
@@ -156,12 +155,10 @@ class EvmLocalAccount(BaseAccount):
         )
 
         # https://github.com/ethereum/eth-account/blob/main/eth_account/account.py#L1047
-        signable_message = encode_typed_data(full_message=typed_data,)
+        signable_message = encode_typed_data(full_message=typed_data)
         message_hash = _hash_eip191_message(signable_message)
 
-        return _run_async(
-            self._server_account.unsafe_sign_hash(message_hash)
-        )
+        return _run_async(self._server_account.unsafe_sign_hash(message_hash))
 
     def _get_types_for_eip712_domain(
         self, domain: dict[str, Any] | None = None

--- a/python/cdp/evm_local_account.py
+++ b/python/cdp/evm_local_account.py
@@ -125,7 +125,7 @@ class EvmLocalAccount(BaseAccount):
         """
         if full_message is not None:
             typed_data = full_message
-        elif domain_data is not None and message_types is not None and message_data is not None:
+        elif message_types is not None and message_data is not None:
             primary_types = list(message_types.keys() - {"EIP712Domain"})
             if not primary_types:
                 raise ValueError("Could not infer primaryType from message_types")
@@ -137,8 +137,23 @@ class EvmLocalAccount(BaseAccount):
             }
         else:
             raise ValueError(
-                "Must provide either full_message or all of domain_data, message_types, and message_data"
+                "Must provide either full_message or both message_types and message_data"
             )
+
+        # Include the EIP712Domain type in the types if not already present
+        typed_data["domain"] = typed_data.get("domain", {})
+        eip712_domain_type = self._get_types_for_eip712_domain(typed_data["domain"])
+        typed_data["types"] = {
+            "EIP712Domain": eip712_domain_type,
+            **typed_data["types"],
+        }
+
+        # Process the message to handle bytes32 types properly
+        typed_data["message"] = self._process_message_bytes(
+            message=typed_data["message"],
+            types=typed_data["types"],
+            type_key=typed_data["primaryType"],
+        )
 
         return _run_async(
             self._server_account.sign_typed_data(
@@ -154,6 +169,86 @@ class EvmLocalAccount(BaseAccount):
                 message=typed_data["message"],
             )
         )
+
+    def _get_types_for_eip712_domain(
+        self, domain: dict[str, Any] | None = None
+    ) -> list[dict[str, str]]:
+        """Get types for EIP712Domain based on the domain properties that are present.
+
+        This function dynamically generates the EIP712Domain type definition based on
+        which domain properties are provided.
+
+        Args:
+            domain: The domain data dictionary
+
+        Returns:
+            List of field definitions for EIP712Domain type
+
+        """
+        types = []
+
+        if domain is None:
+            return types
+
+        if isinstance(domain.get("name"), str):
+            types.append({"name": "name", "type": "string"})
+
+        if domain.get("version"):
+            types.append({"name": "version", "type": "string"})
+
+        if isinstance(domain.get("chainId"), int):
+            types.append({"name": "chainId", "type": "uint256"})
+
+        if domain.get("verifyingContract"):
+            types.append({"name": "verifyingContract", "type": "address"})
+
+        if domain.get("salt"):
+            types.append({"name": "salt", "type": "bytes32"})
+
+        return types
+
+    def _process_message_bytes(
+        self,
+        message: dict[str, Any],
+        types: dict[str, Any],
+        type_key: str,
+    ) -> dict[str, Any]:
+        """Process message data to handle bytes32 types properly.
+
+        Args:
+            message: The message data
+            types: The type definitions
+            type_key: The key of the type to process
+
+        Returns:
+            The processed message with bytes32 values properly encoded
+
+        """
+
+        def _find_field_type(field_name: str, fields: list) -> str | None:
+            for field in fields:
+                if field["name"] == field_name:
+                    return field["type"]
+            return None
+
+        type_fields = types[type_key]
+        processed_message = {}
+
+        for key, value in message.items():
+            processed_message[key] = value
+            if isinstance(value, dict):
+                # Handle nested objects by recursively processing them
+                value_type = _find_field_type(key, type_fields)
+                if value_type:
+                    processed_message[key] = self._process_message_bytes(value, types, value_type)
+            elif isinstance(value, bytes) and _find_field_type(key, type_fields) == "bytes32":
+                # Handle bytes32 values so our internal sign typed data can serialize them properly
+                value_str = value.hex()
+                processed_message[key] = (
+                    "0x" + value_str if not value_str.startswith("0x") else value_str
+                )
+
+        return processed_message
 
     def __str__(self) -> str:
         """Return a string representation of the EthereumAccount object.

--- a/python/cdp/test/test_e2e.py
+++ b/python/cdp/test/test_e2e.py
@@ -1549,6 +1549,106 @@ async def test_evm_local_account_sign_typed_data_with_full_message(cdp_client):
 
 @pytest.mark.e2e
 @pytest.mark.asyncio
+async def test_evm_local_account_sign_typed_data_with_bytes32_type(cdp_client):
+    """Test signing typed data with a bytes32 type with an EVM local account."""
+    account = await cdp_client.evm.create_account()
+    assert account is not None
+
+    evm_local_account = EvmLocalAccount(account)
+    assert evm_local_account is not None
+
+    signature = evm_local_account.sign_typed_data(
+        full_message={
+            "domain": {
+                "name": "EIP712Domain",
+                "version": "1",
+                "chainId": 1,
+                "verifyingContract": "0x0000000000000000000000000000000000000000",
+            },
+            "types": {
+                "EIP712Domain": [
+                    {"name": "name", "type": "string"},
+                    {"name": "version", "type": "string"},
+                    {"name": "chainId", "type": "uint256"},
+                    {"name": "verifyingContract", "type": "address"},
+                ],
+                "TransferWithAuthorization": [
+                    {"name": "from", "type": "address"},
+                    {"name": "to", "type": "address"},
+                    {"name": "value", "type": "uint256"},
+                    {"name": "validAfter", "type": "uint256"},
+                    {"name": "validBefore", "type": "uint256"},
+                    {"name": "nonce", "type": "bytes32"},
+                ],
+            },
+            "primaryType": "TransferWithAuthorization",
+            "message": {
+                "from": "0x0123456789012345678901234567890123456789",
+                "to": "0x0123456789012345678901234567890123456789",
+                "value": 1000000,
+                "validAfter": 1000000,
+                "validBefore": 1000000,
+                "nonce": bytes.fromhex(
+                    "0000000000000000000000001234567890123456789012345678901234567890"
+                ),
+            },
+        },
+    )
+    assert signature is not None
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_evm_local_account_sign_typed_data_without_eip712_domain_type(cdp_client):
+    """Test signing typed data without eip712 domain type with an EVM local account."""
+    account = await cdp_client.evm.create_account()
+    assert account is not None
+
+    evm_local_account = EvmLocalAccount(account)
+    assert evm_local_account is not None
+
+    domain_data = {
+        "name": "EIP712Domain",
+        "version": "1",
+    }
+    message_types = {
+        "TransferWithAuthorization": [
+            {"name": "from", "type": "address"},
+            {"name": "to", "type": "address"},
+            {"name": "value", "type": "uint256"},
+            {"name": "validAfter", "type": "uint256"},
+            {"name": "validBefore", "type": "uint256"},
+            {"name": "nonce", "type": "bytes32"},
+        ]
+    }
+    message_data = {
+        "from": "0x0123456789012345678901234567890123456789",
+        "to": "0x0123456789012345678901234567890123456789",
+        "value": 1000000,
+        "validAfter": 1000000,
+        "validBefore": 1000000,
+        "nonce": bytes.fromhex("0000000000000000000000001234567890123456789012345678901234567890"),
+    }
+    signature = evm_local_account.sign_typed_data(
+        domain_data=domain_data,
+        message_types=message_types,
+        message_data=message_data,
+    )
+    assert signature is not None
+
+    signature = evm_local_account.sign_typed_data(
+        full_message={
+            "domain": domain_data,
+            "types": message_types,
+            "primaryType": "TransferWithAuthorization",
+            "message": message_data,
+        },
+    )
+    assert signature is not None
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
 @pytest.mark.skip(reason="Skipping due to nonce issue with concurrent test")
 async def test_evm_local_account_sign_and_send_transaction(cdp_client):
     """Test signing a transaction with an EVM local account."""

--- a/python/cdp/test/test_evm_local_account.py
+++ b/python/cdp/test/test_evm_local_account.py
@@ -85,22 +85,25 @@ async def test_sign_typed_data_with_full_message(mock_server_account):
     signature_response = MagicMock()
     mock_server_account.sign_typed_data = AsyncMock(return_value=signature_response)
     evm_local_account = EvmLocalAccount(mock_server_account)
-    full_message = {
-        "domain": {
-            "name": "test",
-            "version": "test",
-            "chainId": 1,
-            "verifyingContract": "0x1234567890123456789012345678901234567890",
-        },
-        "types": {
-            "test": [
-                {"name": "test", "type": "test"},
-            ],
-        },
-        "primaryType": "test",
-        "message": {"test": "test"},
-    }
-    signed_message = evm_local_account.sign_typed_data(full_message=full_message)
+
+    signed_message = evm_local_account.sign_typed_data(
+        full_message={
+            "domain": {
+                "name": "test",
+                "version": "test",
+                "chainId": 1,
+                "verifyingContract": "0x1234567890123456789012345678901234567890",
+            },
+            "types": {
+                "test": [
+                    {"name": "test", "type": "test"},
+                ],
+            },
+            "primaryType": "test",
+            "message": {"test": "test"},
+        }
+    )
+
     mock_server_account.sign_typed_data.assert_called_once_with(
         domain=EIP712Domain(
             name="test",
@@ -108,9 +111,19 @@ async def test_sign_typed_data_with_full_message(mock_server_account):
             chainId=1,
             verifyingContract="0x1234567890123456789012345678901234567890",
         ),
-        types=full_message["types"],
-        primary_type=full_message["primaryType"],
-        message=full_message["message"],
+        types={
+            "EIP712Domain": [
+                {"name": "name", "type": "string"},
+                {"name": "version", "type": "string"},
+                {"name": "chainId", "type": "uint256"},
+                {"name": "verifyingContract", "type": "address"},
+            ],
+            "test": [{"name": "test", "type": "test"}],
+        },
+        primary_type="test",
+        message={
+            "test": "test",
+        },
     )
     assert signed_message == signature_response
 
@@ -122,27 +135,28 @@ async def test_sign_typed_data_with_domain_data_message_types_message_data(mock_
     signature_response = MagicMock()
     mock_server_account.sign_typed_data = AsyncMock(return_value=signature_response)
     evm_local_account = EvmLocalAccount(mock_server_account)
-    domain_data = {
-        "name": "test",
-        "version": "test",
-        "chainId": 1,
-        "verifyingContract": "0x1234567890123456789012345678901234567890",
-    }
-    message_types = {
-        "EIP712Domain": [
-            {"name": "name", "type": "string"},
-            {"name": "version", "type": "string"},
-            {"name": "chainId", "type": "uint256"},
-            {"name": "verifyingContract", "type": "address"},
-        ],
-        "test": [{"name": "test", "type": "test"}],
-    }
-    message_data = {"test": "test"}
+
     signed_message = evm_local_account.sign_typed_data(
-        domain_data=domain_data,
-        message_types=message_types,
-        message_data=message_data,
+        domain_data={
+            "name": "test",
+            "version": "test",
+            "chainId": 1,
+            "verifyingContract": "0x1234567890123456789012345678901234567890",
+        },
+        message_types={
+            "EIP712Domain": [
+                {"name": "name", "type": "string"},
+                {"name": "version", "type": "string"},
+                {"name": "chainId", "type": "uint256"},
+                {"name": "verifyingContract", "type": "address"},
+            ],
+            "test": [{"name": "test", "type": "test"}],
+        },
+        message_data={
+            "test": "test",
+        },
     )
+
     mock_server_account.sign_typed_data.assert_called_once_with(
         domain=EIP712Domain(
             name="test",
@@ -150,9 +164,163 @@ async def test_sign_typed_data_with_domain_data_message_types_message_data(mock_
             chainId=1,
             verifyingContract="0x1234567890123456789012345678901234567890",
         ),
-        types=message_types,
+        types={
+            "EIP712Domain": [
+                {"name": "name", "type": "string"},
+                {"name": "version", "type": "string"},
+                {"name": "chainId", "type": "uint256"},
+                {"name": "verifyingContract", "type": "address"},
+            ],
+            "test": [{"name": "test", "type": "test"}],
+        },
         primary_type="test",
-        message=message_data,
+        message={
+            "test": "test",
+        },
+    )
+    assert signed_message == signature_response
+
+
+@pytest.mark.asyncio
+@patch("cdp.evm_local_account.EvmServerAccount")
+async def test_sign_typed_data_with_bytes32_type(mock_server_account):
+    """Test that the EvmLocalAccount can sign typed data with a bytes32 type."""
+    signature_response = MagicMock()
+    mock_server_account.sign_typed_data = AsyncMock(return_value=signature_response)
+    evm_local_account = EvmLocalAccount(mock_server_account)
+
+    signed_message = evm_local_account.sign_typed_data(
+        full_message={
+            "domain": {
+                "name": "test",
+                "version": "test",
+                "chainId": 1,
+                "verifyingContract": "0x1234567890123456789012345678901234567890",
+            },
+            "types": {
+                "test": [
+                    {"name": "test", "type": "bytes32"},
+                ],
+            },
+            "primaryType": "test",
+            "message": {
+                "test": bytes.fromhex(
+                    "0000000000000000000000001234567890123456789012345678901234567890"
+                )
+            },
+        }
+    )
+
+    mock_server_account.sign_typed_data.assert_called_once_with(
+        domain=EIP712Domain(
+            name="test",
+            version="test",
+            chainId=1,
+            verifyingContract="0x1234567890123456789012345678901234567890",
+        ),
+        types={
+            "EIP712Domain": [
+                {"name": "name", "type": "string"},
+                {"name": "version", "type": "string"},
+                {"name": "chainId", "type": "uint256"},
+                {"name": "verifyingContract", "type": "address"},
+            ],
+            "test": [
+                {"name": "test", "type": "bytes32"},
+            ],
+        },
+        primary_type="test",
+        message={
+            "test": "0x0000000000000000000000001234567890123456789012345678901234567890",
+        },
+    )
+    assert signed_message == signature_response
+
+
+@pytest.mark.asyncio
+@patch("cdp.evm_local_account.EvmServerAccount")
+async def test_sign_typed_data_with_bytes32_type_without_eip712_domain_type(mock_server_account):
+    """Test that the EvmLocalAccount can sign typed data with a bytes32 type without the EIP712Domain type."""
+    signature_response = MagicMock()
+    mock_server_account.sign_typed_data = AsyncMock(return_value=signature_response)
+    evm_local_account = EvmLocalAccount(mock_server_account)
+
+    signed_message = evm_local_account.sign_typed_data(
+        full_message={
+            "domain": {
+                "name": "EIP712Domain",
+                "version": "1",
+            },
+            "types": {
+                "test": [
+                    {"name": "test", "type": "bytes32"},
+                ],
+            },
+            "primaryType": "test",
+            "message": {
+                "test": bytes.fromhex(
+                    "0000000000000000000000001234567890123456789012345678901234567890"
+                )
+            },
+        }
+    )
+
+    mock_server_account.sign_typed_data.assert_called_with(
+        domain=EIP712Domain(
+            name="EIP712Domain",
+            version="1",
+        ),
+        types={
+            "EIP712Domain": [
+                {"name": "name", "type": "string"},
+                {"name": "version", "type": "string"},
+            ],
+            "test": [
+                {"name": "test", "type": "bytes32"},
+            ],
+        },
+        primary_type="test",
+        message={
+            "test": "0x0000000000000000000000001234567890123456789012345678901234567890",
+        },
+    )
+    assert signed_message == signature_response
+
+    signed_message = evm_local_account.sign_typed_data(
+        domain_data={
+            "name": "EIP712Domain",
+            "version": "1",
+        },
+        message_types={
+            "test": [
+                {"name": "test", "type": "bytes32"},
+            ],
+        },
+        message_data={
+            "test": bytes.fromhex(
+                "0000000000000000000000001234567890123456789012345678901234567890"
+            )
+        },
+    )
+
+    mock_server_account.sign_typed_data.assert_called_with(
+        domain=EIP712Domain(
+            name="EIP712Domain",
+            version="1",
+        ),
+        types={
+            "EIP712Domain": [
+                {"name": "name", "type": "string"},
+                {"name": "version", "type": "string"},
+            ],
+            "test": [
+                {"name": "test", "type": "bytes32"},
+            ],
+        },
+        primary_type="test",
+        message={
+            "test": "0x0000000000000000000000001234567890123456789012345678901234567890",
+        },
     )
     assert signed_message == signature_response
 
@@ -164,19 +332,19 @@ async def test_sign_typed_data_with_bad_arguments(mock_server_account):
     evm_local_account = EvmLocalAccount(mock_server_account)
     with pytest.raises(
         ValueError,
-        match="Must provide either full_message or all of domain_data, message_types, and message_data",
+        match="Must provide either full_message or both message_types and message_data",
     ):
         evm_local_account.sign_typed_data()
 
     with pytest.raises(
         ValueError,
-        match="Must provide either full_message or all of domain_data, message_types, and message_data",
+        match="Must provide either full_message or both message_types and message_data",
     ):
         evm_local_account.sign_typed_data(full_message=None)
 
     with pytest.raises(
         ValueError,
-        match="Must provide either full_message or all of domain_data, message_types, and message_data",
+        match="Must provide either full_message or both message_types and message_data",
     ):
         evm_local_account.sign_typed_data(
             domain_data={"name": "test"},
@@ -185,19 +353,10 @@ async def test_sign_typed_data_with_bad_arguments(mock_server_account):
 
     with pytest.raises(
         ValueError,
-        match="Must provide either full_message or all of domain_data, message_types, and message_data",
+        match="Must provide either full_message or both message_types and message_data",
     ):
         evm_local_account.sign_typed_data(
             domain_data={"name": "test"},
-            message_data={"test": "test"},
-        )
-
-    with pytest.raises(
-        ValueError,
-        match="Must provide either full_message or all of domain_data, message_types, and message_data",
-    ):
-        evm_local_account.sign_typed_data(
-            message_types={"test": [{"name": "test", "type": "test"}]},
             message_data={"test": "test"},
         )
 

--- a/python/changelog.d/246.bugfix.md
+++ b/python/changelog.d/246.bugfix.md
@@ -2,3 +2,4 @@ Fixed EvmLocalAccount sign typed data compatibility with eth-account.
 
 - Convert bytes32 to hex string to make it serializable
 - Include EIP712 domain if missing from types
+- Return SignedMessage

--- a/python/changelog.d/246.bugfix.md
+++ b/python/changelog.d/246.bugfix.md
@@ -1,0 +1,4 @@
+Fixed EvmLocalAccount sign typed data compatibility with eth-account.
+
+- Convert bytes32 to hex string to make it serializable
+- Include EIP712 domain if missing from types


### PR DESCRIPTION
<!--
Thanks for contributing to CDP SDK!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

Fixed EvmLocalAccount sign typed data compatibility with eth-account.

- Convert bytes32 to hex string to make it serializable
- Include EIP712 domain if missing from types
- Return SignedMessage

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
 -->

## Tests

Updated unit and e2e tests, and updated examples.

<!--
When adding new functionality or fixing a bug, you should be testing your changes with one or more
API method examples in the examples directory.

Please provide samples of the methods you tested with, the outputs for each method,
and any other relevant context, like which network was used.

Use the following format if helpful:

```
Method: <name of method used>
Network: <network used>
Setup: <any other relevant context>

Output:
<example output>
```

For example:

```
Method: createAccount
Network: Base Sepolia

Output:
EVM Account Address:  0xC2c7D554292Bb6AE502fafc3F5c0C46B534d6f31
```
 -->

## Checklist

A couple of things to include in your PR for completeness:

- [ ] Updated the [typescript README](https://github.com/coinbase/cdp-sdk/blob/main/typescript/src/README.md) if relevant
- [ ] Updated the [python README](https://github.com/coinbase/cdp-sdk/blob/main/python/README.md) if relevant
- [x] Added a changelog entry

<!--
For instructions on adding changelog entries:
See here for TypeScript: https://github.com/coinbase/cdp-sdk/blob/main/typescript/CONTRIBUTING.md#changelog
and here for Python: https://github.com/coinbase/cdp-sdk/blob/main/python/CONTRIBUTING.md#changelog
-->
