### PR TITLE
chore(e2e): remove solana tx confirmation from tests

### DIFF
--- a/python/cdp/test/test_e2e.py
+++ b/python/cdp/test/test_e2e.py
@@ -780,8 +780,6 @@ async def test_transfer_usdc_smart_account(cdp_client):
 @pytest.mark.asyncio
 async def test_transfer_sol(solana_account):
     """Test transferring SOL."""
-    connection = SolanaClient("https://api.devnet.solana.com")
-
     await _ensure_sufficient_sol_balance(cdp_client, solana_account)
 
     signature = await solana_account.transfer(
@@ -790,24 +788,11 @@ async def test_transfer_sol(solana_account):
 
     assert signature is not None
 
-    last_valid_block_height = connection.get_latest_blockhash()
-
-    confirmation = connection.confirm_transaction(
-        tx_sig=signature,
-        last_valid_block_height=last_valid_block_height.value.last_valid_block_height,
-        commitment="confirmed",
-    )
-
-    assert confirmation is not None
-    assert confirmation.value[0].err is None
-
 
 @pytest.mark.e2e
 @pytest.mark.asyncio
 async def test_solana_account_transfer_usdc(solana_account):
     """Test transferring USDC tokens."""
-    connection = SolanaClient("https://api.devnet.solana.com")
-
     await _ensure_sufficient_sol_balance(cdp_client, solana_account)
 
     signature = await solana_account.transfer(
@@ -815,17 +800,6 @@ async def test_solana_account_transfer_usdc(solana_account):
     )
 
     assert signature is not None
-
-    last_valid_block_height = connection.get_latest_blockhash()
-
-    confirmation = connection.confirm_transaction(
-        tx_sig=signature,
-        last_valid_block_height=last_valid_block_height.value.last_valid_block_height,
-        commitment="confirmed",
-    )
-
-    assert confirmation is not None
-    assert confirmation.value[0].err is None
 
 
 @pytest.mark.e2e

--- a/typescript/src/e2e.test.ts
+++ b/typescript/src/e2e.test.ts
@@ -1098,9 +1098,7 @@ describe("CDP Client E2E Tests", () => {
     });
 
     describe("transfer", () => {
-      const connection = new Connection("https://api.devnet.solana.com");
-
-      it("should transfer native SOL and wait for confirmation", async () => {
+      it("should transfer native SOL", async () => {
         const { signature } = await testSolanaAccount.transfer({
           to: "3KzDtddx4i53FBkvCzuDmRbaMozTZoJBb1TToWhz3JfE",
           amount: 0n,
@@ -1109,22 +1107,9 @@ describe("CDP Client E2E Tests", () => {
         });
 
         expect(signature).toBeDefined();
-
-        const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash();
-
-        const confirmation = await connection.confirmTransaction(
-          {
-            signature,
-            blockhash,
-            lastValidBlockHeight,
-          },
-          "confirmed",
-        );
-
-        expect(confirmation.value.err).toBeNull();
       });
 
-      it("should transfer USDC and wait for confirmation", async () => {
+      it("should transfer USDC", async () => {
         const { signature } = await testSolanaAccount.transfer({
           to: "3KzDtddx4i53FBkvCzuDmRbaMozTZoJBb1TToWhz3JfE",
           amount: 0n,
@@ -1133,19 +1118,6 @@ describe("CDP Client E2E Tests", () => {
         });
 
         expect(signature).toBeDefined();
-
-        const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash();
-
-        const confirmation = await connection.confirmTransaction(
-          {
-            signature,
-            blockhash,
-            lastValidBlockHeight,
-          },
-          "confirmed",
-        );
-
-        expect(confirmation.value.err).toBeNull();
       });
     });
   });


### PR DESCRIPTION
<!--
Thanks for contributing to CDP SDK!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

The tests currently use the public node, which can be flaky at times and cause our e2e to fail. Testing that a signature is returned is sufficient for testing that our system works correctly

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
 -->

## Tests

<!--
When adding new functionality or fixing a bug, you should be testing your changes with one or more
API method examples in the examples directory.

Please provide samples of the methods you tested with, the outputs for each method,
and any other relevant context, like which network was used.

Use the following format if helpful:

```
Method: <name of method used>
Network: <network used>
Setup: <any other relevant context>

Output:
<example output>
```

For example:

```
Method: createAccount
Network: Base Sepolia

Output:
EVM Account Address:  0xC2c7D554292Bb6AE502fafc3F5c0C46B534d6f31
```
 -->

## Checklist

A couple of things to include in your PR for completeness:

- [ ] Updated the [typescript README](https://github.com/coinbase/cdp-sdk/blob/main/typescript/src/README.md) if relevant
- [ ] Updated the [python README](https://github.com/coinbase/cdp-sdk/blob/main/python/README.md) if relevant
- [ ] Added a changelog entry

<!--
For instructions on adding changelog entries:
See here for TypeScript: https://github.com/coinbase/cdp-sdk/blob/main/typescript/CONTRIBUTING.md#changelog
and here for Python: https://github.com/coinbase/cdp-sdk/blob/main/python/CONTRIBUTING.md#changelog
-->
