### PR TITLE
chore: use correct type in smart account transfer options

### DIFF
--- a/typescript/.changeset/tricky-memes-taste.md
+++ b/typescript/.changeset/tricky-memes-taste.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/cdp-sdk": patch
+---
+
+Update smartAccount#transfer type to include optional paymasterUrl

--- a/typescript/src/actions/evm/types.ts
+++ b/typescript/src/actions/evm/types.ts
@@ -23,7 +23,7 @@ import type {
   SmartAccountQuoteSwapOptions,
   SmartAccountQuoteSwapResult,
 } from "./swap/types.js";
-import type { TransferOptions } from "./transfer/types.js";
+import type { SmartAccountTransferOptions, TransferOptions } from "./transfer/types.js";
 import type {
   WaitForUserOperationOptions,
   WaitForUserOperationReturnType,
@@ -427,7 +427,7 @@ export type SmartAccountActions = Actions & {
    * });
    * ```
    */
-  transfer: (options: TransferOptions) => Promise<SendUserOperationReturnType>;
+  transfer: (options: SmartAccountTransferOptions) => Promise<SendUserOperationReturnType>;
 
   /**
    * Sends a user operation.


### PR DESCRIPTION
<!--
Thanks for contributing to CDP SDK!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

We were using an incorrect type for smart account transfer options.

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
 -->

## Tests

<!--
When adding new functionality or fixing a bug, you should be testing your changes with one or more
API method examples in the examples directory.

Please provide samples of the methods you tested with, the outputs for each method,
and any other relevant context, like which network was used.

Use the following format if helpful:

```
Method: <name of method used>
Network: <network used>
Setup: <any other relevant context>

Output:
<example output>
```

For example:

```
Method: createAccount
Network: Base Sepolia

Output:
EVM Account Address:  0xC2c7D554292Bb6AE502fafc3F5c0C46B534d6f31
```
 -->

## Checklist

A couple of things to include in your PR for completeness:

- [ ] Updated the [typescript README](https://github.com/coinbase/cdp-sdk/blob/main/typescript/src/README.md) if relevant
- [ ] Updated the [python README](https://github.com/coinbase/cdp-sdk/blob/main/python/README.md) if relevant
- [ ] Added a changelog entry

<!--
For instructions on adding changelog entries:
See here for TypeScript: https://github.com/coinbase/cdp-sdk/blob/main/typescript/CONTRIBUTING.md#changelog
and here for Python: https://github.com/coinbase/cdp-sdk/blob/main/python/CONTRIBUTING.md#changelog
-->
