### PR TITLE
fix: use correct transfer method in network scoped server account

### DIFF
--- a/typescript/.changeset/soft-colts-fetch.md
+++ b/typescript/.changeset/soft-colts-fetch.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/cdp-sdk": patch
+---
+
+Fixed network scoped server account transfer

--- a/typescript/src/accounts/evm/toNetworkScopedEvmServerAccount.ts
+++ b/typescript/src/accounts/evm/toNetworkScopedEvmServerAccount.ts
@@ -149,14 +149,6 @@ export async function toNetworkScopedEvmServerAccount<Network extends string>(
     });
   }
 
-  if (isMethodSupportedOnNetwork("transfer", options.network)) {
-    Object.assign(account, {
-      transfer: async (transferOptions: TransferOptions) => {
-        return options.account.transfer(transferOptions);
-      },
-    });
-  }
-
   if (isMethodSupportedOnNetwork("quoteSwap", options.network)) {
     Object.assign(account, {
       quoteSwap: async (quoteSwapOptions: AccountQuoteSwapOptions) => {


### PR DESCRIPTION
<!--
Thanks for contributing to CDP SDK!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

Currently seeing this error:
```
APIError: request body has an error: doesn't match schema: property "network" is missing
```

This is because the transfer method was not being set correctly.

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
 -->

## Tests

<!--
When adding new functionality or fixing a bug, you should be testing your changes with one or more
API method examples in the examples directory.

Please provide samples of the methods you tested with, the outputs for each method,
and any other relevant context, like which network was used.

Use the following format if helpful:

```
Method: <name of method used>
Network: <network used>
Setup: <any other relevant context>

Output:
<example output>
```

For example:

```
Method: createAccount
Network: Base Sepolia

Output:
EVM Account Address:  0xC2c7D554292Bb6AE502fafc3F5c0C46B534d6f31
```
 -->

## Checklist

A couple of things to include in your PR for completeness:

- [ ] Updated the [typescript README](https://github.com/coinbase/cdp-sdk/blob/main/typescript/src/README.md) if relevant
- [ ] Updated the [python README](https://github.com/coinbase/cdp-sdk/blob/main/python/README.md) if relevant
- [x] Added a changelog entry

<!--
For instructions on adding changelog entries:
See here for TypeScript: https://github.com/coinbase/cdp-sdk/blob/main/typescript/CONTRIBUTING.md#changelog
and here for Python: https://github.com/coinbase/cdp-sdk/blob/main/python/CONTRIBUTING.md#changelog
-->
