### PR TITLE
feat: add signTypedData on EvmSmartAccount

### DIFF
--- a/examples/python/evm/smart_account.sign_typed_data.py
+++ b/examples/python/evm/smart_account.sign_typed_data.py
@@ -1,0 +1,49 @@
+# Usage: uv run python evm/account.sign_typed_data.py
+
+import asyncio
+
+from cdp import CdpClient
+import dotenv
+
+dotenv.load_dotenv()
+
+
+async def main():
+    async with CdpClient() as cdp:
+        owner = await cdp.evm.get_or_create_account(name="SignTypedData-Example-Owner")
+        smart_account = await cdp.evm.get_or_create_smart_account(
+            name="SignTypedData-Example-SmartAccount",
+            owner=owner,
+        )
+
+        domain = {
+            "name": "EIP712Domain",
+            "chainId": 84532,
+            "verifyingContract": "0x0000000000000000000000000000000000000000",
+        }
+
+        types = {
+            "EIP712Domain": [
+                {"name": "name", "type": "string"},
+                {"name": "chainId", "type": "uint256"},
+                {"name": "verifyingContract", "type": "address"},
+            ],
+        }
+        primary_type = "EIP712Domain"
+        message = {
+            "name": "EIP712Domain",
+            "chainId": 84532,
+            "verifyingContract": "0x0000000000000000000000000000000000000000",
+        }
+
+        signature = await smart_account.sign_typed_data(
+            domain=domain,
+            types=types,
+            primary_type=primary_type,
+            message=message,
+            network="base-sepolia",
+        )
+        print("Signature: ", signature)
+
+
+asyncio.run(main())

--- a/examples/typescript/evm/smartAccount.signTypedData.ts
+++ b/examples/typescript/evm/smartAccount.signTypedData.ts
@@ -1,0 +1,35 @@
+// Usage: pnpm tsx evm/account.signTypedData.ts
+
+import { CdpClient } from "@coinbase/cdp-sdk";
+import "dotenv/config";
+
+const cdp = new CdpClient();
+
+const owner = await cdp.evm.getOrCreateAccount({
+  name: "SignTypedData-Example-Owner",
+});
+
+const smartAccount = await cdp.evm.getOrCreateSmartAccount({
+  owner,
+  name: "SignTypedData-Example-SmartAccount",
+});
+
+console.log("Created smart account:", smartAccount.address);
+
+const signature = await smartAccount.signTypedData({
+  domain: {
+    name: "Test",
+    chainId: 84532,
+    verifyingContract: "0x0000000000000000000000000000000000000000",
+  },
+  types: {
+    Test: [{ name: "name", type: "string" }],
+  },
+  primaryType: "Test",
+  message: {
+    name: "John Doe",
+  },
+  network: "base-sepolia",
+});
+
+console.log("Signature:", signature);

--- a/python/cdp/network_config.py
+++ b/python/cdp/network_config.py
@@ -1,0 +1,79 @@
+"""Network configuration for EVM chains."""
+
+# Network to chain ID mapping
+NETWORK_TO_CHAIN_ID: dict[str, int] = {
+    # Ethereum networks
+    "ethereum": 1,
+    "ethereum-sepolia": 11155111,
+    "ethereum-hoodi": 17000,  # Holesky
+    # Base networks
+    "base": 8453,
+    "base-sepolia": 84532,
+    # Polygon networks
+    "polygon": 137,
+    "polygon-mumbai": 80001,
+    # Arbitrum networks
+    "arbitrum": 42161,
+    "arbitrum-sepolia": 421614,
+    # Optimism networks
+    "optimism": 10,
+    "optimism-sepolia": 11155420,
+}
+
+# Chain ID to network mapping (reverse lookup)
+CHAIN_ID_TO_NETWORK: dict[int, str] = {v: k for k, v in NETWORK_TO_CHAIN_ID.items()}
+
+
+def get_chain_id(network: str) -> int:
+    """Get chain ID for a network.
+
+    Args:
+        network: Network name (e.g., "base", "ethereum-sepolia")
+
+    Returns:
+        Chain ID for the network
+
+    Raises:
+        ValueError: If network is not supported
+
+    """
+    chain_id = NETWORK_TO_CHAIN_ID.get(network)
+    if chain_id is None:
+        raise ValueError(f"Unsupported network: {network}")
+    return chain_id
+
+
+def get_network_name(chain_id: int) -> str | None:
+    """Get network name for a chain ID.
+
+    Args:
+        chain_id: EVM chain ID
+
+    Returns:
+        Network name if found, None otherwise
+
+    """
+    return CHAIN_ID_TO_NETWORK.get(chain_id)
+
+
+def is_supported_network(network: str) -> bool:
+    """Check if a network is supported.
+
+    Args:
+        network: Network name to check
+
+    Returns:
+        True if network is supported, False otherwise
+
+    """
+    return network in NETWORK_TO_CHAIN_ID
+
+
+def get_supported_networks() -> list[str]:
+    """Get list of all supported networks.
+
+    Returns:
+        List of supported network names
+
+    """
+    return list(NETWORK_TO_CHAIN_ID.keys())

--- a/python/cdp/test/test_evm_smart_account.py
+++ b/python/cdp/test/test_evm_smart_account.py
@@ -704,3 +704,323 @@ async def test_wait_for_fund_operation_receipt_timeout(
         await smart_account.wait_for_fund_operation_receipt(
             transfer_id="test-transfer-id", timeout_seconds=0.1, interval_seconds=0.1
         )
+
+    @pytest.mark.asyncio
+    async def test_sign_typed_data_success(self, smart_account_factory):
+        """Test successful signing of typed data."""
+        from cdp.evm_message_types import EIP712Domain
+
+        address = "0x1234567890123456789012345678901234567890"
+        name = "test-account"
+        smart_account = smart_account_factory(address, name)
+
+        # Mock API clients
+        mock_api_clients = AsyncMock(spec=ApiClients)
+        smart_account = EvmSmartAccount(
+            address, smart_account.owners[0], name, None, mock_api_clients
+        )
+
+        # Create test domain
+        domain = EIP712Domain(
+            name="Test Contract",
+            version="1",
+            chain_id=1,
+            verifying_contract="0x000000000022D473030F116dDEE9F6B43aC78BA3",
+        )
+
+        # Create test types
+        types = {
+            "EIP712Domain": [
+                {"name": "name", "type": "string"},
+                {"name": "version", "type": "string"},
+                {"name": "chainId", "type": "uint256"},
+                {"name": "verifyingContract", "type": "address"},
+            ],
+            "Transaction": [
+                {"name": "to", "type": "address"},
+                {"name": "value", "type": "uint256"},
+                {"name": "data", "type": "bytes"},
+            ],
+        }
+
+        primary_type = "Transaction"
+
+        # Create test message
+        message = {
+            "to": "0x9999999999999999999999999999999999999999",
+            "value": "1000000000000000000",
+            "data": "0x00",
+        }
+
+        # Mock the sign_and_wrap_typed_data_for_smart_account function
+        expected_signature = "0x" + "b" * 130  # 65 bytes signature in hex
+
+        with patch("cdp.evm_smart_account.sign_and_wrap_typed_data_for_smart_account") as mock_sign:
+            mock_sign.return_value = expected_signature
+
+            # Call the method
+            result = await smart_account.sign_typed_data(
+                domain=domain,
+                types=types,
+                primary_type=primary_type,
+                message=message,
+                network="ethereum",
+            )
+
+            # Verify the result
+            assert result == expected_signature
+
+            # Verify the function was called with correct parameters
+            mock_sign.assert_called_once()
+            call_args = mock_sign.call_args
+
+            assert call_args[0][0] == mock_api_clients  # api_clients
+
+            options = call_args[0][1]  # SignAndWrapTypedDataForSmartAccountOptions
+            assert options.smart_account == smart_account
+            assert options.chain_id == 1  # Ethereum mainnet
+            assert options.typed_data["domain"] == domain
+            assert options.typed_data["types"] == types
+            assert options.typed_data["primaryType"] == primary_type
+            assert options.typed_data["message"] == message
+            assert options.owner_index == 0
+
+    @pytest.mark.asyncio
+    async def test_sign_typed_data_with_base_network(self, smart_account_factory):
+        """Test signing typed data on Base network."""
+        from cdp.evm_message_types import EIP712Domain
+
+        address = "0x1234567890123456789012345678901234567890"
+        smart_account = smart_account_factory(address)
+
+        mock_api_clients = AsyncMock(spec=ApiClients)
+        smart_account = EvmSmartAccount(
+            address, smart_account.owners[0], None, None, mock_api_clients
+        )
+
+        domain = EIP712Domain(
+            name="Base Test",
+            chain_id=8453,
+            verifying_contract="0x1111111111111111111111111111111111111111",
+        )
+
+        types = {"Message": [{"name": "content", "type": "string"}]}
+        primary_type = "Message"
+        message = {"content": "Hello Base"}
+
+        expected_signature = "0x" + "c" * 130
+
+        with patch("cdp.evm_smart_account.sign_and_wrap_typed_data_for_smart_account") as mock_sign:
+            mock_sign.return_value = expected_signature
+
+            result = await smart_account.sign_typed_data(
+                domain=domain,
+                types=types,
+                primary_type=primary_type,
+                message=message,
+                network="base",
+            )
+
+            assert result == expected_signature
+
+            # Verify chain_id was set correctly for Base
+            options = mock_sign.call_args[0][1]
+            assert options.chain_id == 8453  # Base mainnet
+
+    @pytest.mark.asyncio
+    async def test_sign_typed_data_with_testnet(self, smart_account_factory):
+        """Test signing typed data on testnet."""
+        from cdp.evm_message_types import EIP712Domain
+
+        address = "0x1234567890123456789012345678901234567890"
+        smart_account = smart_account_factory(address)
+
+        mock_api_clients = AsyncMock(spec=ApiClients)
+        smart_account = EvmSmartAccount(
+            address, smart_account.owners[0], None, None, mock_api_clients
+        )
+
+        domain = EIP712Domain(name="Sepolia Test", version="2", chain_id=11155111)
+
+        types = {"Test": [{"name": "value", "type": "uint256"}]}
+        primary_type = "Test"
+        message = {"value": "42"}
+
+        expected_signature = "0x" + "d" * 130
+
+        with patch("cdp.evm_smart_account.sign_and_wrap_typed_data_for_smart_account") as mock_sign:
+            mock_sign.return_value = expected_signature
+
+            result = await smart_account.sign_typed_data(
+                domain=domain,
+                types=types,
+                primary_type=primary_type,
+                message=message,
+                network="ethereum-sepolia",
+            )
+
+            assert result == expected_signature
+
+            # Verify chain_id was set correctly for Ethereum Sepolia
+            options = mock_sign.call_args[0][1]
+            assert options.chain_id == 11155111
+
+    @pytest.mark.asyncio
+    async def test_sign_typed_data_invalid_network(self, smart_account_factory):
+        """Test signing typed data with invalid network raises error."""
+        from cdp.evm_message_types import EIP712Domain
+
+        address = "0x1234567890123456789012345678901234567890"
+        smart_account = smart_account_factory(address)
+
+        mock_api_clients = AsyncMock(spec=ApiClients)
+        smart_account = EvmSmartAccount(
+            address, smart_account.owners[0], None, None, mock_api_clients
+        )
+
+        domain = EIP712Domain(name="Test")
+        types = {}
+        primary_type = "Test"
+        message = {}
+
+        # Test with unsupported network
+        with pytest.raises(ValueError) as exc_info:
+            await smart_account.sign_typed_data(
+                domain=domain,
+                types=types,
+                primary_type=primary_type,
+                message=message,
+                network="unsupported-network",
+            )
+
+        assert "Unsupported network: unsupported-network" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_sign_typed_data_complex_types(self, smart_account_factory):
+        """Test signing typed data with complex nested types."""
+        from cdp.evm_message_types import EIP712Domain
+
+        address = "0x1234567890123456789012345678901234567890"
+        smart_account = smart_account_factory(address)
+
+        mock_api_clients = AsyncMock(spec=ApiClients)
+        smart_account = EvmSmartAccount(
+            address, smart_account.owners[0], None, None, mock_api_clients
+        )
+
+        # Complex domain with all fields
+        domain = EIP712Domain(
+            name="Complex Protocol",
+            version="3.1.4",
+            chain_id=137,  # Polygon
+            verifying_contract="0x2222222222222222222222222222222222222222",
+            salt="0x" + "ff" * 32,
+        )
+
+        # Complex nested types
+        types = {
+            "EIP712Domain": [
+                {"name": "name", "type": "string"},
+                {"name": "version", "type": "string"},
+                {"name": "chainId", "type": "uint256"},
+                {"name": "verifyingContract", "type": "address"},
+                {"name": "salt", "type": "bytes32"},
+            ],
+            "Order": [
+                {"name": "maker", "type": "address"},
+                {"name": "taker", "type": "address"},
+                {"name": "assets", "type": "Asset[]"},
+                {"name": "metadata", "type": "OrderMetadata"},
+            ],
+            "Asset": [
+                {"name": "token", "type": "address"},
+                {"name": "amount", "type": "uint256"},
+                {"name": "tokenId", "type": "uint256"},
+            ],
+            "OrderMetadata": [
+                {"name": "deadline", "type": "uint256"},
+                {"name": "salt", "type": "bytes32"},
+                {"name": "flags", "type": "uint8"},
+            ],
+        }
+
+        primary_type = "Order"
+
+        # Complex nested message
+        message = {
+            "maker": "0x3333333333333333333333333333333333333333",
+            "taker": "0x4444444444444444444444444444444444444444",
+            "assets": [
+                {
+                    "token": "0x5555555555555555555555555555555555555555",
+                    "amount": "1000000000000000000",
+                    "tokenId": "1",
+                },
+                {
+                    "token": "0x6666666666666666666666666666666666666666",
+                    "amount": "2000000000000000000",
+                    "tokenId": "2",
+                },
+            ],
+            "metadata": {
+                "deadline": "1234567890",
+                "salt": "0x" + "aa" * 32,
+                "flags": "255",
+            },
+        }
+
+        expected_signature = "0x" + "e" * 130
+
+        with patch("cdp.evm_smart_account.sign_and_wrap_typed_data_for_smart_account") as mock_sign:
+            mock_sign.return_value = expected_signature
+
+            result = await smart_account.sign_typed_data(
+                domain=domain,
+                types=types,
+                primary_type=primary_type,
+                message=message,
+                network="polygon",
+            )
+
+            assert result == expected_signature
+
+            # Verify all data was passed correctly
+            options = mock_sign.call_args[0][1]
+            assert options.chain_id == 137  # Polygon mainnet
+            assert options.typed_data["domain"] == domain
+            assert options.typed_data["types"] == types
+            assert options.typed_data["primaryType"] == primary_type
+            assert options.typed_data["message"] == message
+
+    @pytest.mark.asyncio
+    async def test_sign_typed_data_error_propagation(self, smart_account_factory):
+        """Test that errors from sign_and_wrap_typed_data_for_smart_account are propagated."""
+        from cdp.evm_message_types import EIP712Domain
+
+        address = "0x1234567890123456789012345678901234567890"
+        smart_account = smart_account_factory(address)
+
+        mock_api_clients = AsyncMock(spec=ApiClients)
+        smart_account = EvmSmartAccount(
+            address, smart_account.owners[0], None, None, mock_api_clients
+        )
+
+        domain = EIP712Domain(name="Error Test")
+        types = {}
+        primary_type = "Test"
+        message = {}
+
+        # Mock the function to raise an error
+        with patch("cdp.evm_smart_account.sign_and_wrap_typed_data_for_smart_account") as mock_sign:
+            mock_sign.side_effect = Exception("Signing failed")
+
+            with pytest.raises(Exception) as exc_info:
+                await smart_account.sign_typed_data(
+                    domain=domain,
+                    types=types,
+                    primary_type=primary_type,
+                    message=message,
+                    network="ethereum",
+                )
+
+            assert "Signing failed" in str(exc_info.value)

--- a/python/changelog.d/284.feature.md
+++ b/python/changelog.d/284.feature.md
@@ -1,0 +1,1 @@
+Added signTypedData on EvmSmartAccount

--- a/typescript/.changeset/gold-books-pay.md
+++ b/typescript/.changeset/gold-books-pay.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/cdp-sdk": minor
+---
+
+Added signTypedData on EvmSmartAccount

--- a/typescript/src/accounts/evm/networkToChainResolver.test.ts
+++ b/typescript/src/accounts/evm/networkToChainResolver.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import * as chains from "viem/chains";
+
+import { NETWORK_TO_CHAIN_MAP, resolveNetworkToChain } from "./networkToChainResolver.js";
+
+describe("networkToChainResolver", () => {
+  describe("NETWORK_TO_CHAIN_MAP", () => {
+    it("should contain all expected network mappings", () => {
+      expect(NETWORK_TO_CHAIN_MAP.base).toBe(chains.base);
+      expect(NETWORK_TO_CHAIN_MAP["base-sepolia"]).toBe(chains.baseSepolia);
+      expect(NETWORK_TO_CHAIN_MAP.ethereum).toBe(chains.mainnet);
+      expect(NETWORK_TO_CHAIN_MAP["ethereum-sepolia"]).toBe(chains.sepolia);
+      expect(NETWORK_TO_CHAIN_MAP.polygon).toBe(chains.polygon);
+      expect(NETWORK_TO_CHAIN_MAP["polygon-mumbai"]).toBe(chains.polygonMumbai);
+      expect(NETWORK_TO_CHAIN_MAP.arbitrum).toBe(chains.arbitrum);
+      expect(NETWORK_TO_CHAIN_MAP["arbitrum-sepolia"]).toBe(chains.arbitrumSepolia);
+      expect(NETWORK_TO_CHAIN_MAP.optimism).toBe(chains.optimism);
+      expect(NETWORK_TO_CHAIN_MAP["optimism-sepolia"]).toBe(chains.optimismSepolia);
+    });
+  });
+
+  describe("resolveNetworkToChain", () => {
+    it("should resolve valid network identifiers to chains", () => {
+      expect(resolveNetworkToChain("base")).toBe(chains.base);
+      expect(resolveNetworkToChain("ethereum")).toBe(chains.mainnet);
+      expect(resolveNetworkToChain("polygon")).toBe(chains.polygon);
+    });
+
+    it("should be case-insensitive", () => {
+      expect(resolveNetworkToChain("BASE")).toBe(chains.base);
+      expect(resolveNetworkToChain("Base")).toBe(chains.base);
+      expect(resolveNetworkToChain("bAsE")).toBe(chains.base);
+    });
+
+    it("should throw error for unsupported network identifiers", () => {
+      expect(() => resolveNetworkToChain("invalid-network")).toThrow(
+        "Unsupported network identifier: invalid-network",
+      );
+      expect(() => resolveNetworkToChain("")).toThrow("Unsupported network identifier: ");
+    });
+  });
+});

--- a/typescript/src/accounts/evm/networkToChainResolver.ts
+++ b/typescript/src/accounts/evm/networkToChainResolver.ts
@@ -1,0 +1,34 @@
+import * as chains from "viem/chains";
+
+import type { Chain } from "viem";
+
+/**
+ * Network identifier to viem chain mapping
+ */
+export const NETWORK_TO_CHAIN_MAP: Record<string, Chain> = {
+  base: chains.base,
+  "base-sepolia": chains.baseSepolia,
+  ethereum: chains.mainnet,
+  "ethereum-sepolia": chains.sepolia,
+  polygon: chains.polygon,
+  "polygon-mumbai": chains.polygonMumbai,
+  arbitrum: chains.arbitrum,
+  "arbitrum-sepolia": chains.arbitrumSepolia,
+  optimism: chains.optimism,
+  "optimism-sepolia": chains.optimismSepolia,
+};
+
+/**
+ * Resolves a network identifier to a viem chain
+ *
+ * @param network - The network identifier to resolve
+ * @returns The resolved viem chain
+ * @throws Error if the network identifier is not supported
+ */
+export function resolveNetworkToChain(network: string): Chain {
+  const chain = NETWORK_TO_CHAIN_MAP[network.toLowerCase()];
+  if (!chain) {
+    throw new Error(`Unsupported network identifier: ${network}`);
+  }
+  return chain;
+}

--- a/typescript/src/accounts/evm/resolveViemClients.ts
+++ b/typescript/src/accounts/evm/resolveViemClients.ts
@@ -12,24 +12,9 @@ import { toAccount } from "viem/accounts";
 import * as chains from "viem/chains";
 
 import { getBaseNodeRpcUrl } from "./getBaseNodeRpcUrl.js";
+import { NETWORK_TO_CHAIN_MAP, resolveNetworkToChain } from "./networkToChainResolver.js";
 
 import type { EvmAccount } from "./types.js";
-
-/**
- * Network identifier to viem chain mapping
- */
-const NETWORK_TO_CHAIN_MAP: Record<string, Chain> = {
-  base: chains.base,
-  "base-sepolia": chains.baseSepolia,
-  ethereum: chains.mainnet,
-  "ethereum-sepolia": chains.sepolia,
-  polygon: chains.polygon,
-  "polygon-mumbai": chains.polygonMumbai,
-  arbitrum: chains.arbitrum,
-  "arbitrum-sepolia": chains.arbitrumSepolia,
-  optimism: chains.optimism,
-  "optimism-sepolia": chains.optimismSepolia,
-};
 
 /**
  * Get a chain from the viem chains object
@@ -53,20 +38,6 @@ function getChain(id: number): Chain {
 function isNetworkIdentifier(input: string): boolean {
   const normalizedInput = input.toLowerCase();
   return NETWORK_TO_CHAIN_MAP[normalizedInput] !== undefined;
-}
-
-/**
- * Resolves a network identifier to a viem chain
- *
- * @param network - The network identifier to resolve
- * @returns The resolved viem chain
- */
-function resolveNetworkToChain(network: string): Chain {
-  const chain = NETWORK_TO_CHAIN_MAP[network.toLowerCase()];
-  if (!chain) {
-    throw new Error(`Unsupported network identifier: ${network}`);
-  }
-  return chain;
 }
 
 /**

--- a/typescript/src/accounts/evm/toEvmSmartAccount.test.ts
+++ b/typescript/src/accounts/evm/toEvmSmartAccount.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { toEvmSmartAccount } from "./toEvmSmartAccount.js";
 import { EvmAccount } from "./types.js";
-import { Address } from "../../types/misc.js";
+import { Address, Hex } from "../../types/misc.js";
 import {
   CdpOpenApiClientType,
   EvmSmartAccount as EvmSmartAccountModel,
@@ -13,10 +13,15 @@ import type { TransferOptions } from "../../actions/evm/transfer/types.js";
 import { smartAccountTransferStrategy } from "../../actions/evm/transfer/smartAccountTransferStrategy.js";
 import { UserOperation } from "../../client/evm/evm.types.js";
 import { parseUnits } from "viem";
+import { signAndWrapTypedDataForSmartAccount } from "../../actions/evm/signAndWrapTypedDataForSmartAccount.js";
 
 vi.mock("../../actions/evm/transfer/transfer.js", () => ({
   ...vi.importActual("../../actions/evm/transfer/transfer.js"),
   transfer: vi.fn().mockResolvedValue({ transactionHash: "0xmocktransactionhash" }),
+}));
+
+vi.mock("../../actions/evm/signAndWrapTypedDataForSmartAccount.js", () => ({
+  signAndWrapTypedDataForSmartAccount: vi.fn(),
 }));
 
 describe("toEvmSmartAccount", () => {
@@ -56,7 +61,7 @@ describe("toEvmSmartAccount", () => {
       target: {
         network: "base",
         address: mockAddress,
-        symbol: "usdc",
+        currency: "usdc",
       },
       sourceAmount: "0.000001",
       sourceCurrency: "usd",
@@ -130,6 +135,7 @@ describe("toEvmSmartAccount", () => {
       quoteFund: expect.any(Function),
       quoteSwap: expect.any(Function),
       swap: expect.any(Function),
+      signTypedData: expect.any(Function),
       useNetwork: expect.any(Function),
     });
   });
@@ -282,5 +288,143 @@ describe("toEvmSmartAccount", () => {
     });
 
     expect(mockApiClient.getPaymentTransfer).toHaveBeenCalledWith("0xmocktransferid");
+  });
+
+  describe("signTypedData", () => {
+    const mockSignature = "0xabcdef1234567890" as Hex;
+    let mockTypedData;
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      vi.mocked(signAndWrapTypedDataForSmartAccount).mockResolvedValue({
+        signature: mockSignature,
+      });
+
+      mockTypedData = {
+        domain: {
+          name: "Test Domain",
+          version: "1",
+          chainId: 8453,
+          verifyingContract: "0x1234567890abcdef" as Address,
+        },
+        types: {
+          TestMessage: [
+            { name: "from", type: "address" },
+            { name: "to", type: "address" },
+            { name: "value", type: "uint256" },
+          ],
+        },
+        primaryType: "TestMessage",
+        message: {
+          from: mockOwner.address,
+          to: mockAddress,
+          value: "1000000",
+        },
+      };
+    });
+
+    it("should sign typed data for base network", async () => {
+      const smartAccount = toEvmSmartAccount(mockApiClient, {
+        smartAccount: mockSmartAccount,
+        owner: mockOwner,
+      });
+
+      const result = await smartAccount.signTypedData({
+        ...mockTypedData,
+        network: "base",
+      });
+
+      expect(result).toBe(mockSignature);
+      expect(signAndWrapTypedDataForSmartAccount).toHaveBeenCalledWith(mockApiClient, {
+        chainId: 8453n, // Base mainnet chain ID
+        smartAccount,
+        typedData: {
+          ...mockTypedData,
+          network: "base",
+        },
+      });
+    });
+
+    it("should sign typed data for base-sepolia network", async () => {
+      const smartAccount = toEvmSmartAccount(mockApiClient, {
+        smartAccount: mockSmartAccount,
+        owner: mockOwner,
+      });
+
+      const result = await smartAccount.signTypedData({
+        ...mockTypedData,
+        network: "base-sepolia",
+      });
+
+      expect(result).toBe(mockSignature);
+      expect(signAndWrapTypedDataForSmartAccount).toHaveBeenCalledWith(mockApiClient, {
+        chainId: 84532n, // Base Sepolia chain ID
+        smartAccount,
+        typedData: {
+          ...mockTypedData,
+          network: "base-sepolia",
+        },
+      });
+    });
+
+    it("should pass through the typed data structure correctly", async () => {
+      const smartAccount = toEvmSmartAccount(mockApiClient, {
+        smartAccount: mockSmartAccount,
+        owner: mockOwner,
+      });
+
+      const customTypedData = {
+        domain: {
+          name: "Custom Domain",
+          version: "2",
+          chainId: 8453,
+          verifyingContract: "0xCustomContract" as Address,
+          salt: "0xabcdef1234567890" as Hex,
+        },
+        types: {
+          CustomType: [
+            { name: "field1", type: "string" },
+            { name: "field2", type: "uint256" },
+          ],
+        },
+        primaryType: "CustomType",
+        message: {
+          field1: "test value",
+          field2: "42",
+        },
+      };
+
+      await smartAccount.signTypedData({
+        ...customTypedData,
+        network: "base",
+      });
+
+      expect(signAndWrapTypedDataForSmartAccount).toHaveBeenLastCalledWith(
+        mockApiClient,
+        expect.objectContaining({
+          typedData: {
+            ...customTypedData,
+            network: "base",
+          },
+        }),
+      );
+    });
+
+    it("should handle sign typed data errors", async () => {
+      const errorMessage = "Failed to sign typed data";
+      vi.mocked(signAndWrapTypedDataForSmartAccount).mockRejectedValueOnce(new Error(errorMessage));
+
+      const smartAccount = toEvmSmartAccount(mockApiClient, {
+        smartAccount: mockSmartAccount,
+        owner: mockOwner,
+      });
+
+      await expect(
+        smartAccount.signTypedData({
+          ...mockTypedData,
+          network: "base",
+        }),
+      ).rejects.toThrow(errorMessage);
+    });
   });
 });

--- a/typescript/src/actions/evm/types.ts
+++ b/typescript/src/actions/evm/types.ts
@@ -7,7 +7,12 @@ import {
   WaitForFundOperationResult,
 } from "./fund/waitForFundOperationReceipt.js";
 import { SendUserOperationOptions, SendUserOperationReturnType } from "./sendUserOperation.js";
-import { GetUserOperationOptions, UserOperation } from "../../client/evm/evm.types.js";
+import { KnownEvmNetworks } from "../../accounts/evm/types.js";
+import {
+  GetUserOperationOptions,
+  SignTypedDataOptions,
+  UserOperation,
+} from "../../client/evm/evm.types.js";
 import { Hex } from "../../types/misc.js";
 
 import type { ListTokenBalancesOptions, ListTokenBalancesResult } from "./listTokenBalances.js";
@@ -601,4 +606,38 @@ export type SmartAccountActions = Actions & {
    * ```
    */
   swap: (options: SmartAccountSwapOptions) => Promise<SmartAccountSwapResult>;
+
+  /**
+   * Signs a typed data message.
+   *
+   * @param {SignTypedDataOptions} options - Configuration options for signing the typed data.
+   * @param {string} options.network - The network to sign the typed data on
+   * @param {string} options.typedData - The typed data to sign
+   *
+   * @returns A promise that resolves to the signature.
+   *
+   * @example
+   * ```ts
+   * const signature = await smartAccount.signTypedData({
+   *   network: "base-sepolia",
+   *   typedData: {
+   *     domain: {
+   *       name: "Test",
+   *       chainId: 84532,
+   *       verifyingContract: "0x0000000000000000000000000000000000000000",
+   *     },
+   *     types: {
+   *       Test: [{ name: "name", type: "string" }],
+   *     },
+   *     primaryType: "Test",
+   *     message: {
+   *       name: "John Doe",
+   *     },
+   *   },
+   * });
+   * ```
+   */
+  signTypedData: (
+    options: Omit<SignTypedDataOptions, "address"> & { network: KnownEvmNetworks },
+  ) => Promise<Hex>;
 };


### PR DESCRIPTION
<!--
Thanks for contributing to CDP SDK!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

Adds signTypedData to the EvmSmartAccount objects in both Python and TypeScript, leveraging the pre-existing smart account signTypedData util.

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
 -->

## Tests

Tested with the new examples!

<!--
When adding new functionality or fixing a bug, you should be testing your changes with one or more
API method examples in the examples directory.

Please provide samples of the methods you tested with, the outputs for each method,
and any other relevant context, like which network was used.

Use the following format if helpful:

```
Method: <name of method used>
Network: <network used>
Setup: <any other relevant context>

Output:
<example output>
```

For example:

```
Method: createAccount
Network: Base Sepolia

Output:
EVM Account Address:  0xC2c7D554292Bb6AE502fafc3F5c0C46B534d6f31
```
 -->

## Checklist

A couple of things to include in your PR for completeness:

- [ ] Updated the [typescript README](https://github.com/coinbase/cdp-sdk/blob/main/typescript/src/README.md) if relevant
- [ ] Updated the [python README](https://github.com/coinbase/cdp-sdk/blob/main/python/README.md) if relevant
- [x] Added a changelog entry

<!--
For instructions on adding changelog entries:
See here for TypeScript: https://github.com/coinbase/cdp-sdk/blob/main/typescript/CONTRIBUTING.md#changelog
and here for Python: https://github.com/coinbase/cdp-sdk/blob/main/python/CONTRIBUTING.md#changelog
-->
