### PR TITLE
test(CDP-955): add typescript e2e tests for policy evaluation

### DIFF
--- a/typescript/src/e2e.test.ts
+++ b/typescript/src/e2e.test.ts
@@ -178,8 +178,8 @@ describe("CDP Client E2E Tests", () => {
     })();
     testSolanaAccount = await cdp.solana.getOrCreateAccount({ name: testAccountName });
 
-    if(testAccount.policies?.length || 0 > 0) {
-      await cdp.evm.updateAccount({address: testAccount.address, update: { accountPolicy: "" }})
+    if (testAccount.policies?.length || 0 > 0) {
+      await cdp.evm.updateAccount({ address: testAccount.address, update: { accountPolicy: "" } });
     }
   });
 

--- a/typescript/src/e2e.test.ts
+++ b/typescript/src/e2e.test.ts
@@ -1003,7 +1003,7 @@ describe("CDP Client E2E Tests", () => {
         const signature = await testAccount.signTypedData({
           domain: {
             name: "EIP712Domain",
-            chainId: 1n,
+            chainId: 1,
             verifyingContract: "0x0000000000000000000000000000000000000000",
           },
           types: {
@@ -1016,7 +1016,7 @@ describe("CDP Client E2E Tests", () => {
           primaryType: "EIP712Domain",
           message: {
             name: "EIP712Domain",
-            chainId: 1n,
+            chainId: 1,
             verifyingContract: "0x0000000000000000000000000000000000000000",
           },
         });

--- a/typescript/src/e2e.test.ts
+++ b/typescript/src/e2e.test.ts
@@ -51,6 +51,16 @@ const logger = {
       console.log(...args);
     }
   },
+  warn: (...args: any[]) => {
+    if (process.env.E2E_LOGGING) {
+      console.warn(...args);
+    }
+  },
+  error: (...args: any[]) => {
+    if (process.env.E2E_LOGGING) {
+      console.error(...args);
+    }
+  },
 };
 
 // Helper function to stringify objects with bigint values
@@ -167,6 +177,10 @@ describe("CDP Client E2E Tests", () => {
       }
     })();
     testSolanaAccount = await cdp.solana.getOrCreateAccount({ name: testAccountName });
+
+    if(testAccount.policies?.length || 0 > 0) {
+      await cdp.evm.updateAccount({address: testAccount.address, update: { accountPolicy: "" }})
+    }
   });
 
   beforeEach(async () => {
@@ -1549,6 +1563,10 @@ describe("CDP Client E2E Tests", () => {
   });
 
   describe("Policy Evaluation", () => {
+    const policyViolation = {
+      statusCode: 403,
+      errorType: "policy_violation",
+    };
     let policy: Policy;
 
     beforeAll(async () => {
@@ -1574,9 +1592,13 @@ describe("CDP Client E2E Tests", () => {
           accountPolicy: "",
         },
       });
-      await cdp.policies.deletePolicy({
-        id: policy!.id,
-      });
+      if (policy) {
+        await cdp.policies.deletePolicy({
+          id: policy.id,
+        });
+      } else {
+        logger.warn("unable to delete policy, upstream likely unreliable");
+      }
     }
 
     afterAll(cleanup);
@@ -1602,8 +1624,8 @@ describe("CDP Client E2E Tests", () => {
             address: testAccount.address,
             update: { accountPolicy: policy.id },
           });
-          try {
-            await cdp.evm.signTransaction({
+          await expect(() =>
+            cdp.evm.signTransaction({
               address: testAccount.address,
               transaction: serializeTransaction({
                 chainId: baseSepolia.id,
@@ -1615,14 +1637,8 @@ describe("CDP Client E2E Tests", () => {
                 gasLimit: BigInt(21000),
                 nonce: 0,
               }),
-            });
-            expect(true).toBe(false); // Should not reach here
-          } catch (e: any) {
-            const apiError = e as APIError;
-            expect(e).toBeInstanceOf(APIError);
-            expect(apiError.statusCode).toBe(403);
-            expect(apiError.errorType).toBe("policy_violation");
-          }
+            }),
+          ).rejects.toThrowError(expect.objectContaining(policyViolation));
         });
 
         it("<=", async () => {
@@ -1642,8 +1658,8 @@ describe("CDP Client E2E Tests", () => {
             address: testAccount.address,
             update: { accountPolicy: policy.id },
           });
-          try {
-            await cdp.evm.signTransaction({
+          await expect(() =>
+            cdp.evm.signTransaction({
               address: testAccount.address,
               transaction: serializeTransaction({
                 chainId: baseSepolia.id,
@@ -1655,14 +1671,8 @@ describe("CDP Client E2E Tests", () => {
                 gasLimit: BigInt(21000),
                 nonce: 0,
               }),
-            });
-            expect(true).toBe(false); // Should not reach here
-          } catch (e: any) {
-            const apiError = e as APIError;
-            expect(e).toBeInstanceOf(APIError);
-            expect(apiError.statusCode).toBe(403);
-            expect(apiError.errorType).toBe("policy_violation");
-          }
+            }),
+          ).rejects.toThrowError(expect.objectContaining(policyViolation));
         });
 
         it(">", async () => {
@@ -1682,8 +1692,8 @@ describe("CDP Client E2E Tests", () => {
             address: testAccount.address,
             update: { accountPolicy: policy.id },
           });
-          try {
-            await cdp.evm.signTransaction({
+          await expect(() =>
+            cdp.evm.signTransaction({
               address: testAccount.address,
               transaction: serializeTransaction({
                 chainId: baseSepolia.id,
@@ -1695,14 +1705,8 @@ describe("CDP Client E2E Tests", () => {
                 gasLimit: BigInt(21000),
                 nonce: 0,
               }),
-            });
-            expect(true).toBe(false); // Should not reach here
-          } catch (e: any) {
-            const apiError = e as APIError;
-            expect(e).toBeInstanceOf(APIError);
-            expect(apiError.statusCode).toBe(403);
-            expect(apiError.errorType).toBe("policy_violation");
-          }
+            }),
+          ).rejects.toThrowError(expect.objectContaining(policyViolation));
         });
 
         it("<", async () => {
@@ -1722,8 +1726,8 @@ describe("CDP Client E2E Tests", () => {
             address: testAccount.address,
             update: { accountPolicy: policy.id },
           });
-          try {
-            await cdp.evm.signTransaction({
+          await expect(() =>
+            cdp.evm.signTransaction({
               address: testAccount.address,
               transaction: serializeTransaction({
                 chainId: baseSepolia.id,
@@ -1735,14 +1739,8 @@ describe("CDP Client E2E Tests", () => {
                 gasLimit: BigInt(21000),
                 nonce: 0,
               }),
-            });
-            expect(true).toBe(false); // Should not reach here
-          } catch (e: any) {
-            const apiError = e as APIError;
-            expect(e).toBeInstanceOf(APIError);
-            expect(apiError.statusCode).toBe(403);
-            expect(apiError.errorType).toBe("policy_violation");
-          }
+            }),
+          ).rejects.toThrowError(expect.objectContaining(policyViolation));
         });
 
         it("==", async () => {
@@ -1762,8 +1760,8 @@ describe("CDP Client E2E Tests", () => {
             address: testAccount.address,
             update: { accountPolicy: policy.id },
           });
-          try {
-            await cdp.evm.signTransaction({
+          await expect(() =>
+            cdp.evm.signTransaction({
               address: testAccount.address,
               transaction: serializeTransaction({
                 chainId: baseSepolia.id,
@@ -1775,14 +1773,8 @@ describe("CDP Client E2E Tests", () => {
                 gasLimit: BigInt(21000),
                 nonce: 0,
               }),
-            });
-            expect(true).toBe(false); // Should not reach here
-          } catch (e: any) {
-            const apiError = e as APIError;
-            expect(e).toBeInstanceOf(APIError);
-            expect(apiError.statusCode).toBe(403);
-            expect(apiError.errorType).toBe("policy_violation");
-          }
+            }),
+          ).rejects.toThrowError(expect.objectContaining(policyViolation));
         });
       });
 
@@ -1810,8 +1802,8 @@ describe("CDP Client E2E Tests", () => {
             address: testAccount.address,
             update: { accountPolicy: policy.id },
           });
-          try {
-            await cdp.evm.signTransaction({
+          await expect(() =>
+            cdp.evm.signTransaction({
               address: testAccount.address,
               transaction: serializeTransaction({
                 chainId: baseSepolia.id,
@@ -1823,14 +1815,8 @@ describe("CDP Client E2E Tests", () => {
                 gasLimit: BigInt(21000),
                 nonce: 0,
               }),
-            });
-            expect(true).toBe(false); // Should not reach here
-          } catch (e: any) {
-            const apiError = e as APIError;
-            expect(e).toBeInstanceOf(APIError);
-            expect(apiError.statusCode).toBe(403);
-            expect(apiError.errorType).toBe("policy_violation");
-          }
+            }),
+          ).rejects.toThrowError(expect.objectContaining(policyViolation));
         });
 
         it("not in", async () => {
@@ -1856,8 +1842,8 @@ describe("CDP Client E2E Tests", () => {
             address: testAccount.address,
             update: { accountPolicy: policy.id },
           });
-          try {
-            await cdp.evm.signTransaction({
+          await expect(() =>
+            cdp.evm.signTransaction({
               address: testAccount.address,
               transaction: serializeTransaction({
                 chainId: baseSepolia.id,
@@ -1869,14 +1855,8 @@ describe("CDP Client E2E Tests", () => {
                 gasLimit: BigInt(21000),
                 nonce: 0,
               }),
-            });
-            expect(true).toBe(false); // Should not reach here
-          } catch (e: any) {
-            const apiError = e as APIError;
-            expect(e).toBeInstanceOf(APIError);
-            expect(apiError.statusCode).toBe(403);
-            expect(apiError.errorType).toBe("policy_violation");
-          }
+            }),
+          ).rejects.toThrowError(expect.objectContaining(policyViolation));
         });
       });
 
@@ -1936,11 +1916,11 @@ describe("CDP Client E2E Tests", () => {
             address: testAccount.address,
             update: { accountPolicy: policy.id },
           });
-          try {
-            const transferData =
-              "0xa9059cbb000000000000000000000000742d35cc6634c0532925a3b844bc454e4438f44e0000000000000000000000000000000000000000000000000000000000200000"; // transfer to address with 2M tokens
+          const transferData =
+            "0xa9059cbb000000000000000000000000742d35cc6634c0532925a3b844bc454e4438f44e0000000000000000000000000000000000000000000000000000000000200000"; // transfer to address with 2M tokens
 
-            await cdp.evm.signTransaction({
+          await expect(() =>
+            cdp.evm.signTransaction({
               address: testAccount.address,
               transaction: serializeTransaction({
                 chainId: baseSepolia.id,
@@ -1952,14 +1932,8 @@ describe("CDP Client E2E Tests", () => {
                 gasLimit: BigInt(100000),
                 nonce: 0,
               }),
-            });
-            expect(true).toBe(false); // Should not reach here
-          } catch (e: any) {
-            const apiError = e as APIError;
-            expect(e).toBeInstanceOf(APIError);
-            expect(apiError.statusCode).toBe(403);
-            expect(apiError.errorType).toBe("policy_violation");
-          }
+            }),
+          ).rejects.toThrowError(expect.objectContaining(policyViolation));
         });
       });
     });
@@ -1983,8 +1957,8 @@ describe("CDP Client E2E Tests", () => {
             address: testAccount.address,
             update: { accountPolicy: policy.id },
           });
-          try {
-            await cdp.evm.sendTransaction({
+          await expect(() =>
+            cdp.evm.sendTransaction({
               network: "base-sepolia",
               address: testAccount.address,
               transaction: serializeTransaction({
@@ -1997,14 +1971,8 @@ describe("CDP Client E2E Tests", () => {
                 gasLimit: BigInt(21000),
                 nonce: 0,
               }),
-            });
-            expect(true).toBe(false); // Should not reach here
-          } catch (e: any) {
-            const apiError = e as APIError;
-            expect(e).toBeInstanceOf(APIError);
-            expect(apiError.statusCode).toBe(403);
-            expect(apiError.errorType).toBe("policy_violation");
-          }
+            }),
+          ).rejects.toThrowError(expect.objectContaining(policyViolation));
         });
       });
 
@@ -2032,8 +2000,8 @@ describe("CDP Client E2E Tests", () => {
             address: testAccount.address,
             update: { accountPolicy: policy.id },
           });
-          try {
-            await cdp.evm.sendTransaction({
+          await expect(() =>
+            cdp.evm.sendTransaction({
               address: testAccount.address,
               network: "base-sepolia",
               transaction: serializeTransaction({
@@ -2046,14 +2014,8 @@ describe("CDP Client E2E Tests", () => {
                 gasLimit: BigInt(21000),
                 nonce: 0,
               }),
-            });
-            expect(true).toBe(false); // Should not reach here
-          } catch (e: any) {
-            const apiError = e as APIError;
-            expect(e).toBeInstanceOf(APIError);
-            expect(apiError.statusCode).toBe(403);
-            expect(apiError.errorType).toBe("policy_violation");
-          }
+            }),
+          ).rejects.toThrowError(expect.objectContaining(policyViolation));
         });
       });
 
@@ -2075,8 +2037,8 @@ describe("CDP Client E2E Tests", () => {
             address: testAccount.address,
             update: { accountPolicy: policy.id },
           });
-          try {
-            await cdp.evm.sendTransaction({
+          await expect(() =>
+            cdp.evm.sendTransaction({
               address: testAccount.address,
               network: "base-sepolia",
               transaction: serializeTransaction({
@@ -2089,14 +2051,8 @@ describe("CDP Client E2E Tests", () => {
                 gasLimit: BigInt(21000),
                 nonce: 0,
               }),
-            });
-            expect(true).toBe(false); // Should not reach here
-          } catch (e: any) {
-            const apiError = e as APIError;
-            expect(e).toBeInstanceOf(APIError);
-            expect(apiError.statusCode).toBe(403);
-            expect(apiError.errorType).toBe("policy_violation");
-          }
+            }),
+          ).rejects.toThrowError(expect.objectContaining(policyViolation));
         });
 
         it("not in", async () => {
@@ -2116,8 +2072,8 @@ describe("CDP Client E2E Tests", () => {
             address: testAccount.address,
             update: { accountPolicy: policy.id },
           });
-          try {
-            await cdp.evm.sendTransaction({
+          await expect(() =>
+            cdp.evm.sendTransaction({
               address: testAccount.address,
               network: "base-sepolia",
               transaction: serializeTransaction({
@@ -2130,14 +2086,8 @@ describe("CDP Client E2E Tests", () => {
                 gasLimit: BigInt(21000),
                 nonce: 0,
               }),
-            });
-            expect(true).toBe(false); // Should not reach here
-          } catch (e: any) {
-            const apiError = e as APIError;
-            expect(e).toBeInstanceOf(APIError);
-            expect(apiError.statusCode).toBe(403);
-            expect(apiError.errorType).toBe("policy_violation");
-          }
+            }),
+          ).rejects.toThrowError(expect.objectContaining(policyViolation));
         });
       });
 
@@ -2197,11 +2147,11 @@ describe("CDP Client E2E Tests", () => {
             address: testAccount.address,
             update: { accountPolicy: policy.id },
           });
-          try {
-            const transferData =
-              "0xa9059cbb000000000000000000000000742d35cc6634c0532925a3b844bc454e4438f44e0000000000000000000000000000000000000000000000000000000000200000"; // transfer to address with 2M tokens
+          const transferData =
+            "0xa9059cbb000000000000000000000000742d35cc6634c0532925a3b844bc454e4438f44e0000000000000000000000000000000000000000000000000000000000200000"; // transfer to address with 2M tokens
 
-            await cdp.evm.sendTransaction({
+          await expect(() =>
+            cdp.evm.sendTransaction({
               network: "base-sepolia",
               address: testAccount.address,
               transaction: serializeTransaction({
@@ -2214,14 +2164,8 @@ describe("CDP Client E2E Tests", () => {
                 gasLimit: BigInt(100000),
                 nonce: 0,
               }),
-            });
-            expect(true).toBe(false); // Should not reach here
-          } catch (e: any) {
-            const apiError = e as APIError;
-            expect(e).toBeInstanceOf(APIError);
-            expect(apiError.statusCode).toBe(403);
-            expect(apiError.errorType).toBe("policy_violation");
-          }
+            }),
+          ).rejects.toThrowError(expect.objectContaining(policyViolation));
         });
       });
     });
@@ -2245,18 +2189,12 @@ describe("CDP Client E2E Tests", () => {
             address: testAccount.address,
             update: { accountPolicy: policy.id },
           });
-          try {
-            await cdp.evm.signMessage({
+          await expect(() =>
+            cdp.evm.signMessage({
               address: testAccount.address,
               message: "forbidden message content",
-            });
-            expect(true).toBe(false); // Should not reach here
-          } catch (e: any) {
-            const apiError = e as APIError;
-            expect(e).toBeInstanceOf(APIError);
-            expect(apiError.statusCode).toBe(403);
-            expect(apiError.errorType).toBe("policy_violation");
-          }
+            }),
+          ).rejects.toThrowError(expect.objectContaining(policyViolation));
         });
 
         it("complex regex pattern", async () => {
@@ -2276,18 +2214,12 @@ describe("CDP Client E2E Tests", () => {
             address: testAccount.address,
             update: { accountPolicy: policy.id },
           });
-          try {
-            await cdp.evm.signMessage({
+          await expect(() =>
+            cdp.evm.signMessage({
               address: testAccount.address,
               message: "I want to transfer 1000 tokens to my friend",
-            });
-            expect(true).toBe(false); // Should not reach here
-          } catch (e: any) {
-            const apiError = e as APIError;
-            expect(e).toBeInstanceOf(APIError);
-            expect(apiError.statusCode).toBe(403);
-            expect(apiError.errorType).toBe("policy_violation");
-          }
+            }),
+          ).rejects.toThrowError(expect.objectContaining(policyViolation));
         });
       });
     });
@@ -2304,18 +2236,14 @@ describe("CDP Client E2E Tests", () => {
           address: testAccount.address,
           update: { accountPolicy: policy.id },
         });
-        try {
-          await cdp.evm.signHash({
+        await expect(() =>
+          cdp.evm.signHash({
             address: testAccount.address,
             hash: "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
-          });
-          expect(true).toBe(false); // Should not reach here
-        } catch (e: any) {
-          const apiError = e as APIError;
-          expect(e).toBeInstanceOf(APIError);
-          expect(apiError.statusCode).toBe(403);
-          expect(apiError.errorType).toBe("policy_violation");
-        }
+          }),
+        ).rejects.toThrowError(
+          expect.objectContaining({ statusCode: 403, errorType: "policy_violation" }),
+        );
       });
     });
 
@@ -2361,8 +2289,8 @@ describe("CDP Client E2E Tests", () => {
             address: testAccount.address,
             update: { accountPolicy: policy.id },
           });
-          try {
-            await cdp.evm.signTypedData({
+          await expect(() =>
+            cdp.evm.signTypedData({
               address: testAccount.address,
               types: {
                 Permit: [
@@ -2387,14 +2315,8 @@ describe("CDP Client E2E Tests", () => {
                 nonce: 0,
                 deadline: Math.floor(Date.now() / 1000) + 3600,
               },
-            });
-            expect(true).toBe(false); // Should not reach here
-          } catch (e: any) {
-            const apiError = e as APIError;
-            expect(e).toBeInstanceOf(APIError);
-            expect(apiError.statusCode).toBe(403);
-            expect(apiError.errorType).toBe("policy_violation");
-          }
+            }),
+          ).rejects.toThrowError(expect.objectContaining(policyViolation));
         });
 
         it("address field constraint", async () => {
@@ -2437,8 +2359,8 @@ describe("CDP Client E2E Tests", () => {
             address: testAccount.address,
             update: { accountPolicy: policy.id },
           });
-          try {
-            await cdp.evm.signTypedData({
+          await expect(() =>
+            cdp.evm.signTypedData({
               address: testAccount.address,
               types: {
                 Permit: [
@@ -2463,14 +2385,8 @@ describe("CDP Client E2E Tests", () => {
                 nonce: 0,
                 deadline: Math.floor(Date.now() / 1000) + 3600,
               },
-            });
-            expect(true).toBe(false); // Should not reach here
-          } catch (e: any) {
-            const apiError = e as APIError;
-            expect(e).toBeInstanceOf(APIError);
-            expect(apiError.statusCode).toBe(403);
-            expect(apiError.errorType).toBe("policy_violation");
-          }
+            }),
+          ).rejects.toThrowError(expect.objectContaining(policyViolation));
         });
       });
 
@@ -2498,8 +2414,8 @@ describe("CDP Client E2E Tests", () => {
             address: testAccount.address,
             update: { accountPolicy: policy.id },
           });
-          try {
-            await cdp.evm.signTypedData({
+          await expect(() =>
+            cdp.evm.signTypedData({
               address: testAccount.address,
               types: {
                 Permit: [
@@ -2524,14 +2440,8 @@ describe("CDP Client E2E Tests", () => {
                 nonce: 0,
                 deadline: Math.floor(Date.now() / 1000) + 3600,
               },
-            });
-            expect(true).toBe(false); // Should not reach here
-          } catch (e: any) {
-            const apiError = e as APIError;
-            expect(e).toBeInstanceOf(APIError);
-            expect(apiError.statusCode).toBe(403);
-            expect(apiError.errorType).toBe("policy_violation");
-          }
+            }),
+          ).rejects.toThrowError(expect.objectContaining(policyViolation));
         });
 
         it("not in", async () => {
@@ -2557,8 +2467,8 @@ describe("CDP Client E2E Tests", () => {
             address: testAccount.address,
             update: { accountPolicy: policy.id },
           });
-          try {
-            await cdp.evm.signTypedData({
+          await expect(() =>
+            cdp.evm.signTypedData({
               address: testAccount.address,
               types: {
                 Permit: [
@@ -2583,14 +2493,8 @@ describe("CDP Client E2E Tests", () => {
                 nonce: 0,
                 deadline: Math.floor(Date.now() / 1000) + 3600,
               },
-            });
-            expect(true).toBe(false); // Should not reach here
-          } catch (e: any) {
-            const apiError = e as APIError;
-            expect(e).toBeInstanceOf(APIError);
-            expect(apiError.statusCode).toBe(403);
-            expect(apiError.errorType).toBe("policy_violation");
-          }
+            }),
+          ).rejects.toThrowError(expect.objectContaining(policyViolation));
         });
       });
     });

--- a/typescript/src/e2e.test.ts
+++ b/typescript/src/e2e.test.ts
@@ -153,7 +153,6 @@ describe("CDP Client E2E Tests", () => {
 
     testAccount = await cdp.evm.getOrCreateAccount({ name: testAccountName });
     testSmartAccount = await (async () => {
-      console.log(process.env.CDP_E2E_SMART_ACCOUNT_ADDRESS);
       if (process.env.CDP_E2E_SMART_ACCOUNT_ADDRESS) {
         logger.log("CDP_E2E_SMART_ACCOUNT_ADDRESS is set. Using existing smart account.");
         return cdp.evm.getSmartAccount({

--- a/typescript/src/e2e.test.ts
+++ b/typescript/src/e2e.test.ts
@@ -153,7 +153,7 @@ describe("CDP Client E2E Tests", () => {
 
     testAccount = await cdp.evm.getOrCreateAccount({ name: testAccountName });
     testSmartAccount = await (async () => {
-      console.log(process.env.CDP_E2E_SMART_ACCOUNT_ADDRESS)
+      console.log(process.env.CDP_E2E_SMART_ACCOUNT_ADDRESS);
       if (process.env.CDP_E2E_SMART_ACCOUNT_ADDRESS) {
         logger.log("CDP_E2E_SMART_ACCOUNT_ADDRESS is set. Using existing smart account.");
         return cdp.evm.getSmartAccount({
@@ -1549,7 +1549,7 @@ describe("CDP Client E2E Tests", () => {
     });
   });
 
-  describe.only("Policy Evaluation", () => {
+  describe("Policy Evaluation", () => {
     let policy: Policy;
 
     beforeAll(async () => {
@@ -1557,10 +1557,16 @@ describe("CDP Client E2E Tests", () => {
         policy: {
           description: Date.now().toString(),
           scope: "account",
-          rules: [{ action: 'accept', operation: "signEvmMessage", criteria: [{ match: "^$", type: "evmMessage", }] }]
-        }
-      })
-    })
+          rules: [
+            {
+              action: "accept",
+              operation: "signEvmMessage",
+              criteria: [{ match: "^$", type: "evmMessage" }],
+            },
+          ],
+        },
+      });
+    });
 
     async function cleanup() {
       await cdp.evm.updateAccount({
@@ -1583,11 +1589,15 @@ describe("CDP Client E2E Tests", () => {
             id: policy.id,
             policy: {
               rules: [
-                {operation: "signEvmTransaction", action: "reject", criteria: [
-                  {type:"ethValue", operator: ">=", ethValue: "10000000000000000000"}
-                ] }
-              ]
-            }
+                {
+                  operation: "signEvmTransaction",
+                  action: "reject",
+                  criteria: [
+                    { type: "ethValue", operator: ">=", ethValue: "10000000000000000000" },
+                  ],
+                },
+              ],
+            },
           });
           await cdp.evm.updateAccount({
             address: testAccount.address,
@@ -1605,27 +1615,29 @@ describe("CDP Client E2E Tests", () => {
                 maxPriorityFeePerGas: BigInt(1000000000),
                 gasLimit: BigInt(21000),
                 nonce: 0,
-              })
-            })
+              }),
+            });
             expect(true).toBe(false); // Should not reach here
-          } catch(e: any) {
-            const apiError = e as APIError
-            expect(e).toBeInstanceOf(APIError)
-            expect(apiError.statusCode).toBe(403)
-            expect(apiError.errorType).toBe("policy_violation")
+          } catch (e: any) {
+            const apiError = e as APIError;
+            expect(e).toBeInstanceOf(APIError);
+            expect(apiError.statusCode).toBe(403);
+            expect(apiError.errorType).toBe("policy_violation");
           }
-        })
+        });
 
         it("<=", async () => {
           await cdp.policies.updatePolicy({
             id: policy.id,
             policy: {
               rules: [
-                {operation: "signEvmTransaction", action: "reject", criteria: [
-                  {type:"ethValue", operator: "<=", ethValue: "1000000000000000000"}
-                ] }
-              ]
-            }
+                {
+                  operation: "signEvmTransaction",
+                  action: "reject",
+                  criteria: [{ type: "ethValue", operator: "<=", ethValue: "1000000000000000000" }],
+                },
+              ],
+            },
           });
           await cdp.evm.updateAccount({
             address: testAccount.address,
@@ -1643,27 +1655,29 @@ describe("CDP Client E2E Tests", () => {
                 maxPriorityFeePerGas: BigInt(1000000000),
                 gasLimit: BigInt(21000),
                 nonce: 0,
-              })
-            })
+              }),
+            });
             expect(true).toBe(false); // Should not reach here
-          } catch(e: any) {
-            const apiError = e as APIError
-            expect(e).toBeInstanceOf(APIError)
-            expect(apiError.statusCode).toBe(403)
-            expect(apiError.errorType).toBe("policy_violation")
+          } catch (e: any) {
+            const apiError = e as APIError;
+            expect(e).toBeInstanceOf(APIError);
+            expect(apiError.statusCode).toBe(403);
+            expect(apiError.errorType).toBe("policy_violation");
           }
-        })
+        });
 
         it(">", async () => {
           await cdp.policies.updatePolicy({
             id: policy.id,
             policy: {
               rules: [
-                {operation: "signEvmTransaction", action: "reject", criteria: [
-                  {type:"ethValue", operator: ">", ethValue: "500000000000000000"}
-                ] }
-              ]
-            }
+                {
+                  operation: "signEvmTransaction",
+                  action: "reject",
+                  criteria: [{ type: "ethValue", operator: ">", ethValue: "500000000000000000" }],
+                },
+              ],
+            },
           });
           await cdp.evm.updateAccount({
             address: testAccount.address,
@@ -1681,27 +1695,29 @@ describe("CDP Client E2E Tests", () => {
                 maxPriorityFeePerGas: BigInt(1000000000),
                 gasLimit: BigInt(21000),
                 nonce: 0,
-              })
-            })
+              }),
+            });
             expect(true).toBe(false); // Should not reach here
-          } catch(e: any) {
-            const apiError = e as APIError
-            expect(e).toBeInstanceOf(APIError)
-            expect(apiError.statusCode).toBe(403)
-            expect(apiError.errorType).toBe("policy_violation")
+          } catch (e: any) {
+            const apiError = e as APIError;
+            expect(e).toBeInstanceOf(APIError);
+            expect(apiError.statusCode).toBe(403);
+            expect(apiError.errorType).toBe("policy_violation");
           }
-        })
+        });
 
         it("<", async () => {
           await cdp.policies.updatePolicy({
             id: policy.id,
             policy: {
               rules: [
-                {operation: "signEvmTransaction", action: "reject", criteria: [
-                  {type:"ethValue", operator: "<", ethValue: "2000000000000000000"}
-                ] }
-              ]
-            }
+                {
+                  operation: "signEvmTransaction",
+                  action: "reject",
+                  criteria: [{ type: "ethValue", operator: "<", ethValue: "2000000000000000000" }],
+                },
+              ],
+            },
           });
           await cdp.evm.updateAccount({
             address: testAccount.address,
@@ -1719,27 +1735,29 @@ describe("CDP Client E2E Tests", () => {
                 maxPriorityFeePerGas: BigInt(1000000000),
                 gasLimit: BigInt(21000),
                 nonce: 0,
-              })
-            })
+              }),
+            });
             expect(true).toBe(false); // Should not reach here
-          } catch(e: any) {
-            const apiError = e as APIError
-            expect(e).toBeInstanceOf(APIError)
-            expect(apiError.statusCode).toBe(403)
-            expect(apiError.errorType).toBe("policy_violation")
+          } catch (e: any) {
+            const apiError = e as APIError;
+            expect(e).toBeInstanceOf(APIError);
+            expect(apiError.statusCode).toBe(403);
+            expect(apiError.errorType).toBe("policy_violation");
           }
-        })
+        });
 
         it("==", async () => {
           await cdp.policies.updatePolicy({
             id: policy.id,
             policy: {
               rules: [
-                {operation: "signEvmTransaction", action: "reject", criteria: [
-                  {type:"ethValue", operator: "==", ethValue: "1000000000000000000"}
-                ] }
-              ]
-            }
+                {
+                  operation: "signEvmTransaction",
+                  action: "reject",
+                  criteria: [{ type: "ethValue", operator: "==", ethValue: "1000000000000000000" }],
+                },
+              ],
+            },
           });
           await cdp.evm.updateAccount({
             address: testAccount.address,
@@ -1757,17 +1775,17 @@ describe("CDP Client E2E Tests", () => {
                 maxPriorityFeePerGas: BigInt(1000000000),
                 gasLimit: BigInt(21000),
                 nonce: 0,
-              })
-            })
+              }),
+            });
             expect(true).toBe(false); // Should not reach here
-          } catch(e: any) {
-            const apiError = e as APIError
-            expect(e).toBeInstanceOf(APIError)
-            expect(apiError.statusCode).toBe(403)
-            expect(apiError.errorType).toBe("policy_violation")
+          } catch (e: any) {
+            const apiError = e as APIError;
+            expect(e).toBeInstanceOf(APIError);
+            expect(apiError.statusCode).toBe(403);
+            expect(apiError.errorType).toBe("policy_violation");
           }
-        })
-      })
+        });
+      });
 
       describe("evmAddress", () => {
         it("in", async () => {
@@ -1775,11 +1793,19 @@ describe("CDP Client E2E Tests", () => {
             id: policy.id,
             policy: {
               rules: [
-                {operation: "signEvmTransaction", action: "reject", criteria: [
-                  {type:"evmAddress", operator: "in", addresses: ["0x0000000000000000000000000000000000000000"]}
-                ] }
-              ]
-            }
+                {
+                  operation: "signEvmTransaction",
+                  action: "reject",
+                  criteria: [
+                    {
+                      type: "evmAddress",
+                      operator: "in",
+                      addresses: ["0x0000000000000000000000000000000000000000"],
+                    },
+                  ],
+                },
+              ],
+            },
           });
           await cdp.evm.updateAccount({
             address: testAccount.address,
@@ -1797,27 +1823,35 @@ describe("CDP Client E2E Tests", () => {
                 maxPriorityFeePerGas: BigInt(1000000000),
                 gasLimit: BigInt(21000),
                 nonce: 0,
-              })
-            })
+              }),
+            });
             expect(true).toBe(false); // Should not reach here
-          } catch(e: any) {
-            const apiError = e as APIError
-            expect(e).toBeInstanceOf(APIError)
-            expect(apiError.statusCode).toBe(403)
-            expect(apiError.errorType).toBe("policy_violation")
+          } catch (e: any) {
+            const apiError = e as APIError;
+            expect(e).toBeInstanceOf(APIError);
+            expect(apiError.statusCode).toBe(403);
+            expect(apiError.errorType).toBe("policy_violation");
           }
-        })
+        });
 
         it("not in", async () => {
           await cdp.policies.updatePolicy({
             id: policy.id,
             policy: {
               rules: [
-                {operation: "signEvmTransaction", action: "reject", criteria: [
-                  {type:"evmAddress", operator: "not in", addresses: ["0x742d35Cc6634C0532925a3b844Bc454e4438f44e"]}
-                ] }
-              ]
-            }
+                {
+                  operation: "signEvmTransaction",
+                  action: "reject",
+                  criteria: [
+                    {
+                      type: "evmAddress",
+                      operator: "not in",
+                      addresses: ["0x742d35Cc6634C0532925a3b844Bc454e4438f44e"],
+                    },
+                  ],
+                },
+              ],
+            },
           });
           await cdp.evm.updateAccount({
             address: testAccount.address,
@@ -1835,44 +1869,44 @@ describe("CDP Client E2E Tests", () => {
                 maxPriorityFeePerGas: BigInt(1000000000),
                 gasLimit: BigInt(21000),
                 nonce: 0,
-              })
-            })
+              }),
+            });
             expect(true).toBe(false); // Should not reach here
-          } catch(e: any) {
-            const apiError = e as APIError
-            expect(e).toBeInstanceOf(APIError)
-            expect(apiError.statusCode).toBe(403)
-            expect(apiError.errorType).toBe("policy_violation")
+          } catch (e: any) {
+            const apiError = e as APIError;
+            expect(e).toBeInstanceOf(APIError);
+            expect(apiError.statusCode).toBe(403);
+            expect(apiError.errorType).toBe("policy_violation");
           }
-        })
-      })
+        });
+      });
 
       describe("evmData", () => {
         it("erc20 transfer value constraint", async () => {
           const erc20Abi = [
             {
-              "type": "function",
-              "name": "transfer",
-              "inputs": [
+              type: "function",
+              name: "transfer",
+              inputs: [
                 {
-                  "name": "to",
-                  "type": "address",
-                  "internalType": "address"
+                  name: "to",
+                  type: "address",
+                  internalType: "address",
                 },
                 {
-                  "name": "value",
-                  "type": "uint256",
-                  "internalType": "uint256"
-                }
+                  name: "value",
+                  type: "uint256",
+                  internalType: "uint256",
+                },
               ],
-              "outputs": [
+              outputs: [
                 {
-                  "name": "",
-                  "type": "bool",
-                  "internalType": "bool"
-                }
+                  name: "",
+                  type: "bool",
+                  internalType: "bool",
+                },
               ],
-              "stateMutability": "nonpayable"
+              stateMutability: "nonpayable",
             },
           ] as const;
 
@@ -1880,29 +1914,32 @@ describe("CDP Client E2E Tests", () => {
             id: policy.id,
             policy: {
               rules: [
-                {operation: "signEvmTransaction", action: "reject", criteria: [
-                  {
-                    type:"evmData",
-                    abi: erc20Abi,
-                    conditions: [
-                      {
-                        function: "transfer",
-                        params: [
-                          {name: "value", operator: ">", value: "1000000"}
-                        ]
-                      }
-                    ]
-                  }
-                ] }
-              ]
-            }
+                {
+                  operation: "signEvmTransaction",
+                  action: "reject",
+                  criteria: [
+                    {
+                      type: "evmData",
+                      abi: erc20Abi,
+                      conditions: [
+                        {
+                          function: "transfer",
+                          params: [{ name: "value", operator: ">", value: "1000000" }],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
           });
           await cdp.evm.updateAccount({
             address: testAccount.address,
             update: { accountPolicy: policy.id },
           });
           try {
-            const transferData = "0xa9059cbb000000000000000000000000742d35cc6634c0532925a3b844bc454e4438f44e0000000000000000000000000000000000000000000000000000000000200000"; // transfer to address with 2M tokens
+            const transferData =
+              "0xa9059cbb000000000000000000000000742d35cc6634c0532925a3b844bc454e4438f44e0000000000000000000000000000000000000000000000000000000000200000"; // transfer to address with 2M tokens
 
             await cdp.evm.signTransaction({
               address: testAccount.address,
@@ -1915,17 +1952,17 @@ describe("CDP Client E2E Tests", () => {
                 maxPriorityFeePerGas: BigInt(1000000000),
                 gasLimit: BigInt(100000),
                 nonce: 0,
-              })
-            })
+              }),
+            });
             expect(true).toBe(false); // Should not reach here
-          } catch(e: any) {
-            const apiError = e as APIError
-            expect(e).toBeInstanceOf(APIError)
-            expect(apiError.statusCode).toBe(403)
-            expect(apiError.errorType).toBe("policy_violation")
+          } catch (e: any) {
+            const apiError = e as APIError;
+            expect(e).toBeInstanceOf(APIError);
+            expect(apiError.statusCode).toBe(403);
+            expect(apiError.errorType).toBe("policy_violation");
           }
-        })
-      })
+        });
+      });
     });
 
     describe("sendEvmTransaction", () => {
@@ -1935,11 +1972,13 @@ describe("CDP Client E2E Tests", () => {
             id: policy.id,
             policy: {
               rules: [
-                {operation: "sendEvmTransaction", action: "reject", criteria: [
-                  {type:"ethValue", operator: "==", ethValue: "0"}
-                ] }
-              ]
-            }
+                {
+                  operation: "sendEvmTransaction",
+                  action: "reject",
+                  criteria: [{ type: "ethValue", operator: "==", ethValue: "0" }],
+                },
+              ],
+            },
           });
           await cdp.evm.updateAccount({
             address: testAccount.address,
@@ -1958,17 +1997,17 @@ describe("CDP Client E2E Tests", () => {
                 maxPriorityFeePerGas: BigInt(1000000000),
                 gasLimit: BigInt(21000),
                 nonce: 0,
-              })
-            })
+              }),
+            });
             expect(true).toBe(false); // Should not reach here
-          } catch(e: any) {
-            const apiError = e as APIError
-            expect(e).toBeInstanceOf(APIError)
-            expect(apiError.statusCode).toBe(403)
-            expect(apiError.errorType).toBe("policy_violation")
+          } catch (e: any) {
+            const apiError = e as APIError;
+            expect(e).toBeInstanceOf(APIError);
+            expect(apiError.statusCode).toBe(403);
+            expect(apiError.errorType).toBe("policy_violation");
           }
-        })
-      })
+        });
+      });
 
       describe("evmAddress", () => {
         it("in", async () => {
@@ -1976,11 +2015,19 @@ describe("CDP Client E2E Tests", () => {
             id: policy.id,
             policy: {
               rules: [
-                {operation: "sendEvmTransaction", action: "reject", criteria: [
-                  {type:"evmAddress", operator: "in", addresses: ["0x0000000000000000000000000000000000000000"]}
-                ] }
-              ]
-            }
+                {
+                  operation: "sendEvmTransaction",
+                  action: "reject",
+                  criteria: [
+                    {
+                      type: "evmAddress",
+                      operator: "in",
+                      addresses: ["0x0000000000000000000000000000000000000000"],
+                    },
+                  ],
+                },
+              ],
+            },
           });
           await cdp.evm.updateAccount({
             address: testAccount.address,
@@ -1999,17 +2046,17 @@ describe("CDP Client E2E Tests", () => {
                 maxPriorityFeePerGas: BigInt(1000000000),
                 gasLimit: BigInt(21000),
                 nonce: 0,
-              })
-            })
+              }),
+            });
             expect(true).toBe(false); // Should not reach here
-          } catch(e: any) {
-            const apiError = e as APIError
-            expect(e).toBeInstanceOf(APIError)
-            expect(apiError.statusCode).toBe(403)
-            expect(apiError.errorType).toBe("policy_violation")
+          } catch (e: any) {
+            const apiError = e as APIError;
+            expect(e).toBeInstanceOf(APIError);
+            expect(apiError.statusCode).toBe(403);
+            expect(apiError.errorType).toBe("policy_violation");
           }
-        })
-      })
+        });
+      });
 
       describe("evmNetwork", () => {
         it("in", async () => {
@@ -2017,11 +2064,13 @@ describe("CDP Client E2E Tests", () => {
             id: policy.id,
             policy: {
               rules: [
-                {operation: "sendEvmTransaction", action: "reject", criteria: [
-                  {type:"evmNetwork", operator: "in", networks: ["base-sepolia"]}
-                ] }
-              ]
-            }
+                {
+                  operation: "sendEvmTransaction",
+                  action: "reject",
+                  criteria: [{ type: "evmNetwork", operator: "in", networks: ["base-sepolia"] }],
+                },
+              ],
+            },
           });
           await cdp.evm.updateAccount({
             address: testAccount.address,
@@ -2040,27 +2089,29 @@ describe("CDP Client E2E Tests", () => {
                 maxPriorityFeePerGas: BigInt(1000000000),
                 gasLimit: BigInt(21000),
                 nonce: 0,
-              })
-            })
+              }),
+            });
             expect(true).toBe(false); // Should not reach here
-          } catch(e: any) {
-            const apiError = e as APIError
-            expect(e).toBeInstanceOf(APIError)
-            expect(apiError.statusCode).toBe(403)
-            expect(apiError.errorType).toBe("policy_violation")
+          } catch (e: any) {
+            const apiError = e as APIError;
+            expect(e).toBeInstanceOf(APIError);
+            expect(apiError.statusCode).toBe(403);
+            expect(apiError.errorType).toBe("policy_violation");
           }
-        })
+        });
 
         it("not in", async () => {
           await cdp.policies.updatePolicy({
             id: policy.id,
             policy: {
               rules: [
-                {operation: "sendEvmTransaction", action: "reject", criteria: [
-                  {type:"evmNetwork", operator: "not in", networks: ["base"]}
-                ] }
-              ]
-            }
+                {
+                  operation: "sendEvmTransaction",
+                  action: "reject",
+                  criteria: [{ type: "evmNetwork", operator: "not in", networks: ["base"] }],
+                },
+              ],
+            },
           });
           await cdp.evm.updateAccount({
             address: testAccount.address,
@@ -2079,44 +2130,44 @@ describe("CDP Client E2E Tests", () => {
                 maxPriorityFeePerGas: BigInt(1000000000),
                 gasLimit: BigInt(21000),
                 nonce: 0,
-              })
-            })
+              }),
+            });
             expect(true).toBe(false); // Should not reach here
-          } catch(e: any) {
-            const apiError = e as APIError
-            expect(e).toBeInstanceOf(APIError)
-            expect(apiError.statusCode).toBe(403)
-            expect(apiError.errorType).toBe("policy_violation")
+          } catch (e: any) {
+            const apiError = e as APIError;
+            expect(e).toBeInstanceOf(APIError);
+            expect(apiError.statusCode).toBe(403);
+            expect(apiError.errorType).toBe("policy_violation");
           }
-        })
-      })
+        });
+      });
 
       describe("evmData", () => {
         it("erc20 transfer value constraint", async () => {
           const erc20Abi = [
             {
-              "type": "function",
-              "name": "transfer",
-              "inputs": [
+              type: "function",
+              name: "transfer",
+              inputs: [
                 {
-                  "name": "to",
-                  "type": "address",
-                  "internalType": "address"
+                  name: "to",
+                  type: "address",
+                  internalType: "address",
                 },
                 {
-                  "name": "value",
-                  "type": "uint256",
-                  "internalType": "uint256"
-                }
+                  name: "value",
+                  type: "uint256",
+                  internalType: "uint256",
+                },
               ],
-              "outputs": [
+              outputs: [
                 {
-                  "name": "",
-                  "type": "bool",
-                  "internalType": "bool"
-                }
+                  name: "",
+                  type: "bool",
+                  internalType: "bool",
+                },
               ],
-              "stateMutability": "nonpayable"
+              stateMutability: "nonpayable",
             },
           ] as const;
 
@@ -2124,29 +2175,32 @@ describe("CDP Client E2E Tests", () => {
             id: policy.id,
             policy: {
               rules: [
-                {operation: "sendEvmTransaction", action: "reject", criteria: [
-                  {
-                    type:"evmData",
-                    abi: erc20Abi,
-                    conditions: [
-                      {
-                        function: "transfer",
-                        params: [
-                          {name: "value", operator: ">", value: "1000000"}
-                        ]
-                      }
-                    ]
-                  }
-                ] }
-              ]
-            }
+                {
+                  operation: "sendEvmTransaction",
+                  action: "reject",
+                  criteria: [
+                    {
+                      type: "evmData",
+                      abi: erc20Abi,
+                      conditions: [
+                        {
+                          function: "transfer",
+                          params: [{ name: "value", operator: ">", value: "1000000" }],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
           });
           await cdp.evm.updateAccount({
             address: testAccount.address,
             update: { accountPolicy: policy.id },
           });
           try {
-            const transferData = "0xa9059cbb000000000000000000000000742d35cc6634c0532925a3b844bc454e4438f44e0000000000000000000000000000000000000000000000000000000000200000"; // transfer to address with 2M tokens
+            const transferData =
+              "0xa9059cbb000000000000000000000000742d35cc6634c0532925a3b844bc454e4438f44e0000000000000000000000000000000000000000000000000000000000200000"; // transfer to address with 2M tokens
 
             await cdp.evm.sendTransaction({
               network: "base-sepolia",
@@ -2160,17 +2214,17 @@ describe("CDP Client E2E Tests", () => {
                 maxPriorityFeePerGas: BigInt(1000000000),
                 gasLimit: BigInt(100000),
                 nonce: 0,
-              })
-            })
+              }),
+            });
             expect(true).toBe(false); // Should not reach here
-          } catch(e: any) {
-            const apiError = e as APIError
-            expect(e).toBeInstanceOf(APIError)
-            expect(apiError.statusCode).toBe(403)
-            expect(apiError.errorType).toBe("policy_violation")
+          } catch (e: any) {
+            const apiError = e as APIError;
+            expect(e).toBeInstanceOf(APIError);
+            expect(apiError.statusCode).toBe(403);
+            expect(apiError.errorType).toBe("policy_violation");
           }
-        })
-      })
+        });
+      });
     });
 
     describe("signEvmMessage", () => {
@@ -2180,11 +2234,13 @@ describe("CDP Client E2E Tests", () => {
             id: policy.id,
             policy: {
               rules: [
-                {operation: "signEvmMessage", action: "reject", criteria: [
-                  {type:"evmMessage", match: "^forbidden"}
-                ] }
-              ]
-            }
+                {
+                  operation: "signEvmMessage",
+                  action: "reject",
+                  criteria: [{ type: "evmMessage", match: "^forbidden" }],
+                },
+              ],
+            },
           });
           await cdp.evm.updateAccount({
             address: testAccount.address,
@@ -2193,27 +2249,29 @@ describe("CDP Client E2E Tests", () => {
           try {
             await cdp.evm.signMessage({
               address: testAccount.address,
-              message: "forbidden message content"
-            })
+              message: "forbidden message content",
+            });
             expect(true).toBe(false); // Should not reach here
-          } catch(e: any) {
-            const apiError = e as APIError
-            expect(e).toBeInstanceOf(APIError)
-            expect(apiError.statusCode).toBe(403)
-            expect(apiError.errorType).toBe("policy_violation")
+          } catch (e: any) {
+            const apiError = e as APIError;
+            expect(e).toBeInstanceOf(APIError);
+            expect(apiError.statusCode).toBe(403);
+            expect(apiError.errorType).toBe("policy_violation");
           }
-        })
+        });
 
         it("complex regex pattern", async () => {
           await cdp.policies.updatePolicy({
             id: policy.id,
             policy: {
               rules: [
-                {operation: "signEvmMessage", action: "reject", criteria: [
-                  {type:"evmMessage", match: "transfer\\s+[0-9]+\\s+tokens"}
-                ] }
-              ]
-            }
+                {
+                  operation: "signEvmMessage",
+                  action: "reject",
+                  criteria: [{ type: "evmMessage", match: "transfer\\s+[0-9]+\\s+tokens" }],
+                },
+              ],
+            },
           });
           await cdp.evm.updateAccount({
             address: testAccount.address,
@@ -2222,17 +2280,17 @@ describe("CDP Client E2E Tests", () => {
           try {
             await cdp.evm.signMessage({
               address: testAccount.address,
-              message: "I want to transfer 1000 tokens to my friend"
-            })
+              message: "I want to transfer 1000 tokens to my friend",
+            });
             expect(true).toBe(false); // Should not reach here
-          } catch(e: any) {
-            const apiError = e as APIError
-            expect(e).toBeInstanceOf(APIError)
-            expect(apiError.statusCode).toBe(403)
-            expect(apiError.errorType).toBe("policy_violation")
+          } catch (e: any) {
+            const apiError = e as APIError;
+            expect(e).toBeInstanceOf(APIError);
+            expect(apiError.statusCode).toBe(403);
+            expect(apiError.errorType).toBe("policy_violation");
           }
-        })
-      })
+        });
+      });
     });
 
     describe("signEvmHash", () => {
@@ -2240,10 +2298,8 @@ describe("CDP Client E2E Tests", () => {
         await cdp.policies.updatePolicy({
           id: policy.id,
           policy: {
-            rules: [
-              { operation: "signEvmHash", action: "reject" }
-            ]
-          }
+            rules: [{ operation: "signEvmHash", action: "reject" }],
+          },
         });
         await cdp.evm.updateAccount({
           address: testAccount.address,
@@ -2252,16 +2308,16 @@ describe("CDP Client E2E Tests", () => {
         try {
           await cdp.evm.signHash({
             address: testAccount.address,
-            hash: "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
-          })
+            hash: "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+          });
           expect(true).toBe(false); // Should not reach here
-        } catch(e: any) {
-          const apiError = e as APIError
-          expect(e).toBeInstanceOf(APIError)
-          expect(apiError.statusCode).toBe(403)
-          expect(apiError.errorType).toBe("policy_violation")
+        } catch (e: any) {
+          const apiError = e as APIError;
+          expect(e).toBeInstanceOf(APIError);
+          expect(apiError.statusCode).toBe(403);
+          expect(apiError.errorType).toBe("policy_violation");
         }
-      })
+      });
     });
 
     describe("signEvmTypedData", () => {
@@ -2271,32 +2327,36 @@ describe("CDP Client E2E Tests", () => {
             id: policy.id,
             policy: {
               rules: [
-                {operation: "signEvmTypedData", action: "reject", criteria: [
-                  {
-                    type:"evmTypedDataField",
-                    types: {
-                      primaryType: "Permit",
+                {
+                  operation: "signEvmTypedData",
+                  action: "reject",
+                  criteria: [
+                    {
+                      type: "evmTypedDataField",
                       types: {
-                        Permit: [
-                          {name: "owner", type: "address"},
-                          {name: "spender", type: "address"},
-                          {name: "value", type: "uint256"},
-                          {name: "nonce", type: "uint256"},
-                          {name: "deadline", type: "uint256"}
-                        ]
-                      }
+                        primaryType: "Permit",
+                        types: {
+                          Permit: [
+                            { name: "owner", type: "address" },
+                            { name: "spender", type: "address" },
+                            { name: "value", type: "uint256" },
+                            { name: "nonce", type: "uint256" },
+                            { name: "deadline", type: "uint256" },
+                          ],
+                        },
+                      },
+                      conditions: [
+                        {
+                          path: "value",
+                          operator: ">",
+                          value: "1000000000000000000000",
+                        },
+                      ],
                     },
-                    conditions: [
-                      {
-                        path: "value",
-                        operator: ">",
-                        value: "1000000000000000000000"
-                      }
-                    ]
-                  }
-                ] }
-              ]
-            }
+                  ],
+                },
+              ],
+            },
           });
           await cdp.evm.updateAccount({
             address: testAccount.address,
@@ -2307,68 +2367,72 @@ describe("CDP Client E2E Tests", () => {
               address: testAccount.address,
               types: {
                 Permit: [
-                  {name: "owner", type: "address"},
-                  {name: "spender", type: "address"},
-                  {name: "value", type: "uint256"},
-                  {name: "nonce", type: "uint256"},
-                  {name: "deadline", type: "uint256"}
-                ]
+                  { name: "owner", type: "address" },
+                  { name: "spender", type: "address" },
+                  { name: "value", type: "uint256" },
+                  { name: "nonce", type: "uint256" },
+                  { name: "deadline", type: "uint256" },
+                ],
               },
               primaryType: "Permit",
               domain: {
                 name: "Test Token",
                 version: "1",
                 chainId: baseSepolia.id,
-                verifyingContract: "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"
+                verifyingContract: "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
               },
               message: {
                 owner: testAccount.address,
                 spender: "0x742d35Cc6634C0532925a3b844Bc454e4438f44e",
                 value: "2000000000000000000000", // 2000 tokens - exceeds limit
                 nonce: 0,
-                deadline: Math.floor(Date.now() / 1000) + 3600
-              }
-            })
+                deadline: Math.floor(Date.now() / 1000) + 3600,
+              },
+            });
             expect(true).toBe(false); // Should not reach here
-          } catch(e: any) {
-            const apiError = e as APIError
-            expect(e).toBeInstanceOf(APIError)
-            expect(apiError.statusCode).toBe(403)
-            expect(apiError.errorType).toBe("policy_violation")
+          } catch (e: any) {
+            const apiError = e as APIError;
+            expect(e).toBeInstanceOf(APIError);
+            expect(apiError.statusCode).toBe(403);
+            expect(apiError.errorType).toBe("policy_violation");
           }
-        })
+        });
 
         it("address field constraint", async () => {
           await cdp.policies.updatePolicy({
             id: policy.id,
             policy: {
               rules: [
-                {operation: "signEvmTypedData", action: "reject", criteria: [
-                  {
-                    type:"evmTypedDataField",
-                    types: {
-                      primaryType: "Permit",
+                {
+                  operation: "signEvmTypedData",
+                  action: "reject",
+                  criteria: [
+                    {
+                      type: "evmTypedDataField",
                       types: {
-                        Permit: [
-                          {name: "owner", type: "address"},
-                          {name: "spender", type: "address"},
-                          {name: "value", type: "uint256"},
-                          {name: "nonce", type: "uint256"},
-                          {name: "deadline", type: "uint256"}
-                        ]
-                      }
+                        primaryType: "Permit",
+                        types: {
+                          Permit: [
+                            { name: "owner", type: "address" },
+                            { name: "spender", type: "address" },
+                            { name: "value", type: "uint256" },
+                            { name: "nonce", type: "uint256" },
+                            { name: "deadline", type: "uint256" },
+                          ],
+                        },
+                      },
+                      conditions: [
+                        {
+                          path: "spender",
+                          operator: "in",
+                          addresses: ["0x0000000000000000000000000000000000000000"],
+                        },
+                      ],
                     },
-                    conditions: [
-                      {
-                        path: "spender",
-                        operator: "in",
-                        addresses: ["0x0000000000000000000000000000000000000000"]
-                      }
-                    ]
-                  }
-                ] }
-              ]
-            }
+                  ],
+                },
+              ],
+            },
           });
           await cdp.evm.updateAccount({
             address: testAccount.address,
@@ -2379,37 +2443,37 @@ describe("CDP Client E2E Tests", () => {
               address: testAccount.address,
               types: {
                 Permit: [
-                  {name: "owner", type: "address"},
-                  {name: "spender", type: "address"},
-                  {name: "value", type: "uint256"},
-                  {name: "nonce", type: "uint256"},
-                  {name: "deadline", type: "uint256"}
-                ]
+                  { name: "owner", type: "address" },
+                  { name: "spender", type: "address" },
+                  { name: "value", type: "uint256" },
+                  { name: "nonce", type: "uint256" },
+                  { name: "deadline", type: "uint256" },
+                ],
               },
               primaryType: "Permit",
               domain: {
                 name: "Test Token",
                 version: "1",
                 chainId: baseSepolia.id,
-                verifyingContract: "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"
+                verifyingContract: "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
               },
               message: {
                 owner: testAccount.address,
                 spender: "0x0000000000000000000000000000000000000000", // Forbidden spender
                 value: "1000000000000000000",
                 nonce: 0,
-                deadline: Math.floor(Date.now() / 1000) + 3600
-              }
-            })
+                deadline: Math.floor(Date.now() / 1000) + 3600,
+              },
+            });
             expect(true).toBe(false); // Should not reach here
-          } catch(e: any) {
-            const apiError = e as APIError
-            expect(e).toBeInstanceOf(APIError)
-            expect(apiError.statusCode).toBe(403)
-            expect(apiError.errorType).toBe("policy_violation")
+          } catch (e: any) {
+            const apiError = e as APIError;
+            expect(e).toBeInstanceOf(APIError);
+            expect(apiError.statusCode).toBe(403);
+            expect(apiError.errorType).toBe("policy_violation");
           }
-        })
-      })
+        });
+      });
 
       describe("evmTypedDataVerifyingContract", () => {
         it("in", async () => {
@@ -2417,63 +2481,78 @@ describe("CDP Client E2E Tests", () => {
             id: policy.id,
             policy: {
               rules: [
-                {operation: "signEvmTypedData", action: "reject", criteria: [
-                  {type:"evmTypedDataVerifyingContract", operator: "in", addresses: ["0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"]}
-                ] }
-              ]
-            }
+                {
+                  operation: "signEvmTypedData",
+                  action: "reject",
+                  criteria: [
+                    {
+                      type: "evmTypedDataVerifyingContract",
+                      operator: "in",
+                      addresses: ["0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"],
+                    },
+                  ],
+                },
+              ],
+            },
           });
           await cdp.evm.updateAccount({
             address: testAccount.address,
             update: { accountPolicy: policy.id },
           });
           try {
-
             await cdp.evm.signTypedData({
               address: testAccount.address,
               types: {
                 Permit: [
-                  {name: "owner", type: "address"},
-                  {name: "spender", type: "address"},
-                  {name: "value", type: "uint256"},
-                  {name: "nonce", type: "uint256"},
-                  {name: "deadline", type: "uint256"}
-                ]
+                  { name: "owner", type: "address" },
+                  { name: "spender", type: "address" },
+                  { name: "value", type: "uint256" },
+                  { name: "nonce", type: "uint256" },
+                  { name: "deadline", type: "uint256" },
+                ],
               },
               primaryType: "Permit",
               domain: {
                 name: "Test Token",
                 version: "1",
                 chainId: baseSepolia.id,
-                verifyingContract: "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984" // This is in the forbidden list
+                verifyingContract: "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984", // This is in the forbidden list
               },
               message: {
                 owner: testAccount.address,
                 spender: "0x742d35Cc6634C0532925a3b844Bc454e4438f44e",
                 value: "1000000000000000000",
                 nonce: 0,
-                deadline: Math.floor(Date.now() / 1000) + 3600
-              }
-            })
+                deadline: Math.floor(Date.now() / 1000) + 3600,
+              },
+            });
             expect(true).toBe(false); // Should not reach here
-          } catch(e: any) {
-            const apiError = e as APIError
-            expect(e).toBeInstanceOf(APIError)
-            expect(apiError.statusCode).toBe(403)
-            expect(apiError.errorType).toBe("policy_violation")
+          } catch (e: any) {
+            const apiError = e as APIError;
+            expect(e).toBeInstanceOf(APIError);
+            expect(apiError.statusCode).toBe(403);
+            expect(apiError.errorType).toBe("policy_violation");
           }
-        })
+        });
 
         it("not in", async () => {
           await cdp.policies.updatePolicy({
             id: policy.id,
             policy: {
               rules: [
-                {operation: "signEvmTypedData", action: "reject", criteria: [
-                  {type:"evmTypedDataVerifyingContract", operator: "not in", addresses: ["0x742d35Cc6634C0532925a3b844Bc454e4438f44e"]}
-                ] }
-              ]
-            }
+                {
+                  operation: "signEvmTypedData",
+                  action: "reject",
+                  criteria: [
+                    {
+                      type: "evmTypedDataVerifyingContract",
+                      operator: "not in",
+                      addresses: ["0x742d35Cc6634C0532925a3b844Bc454e4438f44e"],
+                    },
+                  ],
+                },
+              ],
+            },
           });
           await cdp.evm.updateAccount({
             address: testAccount.address,
@@ -2484,37 +2563,37 @@ describe("CDP Client E2E Tests", () => {
               address: testAccount.address,
               types: {
                 Permit: [
-                  {name: "owner", type: "address"},
-                  {name: "spender", type: "address"},
-                  {name: "value", type: "uint256"},
-                  {name: "nonce", type: "uint256"},
-                  {name: "deadline", type: "uint256"}
-                ]
+                  { name: "owner", type: "address" },
+                  { name: "spender", type: "address" },
+                  { name: "value", type: "uint256" },
+                  { name: "nonce", type: "uint256" },
+                  { name: "deadline", type: "uint256" },
+                ],
               },
               primaryType: "Permit",
               domain: {
                 name: "Test Token",
                 version: "1",
                 chainId: baseSepolia.id,
-                verifyingContract: "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984" // This is not in the allowed list
+                verifyingContract: "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984", // This is not in the allowed list
               },
               message: {
                 owner: testAccount.address,
                 spender: "0x742d35Cc6634C0532925a3b844Bc454e4438f44e",
                 value: "1000000000000000000",
                 nonce: 0,
-                deadline: Math.floor(Date.now() / 1000) + 3600
-              }
-            })
+                deadline: Math.floor(Date.now() / 1000) + 3600,
+              },
+            });
             expect(true).toBe(false); // Should not reach here
-          } catch(e: any) {
-            const apiError = e as APIError
-            expect(e).toBeInstanceOf(APIError)
-            expect(apiError.statusCode).toBe(403)
-            expect(apiError.errorType).toBe("policy_violation")
+          } catch (e: any) {
+            const apiError = e as APIError;
+            expect(e).toBeInstanceOf(APIError);
+            expect(apiError.statusCode).toBe(403);
+            expect(apiError.errorType).toBe("policy_violation");
           }
-        })
-      })
+        });
+      });
     });
   });
 

--- a/typescript/src/openapi-client/errors.ts
+++ b/typescript/src/openapi-client/errors.ts
@@ -10,8 +10,6 @@ export type HttpErrorType =
   | "not_found"
   | "bad_gateway"
   | "service_unavailable"
-  | "forbidden"
-  | "policy_violation"
   | "unknown"
   | "network_timeout"
   | "network_connection_failed"

--- a/typescript/src/openapi-client/errors.ts
+++ b/typescript/src/openapi-client/errors.ts
@@ -10,6 +10,8 @@ export type HttpErrorType =
   | "not_found"
   | "bad_gateway"
   | "service_unavailable"
+  | "forbidden"
+  | "policy_violation"
   | "unknown"
   | "network_timeout"
   | "network_connection_failed"


### PR DESCRIPTION
## Description

add suite of typescript e2e tests for policy evaluation
test all major use cases

## Tests

<!--
When adding new functionality or fixing a bug, you should be testing your changes with one or more
API method examples in the examples directory.

Please provide samples of the methods you tested with, the outputs for each method,
and any other relevant context, like which network was used.

Use the following format if helpful:

```
Method: <name of method used>
Network: <network used>
Setup: <any other relevant context>

Output:
<example output>
```

For example:

```
Method: createAccount
Network: Base Sepolia

Output:
EVM Account Address:  0xC2c7D554292Bb6AE502fafc3F5c0C46B534d6f31
```
 -->

## Checklist

A couple of things to include in your PR for completeness:

- [ ] Updated the [typescript README](https://github.com/coinbase/cdp-sdk/blob/main/typescript/src/README.md) if relevant
- [ ] Updated the [python README](https://github.com/coinbase/cdp-sdk/blob/main/python/README.md) if relevant
- [ ] Added a changelog entry

<!--
For instructions on adding changelog entries:
See here for TypeScript: https://github.com/coinbase/cdp-sdk/blob/main/typescript/CONTRIBUTING.md#changelog
and here for Python: https://github.com/coinbase/cdp-sdk/blob/main/python/CONTRIBUTING.md#changelog
-->
