### PR TITLE
fix: gracefully handle closed client

### DIFF
--- a/python/cdp/api_clients.py
+++ b/python/cdp/api_clients.py
@@ -46,6 +46,15 @@ class ApiClients:
         self._solana_token_balances: SolanaTokenBalancesApi | None = None
         self._policies: PolicyEngineApi | None = None
         self._payments: PaymentsAlphaApi | None = None
+        self._closed = False
+
+    def _check_closed(self) -> None:
+        """Check if the client has been closed and raise an appropriate error."""
+        if self._closed:
+            raise RuntimeError(
+                "Cannot use a closed CDP client. Please create a new client instance. "
+                "This error occurs when trying to use a client after calling close()."
+            )
 
     @property
     def solana_token_balances(self) -> SolanaTokenBalancesApi:
@@ -58,6 +67,7 @@ class ApiClients:
             This property lazily initializes the SolanaTokenBalancesApi client on first access.
 
         """
+        self._check_closed()
         if self._solana_token_balances is None:
             self._solana_token_balances = SolanaTokenBalancesApi(api_client=self._cdp_client)
         return self._solana_token_balances
@@ -73,6 +83,7 @@ class ApiClients:
             This property lazily initializes the EVMAccountsApi client on first access.
 
         """
+        self._check_closed()
         if self._evm_accounts is None:
             self._evm_accounts = EVMAccountsApi(api_client=self._cdp_client)
         return self._evm_accounts
@@ -88,6 +99,7 @@ class ApiClients:
             This property lazily initializes the EVMSmartAccountsApi client on first access.
 
         """
+        self._check_closed()
         if self._evm_smart_accounts is None:
             self._evm_smart_accounts = EVMSmartAccountsApi(api_client=self._cdp_client)
         return self._evm_smart_accounts
@@ -103,6 +115,7 @@ class ApiClients:
             This property lazily initializes the EVMSwapsApi client on first access.
 
         """
+        self._check_closed()
         if self._evm_swaps is None:
             self._evm_swaps = EVMSwapsApi(api_client=self._cdp_client)
         return self._evm_swaps
@@ -118,6 +131,7 @@ class ApiClients:
             This property lazily initializes the EVMTokenBalancesApi client on first access.
 
         """
+        self._check_closed()
         if self._evm_token_balances is None:
             self._evm_token_balances = EVMTokenBalancesApi(api_client=self._cdp_client)
         return self._evm_token_balances
@@ -133,6 +147,7 @@ class ApiClients:
             This property lazily initializes the FaucetsApi client on first access.
 
         """
+        self._check_closed()
         if self._faucets is None:
             self._faucets = FaucetsApi(api_client=self._cdp_client)
         return self._faucets
@@ -148,6 +163,7 @@ class ApiClients:
             This property lazily initializes the SolanaAccountsApi client on first access.
 
         """
+        self._check_closed()
         if self._solana_accounts is None:
             self._solana_accounts = SolanaAccountsApi(api_client=self._cdp_client)
         return self._solana_accounts
@@ -163,6 +179,7 @@ class ApiClients:
             This property lazily initializes the PolicyEngineApi client on first access.
 
         """
+        self._check_closed()
         if self._policies is None:
             self._policies = PolicyEngineApi(api_client=self._cdp_client)
         return self._policies
@@ -178,6 +195,7 @@ class ApiClients:
             This property lazily initializes the PaymentsAlphaApi client on first access.
 
         """
+        self._check_closed()
         if self._payments is None:
             self._payments = PaymentsAlphaApi(api_client=self._cdp_client)
         return self._payments
@@ -185,3 +203,4 @@ class ApiClients:
     async def close(self):
         """Close the CDP client asynchronously."""
         await self._cdp_client.close()
+        self._closed = True

--- a/python/cdp/cdp_client.py
+++ b/python/cdp/cdp_client.py
@@ -91,6 +91,7 @@ For more information, see: https://github.com/coinbase/cdp-sdk/blob/main/python/
         self._evm = EvmClient(self.api_clients)
         self._solana = SolanaClient(self.api_clients)
         self._policies = PoliciesClient(self.api_clients)
+        self._closed = False
 
         if os.getenv("DISABLE_CDP_ERROR_REPORTING") != "true":
             Analytics["identifier"] = api_key_id
@@ -102,17 +103,28 @@ For more information, see: https://github.com/coinbase/cdp-sdk/blob/main/python/
     @property
     def evm(self) -> EvmClient:
         """Get the EvmClient instance."""
+        self._check_closed()
         return self._evm
 
     @property
     def solana(self) -> SolanaClient:
         """Get the SolanaClient instance."""
+        self._check_closed()
         return self._solana
 
     @property
     def policies(self) -> PoliciesClient:
         """Get the PoliciesClient instance."""
+        self._check_closed()
         return self._policies
+
+    def _check_closed(self) -> None:
+        """Check if the client has been closed and raise an appropriate error."""
+        if self._closed:
+            raise RuntimeError(
+                "Cannot use a closed CDP client. Please create a new client instance. "
+                "This error occurs when trying to use a client after calling close()."
+            )
 
     async def __aenter__(self):
         """Enter the context manager."""
@@ -125,4 +137,5 @@ For more information, see: https://github.com/coinbase/cdp-sdk/blob/main/python/
     async def close(self):
         """Close the CDP client."""
         await self.api_clients.close()
+        self._closed = True
         return None

--- a/python/cdp/test/test_cdp_client.py
+++ b/python/cdp/test/test_cdp_client.py
@@ -76,3 +76,30 @@ async def test_close(mock_close):
 
     mock_close.assert_called_once()
     assert result is None
+
+
+@pytest.mark.asyncio
+@patch("cdp.api_clients.ApiClients.close")
+async def test_use_after_close_raises_error(mock_close):
+    """Test that using a closed client raises a clear error."""
+    mock_close.return_value = None
+
+    client = CdpClient("api_key_id", "api_key_secret", "wallet_secret")
+    await client.close()
+
+    # Test that accessing properties after close raises RuntimeError
+    with pytest.raises(RuntimeError) as exc_info:
+        _ = client.evm
+
+    assert "Cannot use a closed CDP client" in str(exc_info.value)
+    assert "create a new client instance" in str(exc_info.value)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        _ = client.solana
+
+    assert "Cannot use a closed CDP client" in str(exc_info.value)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        _ = client.policies
+
+    assert "Cannot use a closed CDP client" in str(exc_info.value)

--- a/python/changelog.d/298.bugfix.md
+++ b/python/changelog.d/298.bugfix.md
@@ -1,0 +1,1 @@
+Gracefully handle closed client connections


### PR DESCRIPTION
<!--
Thanks for contributing to CDP SDK!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

This PR adds a runtime error to the Python SDK when a builder attempts to use the SDK when the client has been closed, either manually or outside of an async context.

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
 -->

## Tests

Tested manually

<!--
When adding new functionality or fixing a bug, you should be testing your changes with one or more
API method examples in the examples directory.

Please provide samples of the methods you tested with, the outputs for each method,
and any other relevant context, like which network was used.

Use the following format if helpful:

```
Method: <name of method used>
Network: <network used>
Setup: <any other relevant context>

Output:
<example output>
```

For example:

```
Method: createAccount
Network: Base Sepolia

Output:
EVM Account Address:  0xC2c7D554292Bb6AE502fafc3F5c0C46B534d6f31
```
 -->

## Checklist

A couple of things to include in your PR for completeness:

- [ ] Updated the [typescript README](https://github.com/coinbase/cdp-sdk/blob/main/typescript/src/README.md) if relevant
- [ ] Updated the [python README](https://github.com/coinbase/cdp-sdk/blob/main/python/README.md) if relevant
- [x] Added a changelog entry

<!--
For instructions on adding changelog entries:
See here for TypeScript: https://github.com/coinbase/cdp-sdk/blob/main/typescript/CONTRIBUTING.md#changelog
and here for Python: https://github.com/coinbase/cdp-sdk/blob/main/python/CONTRIBUTING.md#changelog
-->
