### PR TITLE
feat(CDPSDK-1238): add create spend permission

### DIFF
--- a/examples/typescript/evm/createSpendPermission.ts
+++ b/examples/typescript/evm/createSpendPermission.ts
@@ -1,0 +1,38 @@
+import { CdpClient, SpendPermission } from "@coinbase/cdp-sdk";
+import { parseEther } from "viem";
+import "dotenv/config";
+
+const cdp = new CdpClient();
+
+const owner = await cdp.evm.createAccount();
+
+const smartAccount = await cdp.evm.createSmartAccount({
+  owner,
+  __experimental_enableSpendPermission: true,
+});
+
+const spender = await cdp.evm.createAccount();
+
+const spendPermission: SpendPermission = {
+  account: smartAccount.address,
+  spender: spender.address,
+  token: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+  allowance: parseEther("0.00001"),
+  period: 86400,
+  start: 0,
+  end: 281474976710655,
+  salt: BigInt(0),
+  extraData: "0x",
+};
+
+const { userOpHash } = await cdp.evm.createSpendPermission({
+  spendPermission,
+  network: "base-sepolia",
+});
+
+const userOperationResult = await cdp.evm.waitForUserOperation({
+  smartAccountAddress: smartAccount.address,
+  userOpHash,
+});
+
+console.log("User Operation:", userOperationResult);

--- a/typescript/src/auth/utils/http.ts
+++ b/typescript/src/auth/utils/http.ts
@@ -126,7 +126,8 @@ export async function getAuthHeaders(
  */
 function requiresWalletAuth(requestMethod: string, requestPath: string): boolean {
   return (
-    requestPath?.includes("/accounts") && (requestMethod === "POST" || requestMethod === "DELETE")
+    (requestPath?.includes("/accounts") || requestPath?.includes("/spend-permissions")) &&
+    (requestMethod === "POST" || requestMethod === "DELETE" || requestMethod === "PUT")
   );
 }
 

--- a/typescript/src/client/evm/evm.ts
+++ b/typescript/src/client/evm/evm.ts
@@ -5,6 +5,7 @@ import { type Address, getTypesForEIP712Domain } from "viem";
 import {
   CreateServerAccountOptions,
   CreateSmartAccountOptions,
+  CreateSpendPermissionOptions,
   CreateSwapQuoteOptions,
   CreateSwapQuoteResult,
   EvmClientInterface,
@@ -364,6 +365,58 @@ export class EvmClient implements EvmClientInterface {
     Analytics.wrapObjectMethodsWithErrorTracking(smartAccount);
 
     return smartAccount;
+  }
+
+  /**
+   * Creates a spend permission for a smart account.
+   *
+   * @param {CreateSpendPermissionOptions} options - Parameters for creating the spend permission.
+   * @param {SpendPermission} options.spendPermission - The spend permission to create.
+   * @param {string} [options.idempotencyKey] - The idempotency key to use for the spend permission.
+   *
+   * @returns A promise that resolves to the spend permission.
+   *
+   * @example
+   * ```ts
+   * const userOperation = await cdp.evm.createSpendPermission({
+   *   spendPermission,
+   *   network: "base-sepolia",
+   * });
+   * ```
+   */
+  async createSpendPermission(options: CreateSpendPermissionOptions): Promise<UserOperation> {
+    Analytics.trackAction({
+      action: "create_spend_permission",
+    });
+
+    const userOperation = await CdpOpenApiClient.createSpendPermission(
+      options.spendPermission.account,
+      {
+        account: options.spendPermission.account,
+        spender: options.spendPermission.spender,
+        token: options.spendPermission.token,
+        allowance: options.spendPermission.allowance.toString(),
+        period: options.spendPermission.period.toString(),
+        start: options.spendPermission.start.toString(),
+        end: options.spendPermission.end.toString(),
+        salt: options.spendPermission.salt.toString(),
+        extraData: options.spendPermission.extraData,
+        network: options.network,
+        paymasterUrl: options.paymasterUrl,
+      },
+      options.idempotencyKey,
+    );
+
+    return {
+      network: userOperation.network,
+      userOpHash: userOperation.userOpHash as Hex,
+      status: userOperation.status,
+      calls: userOperation.calls.map(call => ({
+        to: call.to as Address,
+        value: BigInt(call.value),
+        data: call.data as Hex,
+      })),
+    };
   }
 
   /**

--- a/typescript/src/e2e.test.ts
+++ b/typescript/src/e2e.test.ts
@@ -1158,12 +1158,10 @@ describe("CDP Client E2E Tests", () => {
     });
     describe("create spend permission", () => {
       it("should create a spend permission", async () => {
-        const smartAccount = await cdp.evm.createSmartAccount(
-          {
-            owner: testAccount,
-            __experimental_enableSpendPermission: true,
-          },
-        );
+        const smartAccount = await cdp.evm.createSmartAccount({
+          owner: testAccount,
+          __experimental_enableSpendPermission: true,
+        });
 
         const spendPermission: SpendPermission = {
           account: smartAccount.address,
@@ -1182,7 +1180,7 @@ describe("CDP Client E2E Tests", () => {
           spendPermission,
         });
 
-        const userOpResult = await testSmartAccount.waitForUserOperation({
+        const userOpResult = await smartAccount.waitForUserOperation({
           userOpHash,
         });
 

--- a/typescript/src/e2e.test.ts
+++ b/typescript/src/e2e.test.ts
@@ -1159,18 +1159,22 @@ describe("CDP Client E2E Tests", () => {
     describe("create spend permission", () => {
       it("should create a spend permission", async () => {
         const owner = await cdp.evm.getOrCreateAccount({
-          name: "Spend Permission Owner",
+          name: "Spend-Permission-Owner",
         });
 
         const smartAccount = await cdp.evm.getOrCreateSmartAccount({
-          name: "Spend Permission Smart Account",
+          name: "Spend-Permission-Smart-Account",
           owner,
           __experimental_enableSpendPermission: true,
         });
 
+        const spender = await cdp.evm.getOrCreateAccount({
+          name: "Spend-Permission-Spender",
+        });
+
         const spendPermission: SpendPermission = {
           account: smartAccount.address,
-          spender: testAccount.address,
+          spender: spender.address,
           token: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
           allowance: parseEther("0.00001"),
           period: 86400,
@@ -1181,16 +1185,17 @@ describe("CDP Client E2E Tests", () => {
         };
 
         const { userOpHash } = await cdp.evm.createSpendPermission({
-          network: "base-sepolia",
           spendPermission,
+          network: "base-sepolia",
         });
 
-        const userOpResult = await smartAccount.waitForUserOperation({
+        const userOperationResult = await cdp.evm.waitForUserOperation({
+          smartAccountAddress: smartAccount.address,
           userOpHash,
         });
 
-        expect(userOpResult).toBeDefined();
-        expect(userOpResult.status).toBe("complete");
+        expect(userOperationResult).toBeDefined();
+        expect(userOperationResult.status).toBe("complete");
       });
     });
   });

--- a/typescript/src/e2e.test.ts
+++ b/typescript/src/e2e.test.ts
@@ -1158,8 +1158,13 @@ describe("CDP Client E2E Tests", () => {
     });
     describe("create spend permission", () => {
       it("should create a spend permission", async () => {
-        const smartAccount = await cdp.evm.createSmartAccount({
-          owner: testAccount,
+        const owner = await cdp.evm.getOrCreateAccount({
+          name: "Spend Permission Owner",
+        });
+
+        const smartAccount = await cdp.evm.getOrCreateSmartAccount({
+          name: "Spend Permission Smart Account",
+          owner,
           __experimental_enableSpendPermission: true,
         });
 

--- a/typescript/src/e2e.test.ts
+++ b/typescript/src/e2e.test.ts
@@ -40,6 +40,7 @@ import bs58 from "bs58";
 import { Abi } from "abitype";
 import kitchenSinkAbi from "../fixtures/kitchenSinkAbi.js";
 import { APIError, HttpErrorType } from "./openapi-client/errors.js";
+import { SpendPermission } from "./spend-permissions/types.js";
 
 dotenv.config();
 
@@ -1153,6 +1154,33 @@ describe("CDP Client E2E Tests", () => {
           console.log("Error: ", error);
           console.log("Ignoring for now...");
         }
+      });
+    });
+    describe("create spend permission", () => {
+      it("should create a spend permission", async () => {
+        const spendPermission: SpendPermission = {
+          account: testSmartAccount.address,
+          spender: testAccount.address,
+          token: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+          allowance: parseEther("0.00001"),
+          period: 86400,
+          start: 0,
+          end: 281474976710655,
+          salt: BigInt(0),
+          extraData: "0x",
+        };
+
+        const { userOpHash } = await cdp.evm.createSpendPermission({
+          network: "base-sepolia",
+          spendPermission,
+        });
+
+        const userOpResult = await testSmartAccount.waitForUserOperation({
+          userOpHash,
+        });
+
+        expect(userOpResult).toBeDefined();
+        expect(userOpResult.status).toBe("complete");
       });
     });
   });

--- a/typescript/src/e2e.test.ts
+++ b/typescript/src/e2e.test.ts
@@ -1158,8 +1158,15 @@ describe("CDP Client E2E Tests", () => {
     });
     describe("create spend permission", () => {
       it("should create a spend permission", async () => {
+        const smartAccount = await cdp.evm.createSmartAccount(
+          {
+            owner: testAccount,
+            __experimental_enableSpendPermission: true,
+          },
+        );
+
         const spendPermission: SpendPermission = {
-          account: testSmartAccount.address,
+          account: smartAccount.address,
           spender: testAccount.address,
           token: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
           allowance: parseEther("0.00001"),


### PR DESCRIPTION
<!--
Thanks for contributing to CDP SDK!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description
This PR adds createSpendPermission which allows a smart account to create a spend permission for a designated spender account (EOA or smart account).

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
 -->

## Tests

<!--
When adding new functionality or fixing a bug, you should be testing your changes with one or more
API method examples in the examples directory.

Please provide samples of the methods you tested with, the outputs for each method,
and any other relevant context, like which network was used.

Use the following format if helpful:

```
Method: <name of method used>
Network: <network used>
Setup: <any other relevant context>

Output:
<example output>
```

For example:

```
Method: createAccount
Network: Base Sepolia

Output:
EVM Account Address:  0xC2c7D554292Bb6AE502fafc3F5c0C46B534d6f31
```
 -->

## Checklist

A couple of things to include in your PR for completeness:

- [ ] Updated the [typescript README](https://github.com/coinbase/cdp-sdk/blob/main/typescript/src/README.md) if relevant
- [ ] Updated the [python README](https://github.com/coinbase/cdp-sdk/blob/main/python/README.md) if relevant
- [ ] Added a changelog entry
- [ ] Added e2e tests if introducing new functionality

<!--
For instructions on adding changelog entries:
See here for TypeScript: https://github.com/coinbase/cdp-sdk/blob/main/typescript/CONTRIBUTING.md#changelog
and here for Python: https://github.com/coinbase/cdp-sdk/blob/main/python/CONTRIBUTING.md#changelog
-->
