### PR TITLE
WIP: Switch to listDataTokenBalances for improved freshness guarantees

### DIFF
--- a/typescript/src/actions/evm/listTokenBalances.ts
+++ b/typescript/src/actions/evm/listTokenBalances.ts
@@ -82,7 +82,7 @@ export async function listTokenBalances(
   client: CdpOpenApiClientType,
   options: ListTokenBalancesOptions,
 ): Promise<ListTokenBalancesResult> {
-  const response = await client.listEvmTokenBalances(options.network, options.address, {
+  const response = await client.listDataTokenBalances(options.network, options.address, {
     pageSize: options.pageSize,
     pageToken: options.pageToken,
   });


### PR DESCRIPTION
## Description

Switch from `listEvmTokenBalances()` to `listDataTokenBalances()` to use the new `/v2/data/evm/token-balances` endpoint with improved freshness guarantees.

**Note:** This is a demo PR to show the intended change direction. CI will fail until the OpenAPI spec is updated and clients regenerated.

## Tests

smoke tests locally

## Checklist

- [x] (No user-facing changes)
- [x] (TypeScript only) 