### PR TITLE
chore: use trusted publishing

### DIFF
--- a/.github/workflows/typescript_publish.yml
+++ b/.github/workflows/typescript_publish.yml
@@ -43,5 +43,3 @@ jobs:
         run: |
           pnpm run prepublish
           pnpm publish --recursive --no-git-checks --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
<!--
Thanks for contributing to CDP SDK!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

We've set up NPM Trusted Publishing which uses an OIDC flow to request an auth token to publish, removing the need for us to persist an auth token to the repo.

This will be tested during our next publish. If the next publish fails, we can revert this PR to unblock; otherwise we're all good and would have validated that the Trusted Publishing setup is working correctly, and then we can apply it to other repos.
