### PR TITLE
chore: Add retries to known flaky e2e tests

### DIFF
--- a/python/cdp/test/test_e2e.py
+++ b/python/cdp/test/test_e2e.py
@@ -761,6 +761,7 @@ async def test_evm_sign_typed_data_for_account(cdp_client):
 
 @pytest.mark.e2e
 @pytest.mark.asyncio
+@retry_on_failure()
 async def test_transfer_eth(cdp_client):
     """Test transferring ETH."""
     account = await cdp_client.evm.get_or_create_account(name=test_account_name)
@@ -807,6 +808,7 @@ async def test_transfer_usdc(cdp_client):
 
 @pytest.mark.e2e
 @pytest.mark.asyncio
+@retry_on_failure()
 async def test_transfer_eth_smart_account(cdp_client):
     """Test transferring ETH with a smart account."""
     account = await cdp_client.evm.create_smart_account(owner=Account.create())

--- a/typescript/src/e2e.test.ts
+++ b/typescript/src/e2e.test.ts
@@ -3537,60 +3537,62 @@ describe("CDP Client E2E Tests", () => {
   });
 
   it("should use Base Node RPC URL when using managed mode with network identifiers", async () => {
-    if (process.env.E2E_BASE_PATH?.includes("localhost")) {
-      logger.log("Skipping test in local environment");
-      return;
-    }
+    await retryOnFailure(async () => {
+      if (process.env.E2E_BASE_PATH?.includes("localhost")) {
+        logger.log("Skipping test in local environment");
+        return;
+      }
 
-    // Spy on global fetch to capture HTTP calls
-    const fetchSpy = vi.spyOn(globalThis, "fetch");
+      // Spy on global fetch to capture HTTP calls
+      const fetchSpy = vi.spyOn(globalThis, "fetch");
 
-    try {
-      const account = await cdp.evm.getOrCreateAccount({ name: testAccountName });
+      try {
+        const account = await cdp.evm.getOrCreateAccount({ name: testAccountName });
 
-      const baseAccount = await account.useNetwork("base-sepolia");
+        const baseAccount = await account.useNetwork("base-sepolia");
 
-      const txResult = await baseAccount.sendTransaction({
-        transaction: {
-          to: "0x4252e0c9A3da5A2700e7d91cb50aEf522D0C6Fe8",
-          value: parseEther("0.000001"),
-        },
-      });
+        const txResult = await baseAccount.sendTransaction({
+          transaction: {
+            to: "0x4252e0c9A3da5A2700e7d91cb50aEf522D0C6Fe8",
+            value: parseEther("0.000001"),
+          },
+        });
 
-      // Wait for transaction receipt - this should use the Base Node RPC
-      await baseAccount.waitForTransactionReceipt({
-        hash: txResult.transactionHash,
-      });
+        // Wait for transaction receipt - this should use the Base Node RPC
+        await baseAccount.waitForTransactionReceipt({
+          hash: txResult.transactionHash,
+        });
 
-      // Find the RPC calls made during the transaction
-      const rpcCalls = fetchSpy.mock.calls.filter(call => {
-        const url = call[0] as string;
-        const body = call[1]?.body;
-        return (
-          url.includes("/rpc/v1/base-sepolia/") &&
-          body &&
-          body.toString().includes("eth_getTransactionReceipt")
-        );
-      });
+        // Find the RPC calls made during the transaction
+        const rpcCalls = fetchSpy.mock.calls.filter(call => {
+          const url = call[0] as string;
+          const body = call[1]?.body;
+          return (
+            url.includes("/rpc/v1/base-sepolia/") &&
+            body &&
+            body.toString().includes("eth_getTransactionReceipt")
+          );
+        });
 
-      expect(rpcCalls.length).toBeGreaterThan(0);
+        expect(rpcCalls.length).toBeGreaterThan(0);
 
-      const rpcUrl = rpcCalls[0][0] as string;
-      expect(rpcUrl).toMatch(/\/rpc\/v1\/base-sepolia\/[a-zA-Z0-9-]+$/);
+        const rpcUrl = rpcCalls[0][0] as string;
+        expect(rpcUrl).toMatch(/\/rpc\/v1\/base-sepolia\/[a-zA-Z0-9-]+$/);
 
-      logger.log(`Base Node RPC URL used: ${rpcUrl}`);
+        logger.log(`Base Node RPC URL used: ${rpcUrl}`);
 
-      // Also verify that the initial getBaseNodeRpcUrl call was made
-      const tokenCalls = fetchSpy.mock.calls.filter(call => {
-        const url = call[0] as string;
-        return url.includes("/apikeys/v1/tokens/active");
-      });
+        // Also verify that the initial getBaseNodeRpcUrl call was made
+        const tokenCalls = fetchSpy.mock.calls.filter(call => {
+          const url = call[0] as string;
+          return url.includes("/apikeys/v1/tokens/active");
+        });
 
-      expect(tokenCalls.length).toBeGreaterThan(0);
-      logger.log(`Token endpoint called ${tokenCalls.length} times`);
-    } finally {
-      fetchSpy.mockRestore();
-    }
+        expect(tokenCalls.length).toBeGreaterThan(0);
+        logger.log(`Token endpoint called ${tokenCalls.length} times`);
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
   });
 });
 


### PR DESCRIPTION
<!--
Thanks for contributing to CDP SDK!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

Add retries to known flaky e2e tests on TypeScript and Python, configurable with number of attempts and retry delay.

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
 -->

## Tests

Updated e2e tests.

<!--
When adding new functionality or fixing a bug, you should be testing your changes with one or more
API method examples in the examples directory.

Please provide samples of the methods you tested with, the outputs for each method,
and any other relevant context, like which network was used.

Use the following format if helpful:

```
Method: <name of method used>
Network: <network used>
Setup: <any other relevant context>

Output:
<example output>
```

For example:

```
Method: createAccount
Network: Base Sepolia

Output:
EVM Account Address:  0xC2c7D554292Bb6AE502fafc3F5c0C46B534d6f31
```
 -->

## Checklist

A couple of things to include in your PR for completeness:

- [ ] Updated the [typescript README](https://github.com/coinbase/cdp-sdk/blob/main/typescript/src/README.md) if relevant
- [ ] Updated the [python README](https://github.com/coinbase/cdp-sdk/blob/main/python/README.md) if relevant
- [ ] Added a changelog entry
- [ ] Added e2e tests if introducing new functionality

<!--
For instructions on adding changelog entries:
See here for TypeScript: https://github.com/coinbase/cdp-sdk/blob/main/typescript/CONTRIBUTING.md#changelog
and here for Python: https://github.com/coinbase/cdp-sdk/blob/main/python/CONTRIBUTING.md#changelog
-->
