### PR TITLE
chore: properly mock out network requests in viem tests

### DIFF
--- a/typescript/src/accounts/evm/resolveViemClients.test.ts
+++ b/typescript/src/accounts/evm/resolveViemClients.test.ts
@@ -1,7 +1,46 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, MockedFunction } from "vitest";
 import { base, baseSepolia, mainnet } from "viem/chains";
+import { createPublicClient, createWalletClient, http } from "viem";
+import type { PublicClient, WalletClient, HttpTransport } from "viem";
 
 import { resolveViemClients } from "./resolveViemClients.js";
+
+vi.mock("viem", async () => {
+  const actual = await vi.importActual("viem");
+  return {
+    ...actual,
+    createPublicClient: vi.fn(),
+    createWalletClient: vi.fn(),
+    http: vi.fn(),
+  };
+});
+
+vi.mock("./getBaseNodeRpcUrl.js", () => ({
+  getBaseNodeRpcUrl: vi.fn().mockResolvedValue("https://mocked-base-rpc.url"),
+}));
+
+const mockCreatePublicClient = createPublicClient as MockedFunction<typeof createPublicClient>;
+const mockCreateWalletClient = createWalletClient as MockedFunction<typeof createWalletClient>;
+const mockHttp = http as MockedFunction<typeof http>;
+
+type MockTransport = {
+  config: {
+    url: string | undefined;
+  };
+};
+
+type MockPublicClient = {
+  transport: MockTransport;
+  getChainId?: ReturnType<typeof vi.fn>;
+};
+
+type MockWalletClient = {
+  transport: MockTransport;
+};
+
+type MockHttpTransport = {
+  url: string | undefined;
+};
 
 describe("resolveViemClients", () => {
   const mockAccount = {
@@ -18,60 +57,128 @@ describe("resolveViemClients", () => {
 
   describe("with network identifiers", () => {
     it("should resolve 'base' network identifier correctly", async () => {
+      const mockPublicClient: MockPublicClient = {
+        transport: { config: { url: "https://mocked-base-rpc.url" } },
+      };
+      const mockWalletClient: MockWalletClient = {
+        transport: { config: { url: "https://mocked-base-rpc.url" } },
+      };
+      const mockTransport: MockHttpTransport = { url: "https://mocked-base-rpc.url" };
+
+      mockCreatePublicClient.mockReturnValue(mockPublicClient as unknown as PublicClient);
+      mockCreateWalletClient.mockReturnValue(mockWalletClient as unknown as WalletClient);
+      mockHttp.mockReturnValue(mockTransport as unknown as HttpTransport);
+
       const result = await resolveViemClients({
         networkOrNodeUrl: "base",
         account: mockAccount,
       });
 
       expect(result.chain).toBe(base);
-      expect(result.publicClient.transport.url).toBe(base.rpcUrls.default.http[0]);
-      expect(result.walletClient.transport.url).toBe(base.rpcUrls.default.http[0]);
+      expect(result.publicClient.transport.config.url).toBe("https://mocked-base-rpc.url");
+      expect(result.walletClient.transport.config.url).toBe("https://mocked-base-rpc.url");
     });
 
     it("should resolve 'base-sepolia' network identifier correctly", async () => {
+      const mockPublicClient: MockPublicClient = {
+        transport: { config: { url: "https://mocked-base-rpc.url" } },
+      };
+      const mockWalletClient: MockWalletClient = {
+        transport: { config: { url: "https://mocked-base-rpc.url" } },
+      };
+      const mockTransport: MockHttpTransport = { url: "https://mocked-base-rpc.url" };
+
+      mockCreatePublicClient.mockReturnValue(mockPublicClient as unknown as PublicClient);
+      mockCreateWalletClient.mockReturnValue(mockWalletClient as unknown as WalletClient);
+      mockHttp.mockReturnValue(mockTransport as unknown as HttpTransport);
+
       const result = await resolveViemClients({
         networkOrNodeUrl: "base-sepolia",
         account: mockAccount,
       });
 
       expect(result.chain).toBe(baseSepolia);
-      expect(result.publicClient.transport.url).toBe(baseSepolia.rpcUrls.default.http[0]);
-      expect(result.walletClient.transport.url).toBe(baseSepolia.rpcUrls.default.http[0]);
+      expect(result.publicClient.transport.config.url).toBe("https://mocked-base-rpc.url");
+      expect(result.walletClient.transport.config.url).toBe("https://mocked-base-rpc.url");
     });
 
     it("should resolve 'ethereum' network identifier correctly", async () => {
+      const mockPublicClient: MockPublicClient = { transport: { config: { url: undefined } } };
+      const mockWalletClient: MockWalletClient = { transport: { config: { url: undefined } } };
+      const mockTransport: MockHttpTransport = { url: undefined };
+
+      mockCreatePublicClient.mockReturnValue(mockPublicClient as unknown as PublicClient);
+      mockCreateWalletClient.mockReturnValue(mockWalletClient as unknown as WalletClient);
+      mockHttp.mockReturnValue(mockTransport as unknown as HttpTransport);
+
       const result = await resolveViemClients({
         networkOrNodeUrl: "ethereum",
         account: mockAccount,
       });
 
       expect(result.chain).toBe(mainnet);
-      expect(result.publicClient.transport.url).toBe(mainnet.rpcUrls.default.http[0]);
-      expect(result.walletClient.transport.url).toBe(mainnet.rpcUrls.default.http[0]);
+      expect(result.publicClient.transport.config.url).toBe(undefined);
+      expect(result.walletClient.transport.config.url).toBe(undefined);
     });
   });
 
   describe("with Node URLs", () => {
     it("should resolve Node URL to base chain correctly", async () => {
+      const tempPublicClient: MockPublicClient = {
+        transport: { config: { url: "https://mainnet.base.org" } },
+        getChainId: vi.fn().mockResolvedValue(8453),
+      };
+      const finalPublicClient: MockPublicClient = {
+        transport: { config: { url: "https://mainnet.base.org" } },
+      };
+      const finalWalletClient: MockWalletClient = {
+        transport: { config: { url: "https://mainnet.base.org" } },
+      };
+      const mockTransport: MockHttpTransport = { url: "https://mainnet.base.org" };
+
+      mockCreatePublicClient
+        .mockReturnValueOnce(tempPublicClient as unknown as PublicClient)
+        .mockReturnValue(finalPublicClient as unknown as PublicClient);
+      mockCreateWalletClient.mockReturnValue(finalWalletClient as unknown as WalletClient);
+      mockHttp.mockReturnValue(mockTransport as unknown as HttpTransport);
+
       const result = await resolveViemClients({
         networkOrNodeUrl: "https://mainnet.base.org",
         account: mockAccount,
       });
 
       expect(result.chain).toBe(base);
-      expect(result.publicClient.transport.url).toBe("https://mainnet.base.org");
-      expect(result.walletClient.transport.url).toBe("https://mainnet.base.org");
+      expect(result.publicClient.transport.config.url).toBe("https://mainnet.base.org");
+      expect(result.walletClient.transport.config.url).toBe("https://mainnet.base.org");
     });
 
     it("should resolve Node URL to base-sepolia chain correctly", async () => {
+      const tempPublicClient: MockPublicClient = {
+        transport: { config: { url: "https://sepolia.base.org" } },
+        getChainId: vi.fn().mockResolvedValue(84532),
+      };
+      const finalPublicClient: MockPublicClient = {
+        transport: { config: { url: "https://sepolia.base.org" } },
+      };
+      const finalWalletClient: MockWalletClient = {
+        transport: { config: { url: "https://sepolia.base.org" } },
+      };
+      const mockTransport: MockHttpTransport = { url: "https://sepolia.base.org" };
+
+      mockCreatePublicClient
+        .mockReturnValueOnce(tempPublicClient as unknown as PublicClient)
+        .mockReturnValue(finalPublicClient as unknown as PublicClient);
+      mockCreateWalletClient.mockReturnValue(finalWalletClient as unknown as WalletClient);
+      mockHttp.mockReturnValue(mockTransport as unknown as HttpTransport);
+
       const result = await resolveViemClients({
         networkOrNodeUrl: "https://sepolia.base.org",
         account: mockAccount,
       });
 
       expect(result.chain).toBe(baseSepolia);
-      expect(result.publicClient.transport.url).toBe("https://sepolia.base.org");
-      expect(result.walletClient.transport.url).toBe("https://sepolia.base.org");
+      expect(result.publicClient.transport.config.url).toBe("https://sepolia.base.org");
+      expect(result.walletClient.transport.config.url).toBe("https://sepolia.base.org");
     });
 
     it("should throw error for malformed URLs", async () => {
@@ -93,6 +200,13 @@ describe("resolveViemClients", () => {
     });
 
     it("should throw error when getChainId fails", async () => {
+      const failingPublicClient: MockPublicClient = {
+        transport: { config: { url: "https://invalid-url.org" } },
+        getChainId: vi.fn().mockRejectedValue(new Error("HTTP request failed")),
+      };
+
+      mockCreatePublicClient.mockReturnValueOnce(failingPublicClient as unknown as PublicClient);
+
       await expect(
         resolveViemClients({
           networkOrNodeUrl: "https://invalid-url.org",


### PR DESCRIPTION
<!--
Thanks for contributing to CDP SDK!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

This will reduce flakiness in unit tests caused by using public RPC – the test now fully mocks the network so no real network requests are being made.

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
 -->

## Tests

<!--
When adding new functionality or fixing a bug, you should be testing your changes with one or more
API method examples in the examples directory.

Please provide samples of the methods you tested with, the outputs for each method,
and any other relevant context, like which network was used.

Use the following format if helpful:

```
Method: <name of method used>
Network: <network used>
Setup: <any other relevant context>

Output:
<example output>
```

For example:

```
Method: createAccount
Network: Base Sepolia

Output:
EVM Account Address:  0xC2c7D554292Bb6AE502fafc3F5c0C46B534d6f31
```
 -->

## Checklist

A couple of things to include in your PR for completeness:

- [ ] Updated the [typescript README](https://github.com/coinbase/cdp-sdk/blob/main/typescript/src/README.md) if relevant
- [ ] Updated the [python README](https://github.com/coinbase/cdp-sdk/blob/main/python/README.md) if relevant
- [ ] Added a changelog entry
- [ ] Added e2e tests if introducing new functionality

<!--
For instructions on adding changelog entries:
See here for TypeScript: https://github.com/coinbase/cdp-sdk/blob/main/typescript/CONTRIBUTING.md#changelog
and here for Python: https://github.com/coinbase/cdp-sdk/blob/main/python/CONTRIBUTING.md#changelog
-->
