### PR TITLE
chore: Conditionally skip EVM token balances e2e tests

### DIFF
--- a/typescript/src/e2e.test.ts
+++ b/typescript/src/e2e.test.ts
@@ -802,6 +802,11 @@ describe("CDP Client E2E Tests", () => {
   });
 
   it("should list evm token balances", async () => {
+    if (process.env.CDP_E2E_SKIP_EVM_TOKEN_BALANCES === "true") {
+      console.log("Skipping token balances test as per environment variable");
+      return;
+    }
+
     const address = "0x5b76f5B8fc9D700624F78208132f91AD4e61a1f0";
 
     const firstPage = await cdp.evm.listTokenBalances({
@@ -975,6 +980,11 @@ describe("CDP Client E2E Tests", () => {
 
     describe("list token balances", () => {
       it("should list token balances", async () => {
+        if (process.env.CDP_E2E_SKIP_EVM_TOKEN_BALANCES === "true") {
+          console.log("Skipping token balances test as per environment variable");
+          return;
+        }
+
         const balances = await testAccount.listTokenBalances({
           network: "base-sepolia",
         });
@@ -1102,6 +1112,11 @@ describe("CDP Client E2E Tests", () => {
 
     describe("list token balances", () => {
       it("should list token balances", async () => {
+        if (process.env.CDP_E2E_SKIP_EVM_TOKEN_BALANCES === "true") {
+          console.log("Skipping token balances test as per environment variable");
+          return;
+        }
+
         const balances = await testSmartAccount.listTokenBalances({
           network: "base-sepolia",
         });


### PR DESCRIPTION
<!--
Thanks for contributing to CDP SDK!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description
This makes it so that we can conditionally skip EVM token balances e2e tests behind the env var flag `CDP_E2E_SKIP_EVM_TOKEN_BALANCES`.

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
 -->

## Tests
This only impacts e2e tests
<!--
When adding new functionality or fixing a bug, you should be testing your changes with one or more
API method examples in the examples directory.

Please provide samples of the methods you tested with, the outputs for each method,
and any other relevant context, like which network was used.

Use the following format if helpful:

```
Method: <name of method used>
Network: <network used>
Setup: <any other relevant context>

Output:
<example output>
```

For example:

```
Method: createAccount
Network: Base Sepolia

Output:
EVM Account Address:  0xC2c7D554292Bb6AE502fafc3F5c0C46B534d6f31
```
 -->

## Checklist

A couple of things to include in your PR for completeness:

- [ ] Updated the [typescript README](https://github.com/coinbase/cdp-sdk/blob/main/typescript/src/README.md) if relevant
- [ ] Updated the [python README](https://github.com/coinbase/cdp-sdk/blob/main/python/README.md) if relevant
- [ ] Added a changelog entry
- [ ] Added e2e tests if introducing new functionality

<!--
For instructions on adding changelog entries:
See here for TypeScript: https://github.com/coinbase/cdp-sdk/blob/main/typescript/CONTRIBUTING.md#changelog
and here for Python: https://github.com/coinbase/cdp-sdk/blob/main/python/CONTRIBUTING.md#changelog
-->
