### PR TITLE
fix: throw user validation error when providing wrong smart account owner

### DIFF
--- a/examples/python/uv.lock
+++ b/examples/python/uv.lock
@@ -245,7 +245,7 @@ wheels = [
 
 [[package]]
 name = "cdp-sdk"
-version = "1.28.0"
+version = "1.30.0"
 source = { editable = "../../python" }
 dependencies = [
     { name = "aiohttp" },

--- a/python/changelog.d/411.bugfix.md
+++ b/python/changelog.d/411.bugfix.md
@@ -1,0 +1,1 @@
+Added check to validate smart account owner

--- a/typescript/.changeset/metal-cows-draw.md
+++ b/typescript/.changeset/metal-cows-draw.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/cdp-sdk": patch
+---
+
+Added check to validate smart account owner

--- a/typescript/src/client/evm/evm.ts
+++ b/typescript/src/client/evm/evm.ts
@@ -1484,6 +1484,16 @@ export class EvmClient implements EvmClientInterface {
       throw new UserInputValidationError("Either address or name must be provided");
     })();
 
+    if (!openApiSmartAccount.owners.includes(options.owner.address)) {
+      throw new UserInputValidationError(
+        `Owner mismatch: The provided owner address is not an owner of the smart account. Please use a valid owner for this smart account.
+
+Smart Account Address: ${openApiSmartAccount.address}
+Smart Account Owners: ${openApiSmartAccount.owners.join(", ")}
+Provided Owner Address: ${options.owner.address}\n`,
+      );
+    }
+
     const smartAccount = toEvmSmartAccount(CdpOpenApiClient, {
       smartAccount: openApiSmartAccount,
       owner: options.owner,


### PR DESCRIPTION
## Description

Added owner validation to smart account operations to prevent mismatches between provided owners and existing account owners. This change helps users avoid errors when trying to use a smart account with an incorrect owner.

The implementation:
1. Adds internal methods in Python SDK to handle account operations without tracking analytics
2. Implements owner validation in both Python and TypeScript SDKs
3. Provides clear error messages when owner validation fails, showing the account address, existing owners, and the provided owner address
4. Updates tests to verify the new validation behavior

## Tests

Added a new test case in both Python and TypeScript to verify that attempting to get a smart account with a mismatched owner raises a clear validation error:

```
Method: (TS SDK) getOrCreateSmartAccount with mismatched owner

Output:
UserInputValidationError: Owner mismatch: The provided owner address is not an owner of the smart account. Please use a valid owner for this smart account.

Smart Account Address: 0x1890a39379016623340e6fF8860F9e53cf95674f
Smart Account Owners: 0xe4ab88b6E97fD885adD9b1c407e9B12612C27773
Provided Owner Address: 0x10d2aD2199A26402FbBdb02A17b764F0aA454385

    at EvmClient._getSmartAccountInternal (/Users/ryan/code/public/cdp-sdk/typescript/src/client/evm/evm.ts:1488:13)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async EvmClient.getOrCreateSmartAccount (/Users/ryan/code/public/cdp-sdk/typescript/src/client/evm/evm.ts:582:23)
    at async <anonymous> (/Users/ryan/code/public/cdp-sdk/examples/typescript/evm/smart-accounts/getOrCreateSmartAccount.ts:16:17)

Node.js v22.14.0
```

```
Method: (Python SDK) get_or_create_smart_account with mismatched owner

Output:
cdp.errors.UserInputValidationError: Owner mismatch: The provided owner address is not an owner of the smart account. Please use a valid owner for this smart account.

Smart Account Address: 0x1890a39379016623340e6fF8860F9e53cf95674f
Smart Account Owners: 0xe4ab88b6E97fD885adD9b1c407e9B12612C27773
Provided Owner Address: 0x10d2aD2199A26402FbBdb02A17b764F0aA454385
```


## Checklist

A couple of things to include in your PR for completeness:

- [ ] Updated the [typescript README](https://github.com/coinbase/cdp-sdk/blob/main/typescript/src/README.md) if relevant
- [ ] Updated the [python README](https://github.com/coinbase/cdp-sdk/blob/main/python/README.md) if relevant
- [x] Added a changelog entry
- [ ] Added e2e tests if introducing new functionality