### PR TITLE
fix: remove approal in transfer method

### DIFF
--- a/examples/python/uv.lock
+++ b/examples/python/uv.lock
@@ -245,7 +245,7 @@ wheels = [
 
 [[package]]
 name = "cdp-sdk"
-version = "1.30.0"
+version = "1.31.0"
 source = { editable = "../../python" }
 dependencies = [
     { name = "aiohttp" },

--- a/python/cdp/actions/evm/transfer/account_transfer_strategy.py
+++ b/python/cdp/actions/evm/transfer/account_transfer_strategy.py
@@ -64,24 +64,6 @@ class AccountTransferStrategy(TransferExecutionStrategy):
         else:
             erc20_address = get_erc20_address(token, network)
 
-            approve_data = _encode_erc20_function_call(erc20_address, "approve", [to, value])
-
-            approve_tx = TransactionRequestEIP1559(
-                to=erc20_address,
-                data=approve_data,
-            )
-
-            typed_tx = DynamicFeeTransaction.from_dict(approve_tx.as_dict())
-            serialized_tx = serialize_unsigned_transaction(typed_tx)
-
-            await api_clients.evm_accounts.send_evm_transaction(
-                address=from_account.address,
-                send_evm_transaction_request=SendEvmTransactionRequest(
-                    transaction=serialized_tx,
-                    network=network,
-                ),
-            )
-
             transfer_data = _encode_erc20_function_call(erc20_address, "transfer", [to, value])
 
             transfer_tx = TransactionRequestEIP1559(

--- a/python/cdp/actions/evm/transfer/smart_account_transfer_strategy.py
+++ b/python/cdp/actions/evm/transfer/smart_account_transfer_strategy.py
@@ -59,9 +59,6 @@ class SmartAccountTransferStrategy(TransferExecutionStrategy):
             w3 = Web3()
             contract = w3.eth.contract(abi=ERC20_ABI)
 
-            # Create approve call
-            approve_data = contract.encode_abi("approve", args=[to, value])
-
             # Create transfer call
             transfer_data = contract.encode_abi("transfer", args=[to, value])
 
@@ -71,7 +68,6 @@ class SmartAccountTransferStrategy(TransferExecutionStrategy):
                 address=from_account.address,
                 owner=from_account.owners[0],
                 calls=[
-                    EncodedCall(to=erc20_address, data=approve_data),
                     EncodedCall(to=erc20_address, data=transfer_data),
                 ],
                 network=network,

--- a/python/cdp/test/test_account_transfer_strategy.py
+++ b/python/cdp/test/test_account_transfer_strategy.py
@@ -64,7 +64,6 @@ async def test_execute_transfer_erc20():
     mock_api_clients.evm_accounts = AsyncMock()
     mock_api_clients.evm_accounts.send_evm_transaction = AsyncMock(
         side_effect=[
-            SendEvmTransaction200Response(transaction_hash="0xapprove123"),
             SendEvmTransaction200Response(transaction_hash="0xtransfer456"),
         ]
     )
@@ -87,7 +86,7 @@ async def test_execute_transfer_erc20():
     )
 
     # Assert
-    assert mock_api_clients.evm_accounts.send_evm_transaction.call_count == 2
+    assert mock_api_clients.evm_accounts.send_evm_transaction.call_count == 1
 
     assert result == "0xtransfer456"
 

--- a/python/changelog.d/427.bugfix.md
+++ b/python/changelog.d/427.bugfix.md
@@ -1,0 +1,1 @@
+Removed approval in transfer method for Smart Accounts and EOAs

--- a/typescript/.changeset/green-years-bake.md
+++ b/typescript/.changeset/green-years-bake.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/cdp-sdk": patch
+---
+
+Removed approval in transfer method for Smart Accounts and EOAs

--- a/typescript/src/actions/evm/transfer/accountTransferStrategy.test.ts
+++ b/typescript/src/actions/evm/transfer/accountTransferStrategy.test.ts
@@ -98,13 +98,9 @@ describe("accountTransferStrategy", () => {
       const value = 100000n; // 0.1 USDC (6 decimals)
       const erc20Address = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
 
-      (mockApiClient.sendEvmTransaction as any)
-        .mockResolvedValueOnce({
-          transactionHash: "0xhash-approve",
-        })
-        .mockResolvedValueOnce({
-          transactionHash: "0xhash-transfer",
-        });
+      (mockApiClient.sendEvmTransaction as any).mockResolvedValueOnce({
+        transactionHash: "0xhash-transfer",
+      });
 
       const result = await accountTransferStrategy.executeTransfer({
         ...mockTransferArgs,
@@ -116,11 +112,6 @@ describe("accountTransferStrategy", () => {
       });
 
       expect(getErc20Address).toHaveBeenCalledWith("usdc", "base");
-      expect(encodeFunctionData).toHaveBeenCalledWith({
-        abi: erc20Abi,
-        functionName: "approve",
-        args: [toAddress, value],
-      });
       expect(serializeEIP1559Transaction).toHaveBeenCalledWith({
         to: erc20Address,
         data: "0xmockedEncodedData",
@@ -148,13 +139,9 @@ describe("accountTransferStrategy", () => {
       const value = 100000n;
       const customTokenAddress = "0x4200000000000000000000000000000000000006" as Hex;
 
-      (mockApiClient.sendEvmTransaction as any)
-        .mockResolvedValueOnce({
-          transactionHash: "0xhash-approve",
-        })
-        .mockResolvedValueOnce({
-          transactionHash: "0xhash-transfer",
-        });
+      (mockApiClient.sendEvmTransaction as any).mockResolvedValueOnce({
+        transactionHash: "0xhash-transfer",
+      });
 
       const result = await accountTransferStrategy.executeTransfer({
         ...mockTransferArgs,

--- a/typescript/src/actions/evm/transfer/accountTransferStrategy.ts
+++ b/typescript/src/actions/evm/transfer/accountTransferStrategy.ts
@@ -23,18 +23,6 @@ export const accountTransferStrategy: TransferExecutionStrategy<EvmAccount> = {
 
     const erc20Address = getErc20Address(token, network);
 
-    await apiClient.sendEvmTransaction(from.address, {
-      transaction: serializeEIP1559Transaction({
-        to: erc20Address,
-        data: encodeFunctionData({
-          abi: erc20Abi,
-          functionName: "approve",
-          args: [to, value],
-        }),
-      }),
-      network,
-    });
-
     return apiClient.sendEvmTransaction(from.address, {
       transaction: serializeEIP1559Transaction({
         to: erc20Address,

--- a/typescript/src/actions/evm/transfer/smartAccountTransferStrategy.test.ts
+++ b/typescript/src/actions/evm/transfer/smartAccountTransferStrategy.test.ts
@@ -126,12 +126,6 @@ describe("smartAccountTransferStrategy", () => {
 
       expect(encodeFunctionData).toHaveBeenCalledWith({
         abi: erc20Abi,
-        functionName: "approve",
-        args: [toAddress, value],
-      });
-
-      expect(encodeFunctionData).toHaveBeenCalledWith({
-        abi: erc20Abi,
         functionName: "transfer",
         args: [toAddress, value],
       });
@@ -140,10 +134,6 @@ describe("smartAccountTransferStrategy", () => {
         smartAccount: mockSmartAccount,
         network: "base",
         calls: [
-          {
-            to: erc20Address,
-            data: "0xmockedEncodedData",
-          },
           {
             to: erc20Address,
             data: "0xmockedEncodedData",

--- a/typescript/src/actions/evm/transfer/smartAccountTransferStrategy.ts
+++ b/typescript/src/actions/evm/transfer/smartAccountTransferStrategy.ts
@@ -37,14 +37,6 @@ export const smartAccountTransferStrategy: TransferExecutionStrategy<EvmSmartAcc
             to: erc20Address,
             data: encodeFunctionData({
               abi: erc20Abi,
-              functionName: "approve",
-              args: [to, value],
-            }),
-          },
-          {
-            to: erc20Address,
-            data: encodeFunctionData({
-              abi: erc20Abi,
               functionName: "transfer",
               args: [to, value],
             }),


### PR DESCRIPTION
## Description

Removed the ERC20 approval step from token transfers for both EOAs and Smart Accounts.

The change affects both TypeScript and Python implementations, removing the redundant approval calls from:
- Account transfer strategy
- Smart account transfer strategy

## Tests

Updated existing tests to reflect the removal of the approval step:
- Adjusted mock expectations to only expect a single transaction call
- Verified that transfer functionality continues to work correctly
- Updated assertions to check for a single transaction instead of two

Tested locally by running all transfer example scripts to completion.

## Checklist

- [x] Added a changelog entry
