### PR TITLE
chore: add triage-issues slash command

### DIFF
--- a/.claude/commands/triage-issues.md
+++ b/.claude/commands/triage-issues.md
@@ -1,11 +1,11 @@
 ---
-description: Triage open GitHub issues - analyze priority, type, and recommend labels
+description: Triage open GitHub issues and PRs - analyze priority, type, and recommend labels
 allowed-tools: Bash(gh:*), Bash(curl:*), Read, Grep, Glob
 ---
 
-# Triage GitHub Issues
+# Triage GitHub Issues and Pull Requests
 
-Triage open GitHub issues for the CDP SDK repository. Analyze each issue and recommend appropriate labels, priority, and next actions.
+Triage open GitHub issues and pull requests for the CDP SDK repository. Analyze each item and recommend appropriate labels, priority, and next actions.
 
 ## Prerequisites
 
@@ -50,17 +50,49 @@ If a `--token` argument is provided, extract it from $ARGUMENTS and set it for s
 ## Arguments
 
 $ARGUMENTS supports:
-- Optional filter: `bug`, `docs`, `security`, `all`, or a specific issue number. Defaults to `all`.
+- Optional filter: `bug`, `docs`, `security`, `prs`, `all`, or a specific issue/PR number. Defaults to `all`.
 - Optional GitHub token: `--token <github_token>` to authenticate without environment variable.
 - Optional Linear token: `--linear-token <linear_api_key>` to enable Linear ticket creation.
 
-## Step 1: Fetch Issues
+## Step 1: Fetch Issues and PRs
+
+### Fetching Issues
 
 First, fetch the open issues based on the filter:
 
 - If $ARGUMENTS is a number, fetch that specific issue: `gh issue view <number> --json number,title,body,labels,createdAt,author,comments`
 - If $ARGUMENTS is `bug`, `docs`, or `security`, search with that term
-- Otherwise, fetch all open issues: `gh issue list --state open --limit 30 --json number,title,body,labels,createdAt,author`
+- If $ARGUMENTS is `prs`, skip issue fetching and only fetch PRs
+- Otherwise, fetch all open issues: `gh issue list --state open --limit 100 --json number,title,body,labels,createdAt,author`
+
+### Fetching Pull Requests
+
+After fetching issues (unless filter is a specific issue number), also fetch open PRs from external contributors:
+
+```bash
+gh pr list --state open --limit 100 --json number,title,author,createdAt,labels,isDraft
+```
+
+For each PR, check the author association to determine if it's from an external contributor:
+
+```bash
+gh api repos/coinbase/cdp-sdk/pulls/<number> --jq '{number, title, author: .user.login, authorAssociation: .author_association}'
+```
+
+**Filter out internal PRs** - Skip PRs where `author_association` is:
+- `MEMBER` - GitHub org member (Coinbase employee)
+- `COLLABORATOR` - Has direct push access (likely internal)
+- `OWNER` - Repository owner
+
+**Include external PRs** - Triage PRs where `author_association` is:
+- `CONTRIBUTOR` - External contributor with prior merged PRs
+- `FIRST_TIME_CONTRIBUTOR` - External contributor's first PR
+- `FIRST_TIMER` - First-ever GitHub contribution
+- `NONE` - No prior association
+
+Also skip:
+- Draft PRs (`isDraft: true`) - not ready for review
+- PRs from bot accounts (`author.is_bot: true`)
 
 ## Step 2: Analyze Each Issue
 
@@ -131,20 +163,91 @@ Label as: `typescript`, `python`, `go`, `rust`, or multiple if cross-cutting
 
 **Important**: Most bug reports should start as `needs-info` unless they explicitly include environment details and reproduction steps. Feature requests and documentation issues have lighter requirements but should still specify which SDK language/version they relate to.
 
+## Step 2b: Analyze Each External PR
+
+For each external PR (non-internal contributor), determine:
+
+### 2b.1 PR Type
+- **bug-fix**: Fixes a reported bug or issue
+- **feature**: Adds new functionality
+- **documentation**: Updates docs, README, comments
+- **chore**: Maintenance, dependency updates, CI changes
+- **refactor**: Code improvements without behavior change
+
+### 2b.2 Affected SDK Language
+Same as issues - determine from file paths in the PR:
+- Files in `typescript/` → `typescript`
+- Files in `python/` → `python`
+- Files in `go/` → `go`
+- Files in `rust/` → `rust`
+
+### 2b.3 PR Quality Assessment
+
+**ready-for-review** - PR is ready for team review if ALL:
+- Has clear description of changes
+- Includes tests (if applicable)
+- Passes CI checks (if visible)
+- Linked to an issue (if fixing a bug)
+
+**needs-work** - PR needs attention from author:
+- Missing description or context
+- No tests for new functionality
+- Failing CI checks
+- Breaking changes without documentation
+
+**needs-discussion** - PR requires architectural discussion:
+- Large refactoring
+- New dependencies
+- API changes
+- Security-sensitive changes
+
+**spam/invalid** - PR should be closed:
+- Nonsensical title or description (e.g., unrelated text, gibberish)
+- Empty or placeholder content
+- No meaningful code changes
+- Suspicious patterns (e.g., "fix my account", random words)
+
+**superseded** - PR is duplicated by another:
+- Another PR contains the same fix plus more
+- Check file overlap between PRs with similar purposes
+
+### 2b.4 Linked Issues
+
+Check if the PR references any issues:
+- Look for "Fixes #123", "Closes #123", "Resolves #123" in PR body
+- Note linked issues in the triage report
+- If PR fixes a triaged issue, update the issue status
+
 ## Step 3: Generate Triage Report
 
-Present findings in a markdown table:
+Present findings in separate tables for issues and PRs.
 
-| Issue | Type | Language | Priority | Complexity | Suggested Labels | Notes |
-|-------|------|----------|----------|------------|------------------|-------|
-| #123 Title | bug | typescript | high | small | `bug`, `typescript`, `high` | Clear repro steps |
+### Issues Table
+
+| Issue | Type | Language | Priority | Complexity | Suggested Labels | Status |
+|-------|------|----------|----------|------------|------------------|--------|
+| #123 Title | bug | typescript | high | small | `bug`, `typescript`, `high` | ready |
+
+### External PRs Table
+
+| PR | Type | Language | Author | Status | Linked Issues | Notes |
+|----|------|----------|--------|--------|---------------|-------|
+| #456 Title | bug-fix | typescript | @contributor | ready-for-review | Fixes #123 | Clean fix with tests |
+
+Note: Internal PRs (from MEMBER/COLLABORATOR authors) are excluded from this report.
 
 ## Step 4: Provide Recommendations
 
-For each issue, provide:
+### For Issues
 1. **Suggested labels** to apply
 2. **Next action**: needs-info response, ready for dev, close as invalid, etc.
 3. **Draft response** if the issue needs-info or should be closed
+
+### For External PRs
+1. **Review priority**: Should this be reviewed soon, or can it wait?
+2. **Suggested reviewers**: Based on affected SDK language
+3. **Concerns**: Any red flags (security, breaking changes, missing tests)
+4. **Next action**: Request changes, approve, request more info from author
 
 ## Step 5: Apply Labels (Optional)
 
@@ -173,9 +276,31 @@ gh issue close <number> --reason "not planned" --comment "Closing as invalid/spa
 - Issues older than 90 days with no activity may need a ping or closure
 - Check if the issue still applies to the current SDK version
 
+### Stale PRs
+- PRs older than 90 days may need attention:
+  - Check if still relevant to current codebase
+  - May need rebase due to conflicts
+  - Author may have abandoned it
+- Options: ping author, close as stale, or adopt if valuable
+
+### Spam PRs
+- Close PRs with nonsensical descriptions or titles
+- Use: `gh pr close <number> --comment "Closing - this PR appears to be spam."`
+- Common indicators: unrelated text in body, random words in title, no meaningful changes
+
+### Superseded PRs
+- When multiple PRs fix the same issue, keep the more comprehensive one
+- Close the narrower PR with a comment linking to the better one
+- Use: `gh pr close <number> --comment "Closing - this fix is included in #XXX which addresses the same issue."`
+
+### PRs That Fix Triaged Issues
+- When a PR fixes a triaged issue (e.g., "Fixes #345"), note this relationship
+- If the PR is merged, the linked issue will auto-close
+- Consider prioritizing review of PRs that fix high-priority issues
+
 ## Step 6: Create Linear Tickets (Optional)
 
-For issues with status **ready**, offer to create Linear tickets. This step is optional and requires Linear API authentication.
+For issues with status **ready** and PRs with status **ready-for-review**, offer to create Linear tickets to track the work. This step is optional and requires Linear API authentication.
 
 ### Linear Authentication
 
@@ -214,7 +339,7 @@ Map GitHub priority labels to Linear priority values:
 | `low` | 4 (Low) |
 | (none) | 0 (No priority) |
 
-### Creating Tickets
+### Creating Tickets for Issues
 
 For each **ready** issue, prompt the user: "Create Linear ticket for #[number] [title]?"
 
@@ -238,6 +363,18 @@ curl -X POST https://api.linear.app/graphql \
   }'
 ```
 
+### Creating Tickets for PR Reviews
+
+For each **ready-for-review** external PR, prompt the user: "Create Linear ticket to track review of PR #[number]?"
+
+If confirmed, create the ticket with:
+- **Title**: `[PR Review] #<number> <PR title>`
+- **Description**: Summary of changes, linked issues, author, and review notes
+- **Priority**: Based on linked issues (if PR fixes a high-priority issue, inherit that priority)
+- **Link**: `https://github.com/coinbase/cdp-sdk/pull/<number>`
+
+### After Ticket Creation
+
 After successful creation, display the Linear ticket URL (e.g., `https://linear.app/coinbase/issue/CDPSDK-1234`).
 
-**Important**: Do NOT update the GitHub issue with the Linear link. The Linear ticket should contain the link back to GitHub, but not vice versa.
+**Important**: Do NOT update the GitHub issue/PR with the Linear link. The Linear ticket should contain the link back to GitHub, but not vice versa.


### PR DESCRIPTION
<!--
Thanks for contributing to CDP SDK!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
 -->

Adds a slash command (`/triage-issues`) for Claude to help with triaging open issues.

Usage:
In Claude Code, run `/triage-issues`