### PR TITLE
fix: handle newlines in ec keys

### DIFF
--- a/python/cdp/auth/test/test_jwt.py
+++ b/python/cdp/auth/test/test_jwt.py
@@ -101,6 +101,23 @@ def test_parse_private_key_ed25519(ed25519_private_key_factory):
     assert isinstance(key, ed25519.Ed25519PrivateKey)
 
 
+def test_parse_private_key_ec_with_literal_newlines(ec_private_key_factory):
+    r"""Test parsing an EC private key with literal \n sequences.
+
+    This handles the case where a PEM key is provided in an env file without quotes,
+    causing the newline escape sequences to remain as literal characters.
+    """
+    # Setup - convert actual newlines to literal \n sequences
+    key_data = ec_private_key_factory()
+    key_with_literal_newlines = key_data.replace("\n", "\\n")
+
+    # Execute
+    key = _parse_private_key(key_with_literal_newlines)
+
+    # Verify
+    assert isinstance(key, ec.EllipticCurvePrivateKey)
+
+
 def test_parse_private_key_invalid():
     """Test parsing an invalid private key."""
     # Execute & Verify

--- a/python/cdp/auth/utils/jwt.py
+++ b/python/cdp/auth/utils/jwt.py
@@ -274,6 +274,11 @@ def _parse_private_key(
         ValueError: If the key cannot be parsed or is of an unsupported type
 
     """
+    # Handle literal \n sequences (common when env vars are unquoted)
+    # If the key contains literal '\n' strings, replace them with actual newlines
+    if "\\n" in key_data:
+        key_data = key_data.replace("\\n", "\n")
+
     # First try parsing as PEM (EC key)
     try:
         key = serialization.load_pem_private_key(key_data.encode(), password=None)

--- a/python/changelog.d/546.bugfix.md
+++ b/python/changelog.d/546.bugfix.md
@@ -1,0 +1,1 @@
+Improved handling of ECDSA-formatted API keys.


### PR DESCRIPTION
<!--
Thanks for contributing to CDP SDK!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

Closes #422 

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
 -->

Gracefully handles un-quoted user-provided EC key, like:
```
export CDP_API_KEY_SECRET=-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEILFJCXH...q5Q==\n-----END EC PRIVATE KEY-----\n
```

## Tests

Tested with basic examples for each language. Tested both ECDSA and Ed25519 keys work as expected.

<!--
When adding new functionality or fixing a bug, you should be testing your changes with one or more
API method examples in the examples directory.

Please provide samples of the methods you tested with, the outputs for each method,
and any other relevant context, like which network was used.

Use the following format if helpful:

```
Method: <name of method used>
Network: <network used>
Setup: <any other relevant context>

Output:
<example output>
```

For example:

```
Method: createAccount
Network: Base Sepolia

Output:
EVM Account Address:  0xC2c7D554292Bb6AE502fafc3F5c0C46B534d6f31
```
 -->

## Checklist

A couple of things to include in your PR for completeness:

- [ ] Updated the [typescript README](https://github.com/coinbase/cdp-sdk/blob/main/typescript/src/README.md) if relevant
- [ ] Updated the [python README](https://github.com/coinbase/cdp-sdk/blob/main/python/README.md) if relevant
- [x] Added a changelog entry
- [ ] Added e2e tests if introducing new functionality

<!--
For instructions on adding changelog entries:
See here for TypeScript: https://github.com/coinbase/cdp-sdk/blob/main/typescript/CONTRIBUTING.md#changelog
and here for Python: https://github.com/coinbase/cdp-sdk/blob/main/python/CONTRIBUTING.md#changelog
-->
