### PR TITLE
Update minimum Rust version in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ make local-docs
 
 #### Prerequisites
 
-- Rust 1.70 or higher
+- Rust 1.86.0 or higher
 - Cargo
 - Make
 


### PR DESCRIPTION
## Description

Updated the minimum Rust version in `CONTRIBUTING.md` to `1.86.0` to align with `rust-toolchain.toml`.

Checked on [Rust website](https://rust-lang.org/), the latest stable version is `1.93.1`, so the specified minimum version is valid and the project builds correctly on the current stable Rust.  
Reference to the fixed version file: [rust-toolchain](https://github.com/hst0mp0x/cdp-sdk/blob/main/rust-toolchain.toml)
