### PR TITLE
Fix Python Solana transfer examples: imports, f-strings, and network …

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -751,6 +751,7 @@ You can transfer tokens between accounts using the `transfer` function, and wait
 import asyncio
 from cdp import CdpClient
 from solana.rpc.api import Client as SolanaClient
+from solana.rpc.types import LAMPORTS_PER_SOL
 
 async def main():
     async with CdpClient() as cdp:
@@ -769,17 +770,17 @@ async def main():
 
         confirmation = await connection.confirm_transaction(
             {
-                signature,
-                blockhash,
-                lastValidBlockHeight,
+                "signature": signature,
+                "blockhash": blockhash,
+                "lastValidBlockHeight": lastValidBlockHeight,
             },
         )
 
         if confirmation.value.err:
-            print(f"Something went wrong! Error: {confirmation.value.err.toString()}")
+            print(f"Something went wrong! Error: {confirmation.value.err}")
         else:
             print(
-                f"Transaction confirmed: Link: https://explorer.solana.com/tx/${signature}?cluster=devnet",
+                f"Transaction confirmed: Link: https://explorer.solana.com/tx/{signature}?cluster=devnet",
             )
 ```
 
@@ -795,7 +796,7 @@ tx_hash = await sender.transfer(
     to="0x9F663335Cd6Ad02a37B633602E98866CF944124d",
     amount=amount,
     token="usdc",
-    network="devet",
+    network="devnet",
 )
 ```
 


### PR DESCRIPTION
## Description

This PR fixes several issues in the Python Solana transfer examples to make them self-contained and functional:

**Added missing import:**

`LAMPORTS_PER_SOL` is now imported from `solana.rpc.types` to correctly compute SOL amounts.

**Fixed transaction confirmation printing:**

Removed JavaScript-style `.toString()` from `confirmation.value.err`.

Fixed f-string in explorer URL: replaced `https://explorer.solana.com/tx/${signature}?cluster=devnet` with the correct Python f-string `https://explorer.solana.com/tx/{signature}?cluster=devnet`.

**Corrected network specification:**

The USDC transfer example currently specifies `“network=devet”`, which is a typo. I have corrected it to `“network=devnet”`

**Fixed `confirm_transaction` argument formatting:**

Replaced the JS-style positional dict with a proper Python dictionary:
```python
{
    "signature": signature,
    "blockhash": blockhash,
    "lastValidBlockHeight": lastValidBlockHeight,
}
```
This ensures Python interprets the transaction confirmation parameters correctly, avoiding any runtime errors.

## Checklist

A couple of things to include in your PR for completeness:

- [ ] Updated the [typescript README](https://github.com/coinbase/cdp-sdk/blob/main/typescript/src/README.md) if relevant
- [ ] Updated the [python README](https://github.com/coinbase/cdp-sdk/blob/main/python/README.md) if relevant
- [ ] Added a changelog entry
- [ ] Added e2e tests if introducing new functionality

<!--
For instructions on adding changelog entries:
See here for TypeScript: https://github.com/coinbase/cdp-sdk/blob/main/typescript/CONTRIBUTING.md#changelog
and here for Python: https://github.com/coinbase/cdp-sdk/blob/main/python/CONTRIBUTING.md#changelog
-->
