### PR TITLE
chore: bump @coinbase/cdp-sdk to 1.46.0

### DIFF
--- a/typescript/.changeset/fair-paths-smile.md
+++ b/typescript/.changeset/fair-paths-smile.md
@@ -1,5 +1,0 @@
----
-"@coinbase/cdp-sdk": minor
----
-
-Add revokeDelegation, and delegated signing operations to end user client

--- a/typescript/.changeset/real-teeth-hunt.md
+++ b/typescript/.changeset/real-teeth-hunt.md
@@ -1,5 +1,0 @@
----
-"@coinbase/cdp-sdk": patch
----
-
-Removed @solana/web3.js dependency to avoid transitive LGPL license

--- a/typescript/.changeset/security-dependency-updates.md
+++ b/typescript/.changeset/security-dependency-updates.md
@@ -1,5 +1,0 @@
----
-"@coinbase/cdp-sdk": patch
----
-
-Patched security vulnerabilities across several dependencies.

--- a/typescript/.changeset/soft-goats-kiss.md
+++ b/typescript/.changeset/soft-goats-kiss.md
@@ -1,5 +1,0 @@
----
-"@coinbase/cdp-sdk": patch
----
-
-Added EIP-6492 signature wrapping for undeployed smart accounts

--- a/typescript/src/CHANGELOG.md
+++ b/typescript/src/CHANGELOG.md
@@ -1,5 +1,19 @@
 # CDP SDK Changelog
 
+## 1.46.0
+
+### Minor Changes
+
+- [#624](https://github.com/coinbase/cdp-sdk/pull/624) [`0c0c1c8`](https://github.com/coinbase/cdp-sdk/commit/0c0c1c8d4202dc24bd07b926de2d81144fba8599) Thanks [@sammccord](https://github.com/sammccord)! - Add revokeDelegation, and delegated signing operations to end user client
+
+### Patch Changes
+
+- [#627](https://github.com/coinbase/cdp-sdk/pull/627) [`4a10b49`](https://github.com/coinbase/cdp-sdk/commit/4a10b4940c825a77e7af2378e1cb9f8e6d4db956) Thanks [@0xRAG](https://github.com/0xRAG)! - Removed @solana/web3.js dependency to avoid transitive LGPL license
+
+- [#622](https://github.com/coinbase/cdp-sdk/pull/622) [`03d0b68`](https://github.com/coinbase/cdp-sdk/commit/03d0b680b0a5d3758a9092a8cf9abaeb2ae4790a) Thanks [@0xRAG](https://github.com/0xRAG)! - Patched security vulnerabilities across several dependencies.
+
+- [#623](https://github.com/coinbase/cdp-sdk/pull/623) [`ec2866f`](https://github.com/coinbase/cdp-sdk/commit/ec2866ff0423130a3a6ed948ab7e3c741e376b90) Thanks [@milan-cb](https://github.com/milan-cb)! - Added EIP-6492 signature wrapping for undeployed smart accounts
+
 ## 1.45.0
 
 ### Minor Changes
@@ -428,7 +442,6 @@
 - [#122](https://github.com/coinbase/cdp-sdk/pull/122) [`ee41d98`](https://github.com/coinbase/cdp-sdk/commit/ee41d986406e3e8666d1d1a1b1525e7ff7435a2b) Thanks [@sddioulde](https://github.com/sddioulde)! - Added account actions to Solana
 
 - [#103](https://github.com/coinbase/cdp-sdk/pull/103) [`2777cde`](https://github.com/coinbase/cdp-sdk/commit/2777cde93e4f10579a4ca31e140720067799cf66) Thanks [@0xRAG](https://github.com/0xRAG)! - Added additional options to transfer methods:
-
   - Added `paymasterUrl` and `waitOptions` to EvmSmartAccount.transfer
   - Added `waitOptions` to EvmAccount.transfer
 
@@ -437,7 +450,6 @@
 ### Minor Changes
 
 - [#99](https://github.com/coinbase/cdp-sdk/pull/99) [`0fd6d2b`](https://github.com/coinbase/cdp-sdk/commit/0fd6d2ba56b2da52c96eb19278dc782560b7680b) Thanks [@0xRAG](https://github.com/0xRAG)! - Added actions to EvmAccount and EvmSmartAccount:
-
   - listTokenBalances
   - requestFaucet
   - sendTransaction (EvmAccount only)

--- a/typescript/src/package.json
+++ b/typescript/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cdp-sdk",
-  "version": "1.45.0",
+  "version": "1.46.0",
   "description": "SDK for interacting with the Coinbase Developer Platform Wallet API",
   "type": "module",
   "main": "./_cjs/index.js",

--- a/typescript/src/version.ts
+++ b/typescript/src/version.ts
@@ -1,1 +1,1 @@
-export const version = "1.45.0";
+export const version = "1.46.0";


### PR DESCRIPTION
## Summary

- Bumps `@coinbase/cdp-sdk` from `1.45.0` to `1.46.0` (minor)
- Consumes 4 pending changesets:
  - **minor**: Add `revokeDelegation` and delegated signing operations to end user client
  - **patch**: Removed `@solana/web3.js` dependency to avoid transitive LGPL license
  - **patch**: Patched security vulnerabilities across several dependencies
  - **patch**: Added EIP-6492 signature wrapping for undeployed smart accounts
- Updates `src/package.json`, `src/version.ts`, and `src/CHANGELOG.md`