### PR TITLE
Relax version constraint for web3 package

### DIFF
--- a/python/changelog.d/642.bugfix.md
+++ b/python/changelog.d/642.bugfix.md
@@ -1,0 +1,1 @@
+Relax version constraint for the web3 package to allow upgrades to newer versions that include security fixes.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "urllib3>=2.2.3",
     "aiohttp>=3.11.16",
     "aiohttp-retry>=2.9.1",
-    "web3>=7.6.0,<=7.10.0",
+    "web3>=7.6.0,<8",
     "solana>=0.36.6",
     "solders>=0.26.0",
     "nest-asyncio>=1.6.0,<2",

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -363,7 +363,7 @@ requires-dist = [
     { name = "sphinxcontrib-napoleon", marker = "extra == 'dev'", specifier = ">=0.7" },
     { name = "towncrier", marker = "extra == 'dev'", specifier = ">=24.8.0,<25" },
     { name = "urllib3", specifier = ">=2.2.3" },
-    { name = "web3", specifier = ">=7.6.0,<=7.10.0" },
+    { name = "web3", specifier = ">=7.6.0,<8" },
 ]
 provides-extras = ["dev"]
 


### PR DESCRIPTION
## Description

The version constraint for the web3 package is too restrictive, preventing upgrades to newer versions that include security fixes. This change relaxes the version constraint for the web3 package, similar to what was requested in issue #560.

## Checklist

A couple of things to include in your PR for completeness:

- [ ] Updated the [typescript README](https://github.com/coinbase/cdp-sdk/blob/main/typescript/src/README.md) if relevant
- [ ] Updated the [python README](https://github.com/coinbase/cdp-sdk/blob/main/python/README.md) if relevant
- [x] Added a changelog entry
- [ ] Added e2e tests if introducing new functionality
