### PR TITLE
fix: Remove nest_asyncio dependency

### DIFF
--- a/examples/python/uv.lock
+++ b/examples/python/uv.lock
@@ -286,14 +286,13 @@ wheels = [
 
 [[package]]
 name = "cdp-sdk"
-version = "1.40.0"
+version = "1.41.0"
 source = { editable = "../../python" }
 dependencies = [
     { name = "aiohttp" },
     { name = "aiohttp-retry" },
     { name = "base58" },
     { name = "cryptography" },
-    { name = "nest-asyncio" },
     { name = "pydantic" },
     { name = "pyjwt" },
     { name = "python-dateutil" },
@@ -310,7 +309,6 @@ requires-dist = [
     { name = "base58", specifier = ">=2.1.1" },
     { name = "cryptography", specifier = ">=42.0.0" },
     { name = "myst-parser", marker = "extra == 'dev'", specifier = ">=4.0.1" },
-    { name = "nest-asyncio", specifier = ">=1.6.0,<2" },
     { name = "pydantic", specifier = ">=2.10.3" },
     { name = "pyjwt", specifier = ">=2.10.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
@@ -1106,15 +1104,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b9/3b/1599631f59024b75c4d6e3069f4502409970a336647502aaf6b62fb7ac98/multidict-6.4.3-cp313-cp313t-win32.whl", hash = "sha256:0ecdc12ea44bab2807d6b4a7e5eef25109ab1c82a8240d86d3c1fc9f3b72efd5", size = 41775, upload-time = "2025-04-10T22:19:43.707Z" },
     { url = "https://files.pythonhosted.org/packages/e8/4e/09301668d675d02ca8e8e1a3e6be046619e30403f5ada2ed5b080ae28d02/multidict-6.4.3-cp313-cp313t-win_amd64.whl", hash = "sha256:7146a8742ea71b5d7d955bffcef58a9e6e04efba704b52a460134fefd10a8208", size = 45946, upload-time = "2025-04-10T22:19:45.071Z" },
     { url = "https://files.pythonhosted.org/packages/96/10/7d526c8974f017f1e7ca584c71ee62a638e9334d8d33f27d7cdfc9ae79e4/multidict-6.4.3-py3-none-any.whl", hash = "sha256:59fe01ee8e2a1e8ceb3f6dbb216b09c8d9f4ef1c22c4fc825d045a147fa2ebc9", size = 10400, upload-time = "2025-04-10T22:20:16.445Z" },
-]
-
-[[package]]
-name = "nest-asyncio"
-version = "1.6.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
 ]
 
 [[package]]

--- a/python/cdp/analytics.py
+++ b/python/cdp/analytics.py
@@ -30,7 +30,9 @@ class ActionEventData(BaseModel):
     """The data in an action event."""
 
     action: str  # The operation being performed, e.g. "transfer", "swap", "fund", "requestFaucet"
-    account_type: Literal["evm_server", "evm_smart", "solana"] | None = None  # The account type
+    account_type: Literal["evm_server", "evm_smart", "evm_local", "solana"] | None = (
+        None  # The account type
+    )
     properties: dict[str, Any] | None = None  # Additional properties specific to the action
     name: Literal["action"]  # The name of the event
 
@@ -44,7 +46,7 @@ Analytics = {
 
 def track_action(
     action: str,
-    account_type: Literal["evm_server", "evm_smart", "solana"] | None = None,
+    account_type: Literal["evm_server", "evm_smart", "evm_local", "solana"] | None = None,
     properties: dict[str, Any] | None = None,
 ) -> None:
     """Track an action being performed.

--- a/python/cdp/evm_local_account.py
+++ b/python/cdp/evm_local_account.py
@@ -1,45 +1,142 @@
-import asyncio
+import json
 from typing import Any
 
-import nest_asyncio
 from eth_account.datastructures import SignedMessage, SignedTransaction
 from eth_account.messages import SignableMessage, _hash_eip191_message, encode_typed_data
 from eth_account.signers.base import BaseAccount
+from eth_account.typed_transactions import TypedTransaction
 from eth_account.types import TransactionDictType
 from eth_typing import Hash32
+from hexbytes import HexBytes
+from web3 import Web3
 
+from cdp.analytics import track_action, track_error
+from cdp.auth.clients.urllib3 import Urllib3AuthClient, Urllib3AuthClientOptions
 from cdp.errors import UserInputValidationError
 from cdp.evm_server_account import EvmServerAccount
-
-# Apply nest-asyncio to allow nested event loops, but only if compatible
-try:
-    nest_asyncio.apply()
-except ValueError as e:
-    # If nest_asyncio can't patch the loop (e.g., uvloop), silently continue
-    # This commonly happens when uvloop is installed and running
-    if "Can't patch loop" in str(e):
-        pass
-    else:
-        # Re-raise other ValueError exceptions
-        raise
+from cdp.openapi_client.constants import ERROR_DOCS_PAGE_URL
+from cdp.openapi_client.errors import ApiError, HttpErrorType, is_openapi_error
 
 
-def _run_async(coroutine):
-    """Run an async coroutine synchronously.
+class _EvmServerAccountSync:
+    """Sync signing client used only by EvmLocalAccount.
 
-    Args:
-        coroutine: The coroutine to run
-
-    Returns:
-        Any: The result of the coroutine
-
+    Makes synchronous HTTP calls to the CDP signing endpoints via urllib3,
+    bypassing the async openapi_client entirely.
     """
-    try:
-        loop = asyncio.get_event_loop()
-    except RuntimeError:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-    return loop.run_until_complete(coroutine)
+
+    def __init__(self, address: str, http_client: Urllib3AuthClient) -> None:
+        self._address = address
+        self._http = http_client
+
+    def _request(self, path: str, body: dict) -> dict:
+        response = self._http.request("POST", path, body=body)
+        data = json.loads(response.data)
+        if response.status < 200 or response.status >= 300:
+            if is_openapi_error(data):
+                raise ApiError(
+                    http_code=response.status,
+                    error_type=data["errorType"],
+                    error_message=data["errorMessage"],
+                    correlation_id=data.get("correlationId"),
+                    error_link=data.get(
+                        "errorLink",
+                        f"{ERROR_DOCS_PAGE_URL}#{data['errorType'].lower()}",
+                    ),
+                )
+            raise ApiError(
+                http_code=response.status,
+                error_type=HttpErrorType.UNEXPECTED_ERROR,
+                error_message=f"An unexpected error occurred: {data}",
+                error_link=ERROR_DOCS_PAGE_URL,
+            )
+        return data
+
+    def unsafe_sign_hash(self, message_hash: Hash32) -> SignedMessage:
+        """Sign a message hash synchronously."""
+        track_action(action="sign", account_type="evm_local")
+        try:
+            hash_hex = HexBytes(message_hash).hex()
+            data = self._request(
+                f"v2/evm/accounts/{self._address}/sign",
+                {"hash": hash_hex},
+            )
+            signature_bytes = HexBytes(data["signature"])
+            r = int.from_bytes(signature_bytes[0:32], byteorder="big")
+            s = int.from_bytes(signature_bytes[32:64], byteorder="big")
+            v = signature_bytes[64]
+            return SignedMessage(
+                message_hash=message_hash,
+                r=r,
+                s=s,
+                v=v,
+                signature=signature_bytes,
+            )
+        except Exception as error:
+            track_error(error, "unsafe_sign_hash")
+            raise
+
+    def sign_message(self, signable_message: SignableMessage) -> SignedMessage:
+        """Sign an EIP-191 message synchronously."""
+        track_action(action="sign_message", account_type="evm_local")
+        try:
+            message_body = signable_message.body
+            message_hex = (
+                message_body.hex()
+                if isinstance(message_body, bytes)
+                else HexBytes(message_body).hex()
+            )
+            data = self._request(
+                f"v2/evm/accounts/{self._address}/sign/message",
+                {"message": message_hex},
+            )
+            message_hash = _hash_eip191_message(signable_message)
+            signature_bytes = HexBytes(data["signature"])
+            r = int.from_bytes(signature_bytes[0:32], byteorder="big")
+            s = int.from_bytes(signature_bytes[32:64], byteorder="big")
+            v = signature_bytes[64]
+            return SignedMessage(
+                message_hash=message_hash,
+                r=r,
+                s=s,
+                v=v,
+                signature=signature_bytes,
+            )
+        except Exception as error:
+            track_error(error, "sign_message")
+            raise
+
+    def sign_transaction(self, transaction_dict: TransactionDictType) -> SignedTransaction:
+        """Sign a transaction dict synchronously."""
+        track_action(action="sign_transaction", account_type="evm_local")
+        try:
+            typed_tx = TypedTransaction.from_dict(transaction_dict)
+            typed_tx.transaction.dictionary["v"] = 0
+            typed_tx.transaction.dictionary["r"] = 0
+            typed_tx.transaction.dictionary["s"] = 0
+            payload = typed_tx.transaction.payload()
+            serialized_tx = bytes([typed_tx.transaction_type]) + payload
+
+            data = self._request(
+                f"v2/evm/accounts/{self._address}/sign/transaction",
+                {"transaction": "0x" + serialized_tx.hex()},
+            )
+            signed_tx_bytes = HexBytes(data["signedTransaction"])
+            transaction_hash = Web3.keccak(signed_tx_bytes)
+            signature_bytes = signed_tx_bytes
+            r = int.from_bytes(signature_bytes[0:32], byteorder="big")
+            s = int.from_bytes(signature_bytes[32:64], byteorder="big")
+            v = signature_bytes[64]
+            return SignedTransaction(
+                raw_transaction=signed_tx_bytes,
+                hash=transaction_hash,
+                r=r,
+                s=s,
+                v=v,
+            )
+        except Exception as error:
+            track_error(error, "sign_transaction")
+            raise
 
 
 class EvmLocalAccount(BaseAccount):
@@ -60,7 +157,19 @@ class EvmLocalAccount(BaseAccount):
             server_account (EvmServerAccount): The EVM server account to sign transactions and messages for.
 
         """
-        self._server_account = server_account
+        cdp_client = server_account.api_clients._cdp_client
+        http_client = Urllib3AuthClient(
+            options=Urllib3AuthClientOptions(
+                api_key_id=cdp_client.api_key_id,
+                api_key_secret=cdp_client.api_key_secret,
+                wallet_secret=cdp_client.wallet_secret,
+                source=cdp_client.source,
+                source_version=cdp_client.source_version,
+            ),
+            base_url=cdp_client.configuration.host,
+        )
+        self._address = server_account.address
+        self._sync_account = _EvmServerAccountSync(self._address, http_client)
 
     @property
     def address(self) -> str:
@@ -70,7 +179,7 @@ class EvmLocalAccount(BaseAccount):
             str: The address of the EVM server account.
 
         """
-        return self._server_account.address
+        return self._address
 
     def unsafe_sign_hash(self, message_hash: Hash32) -> SignedMessage:
         """Sign a message hash.
@@ -85,7 +194,7 @@ class EvmLocalAccount(BaseAccount):
             SignedMessage: The signed message.
 
         """
-        return _run_async(self._server_account.unsafe_sign_hash(message_hash))
+        return self._sync_account.unsafe_sign_hash(message_hash)
 
     def sign_message(self, signable_message: SignableMessage) -> SignedMessage:
         """Sign a message.
@@ -97,7 +206,7 @@ class EvmLocalAccount(BaseAccount):
             SignedMessage: The signed message.
 
         """
-        return _run_async(self._server_account.sign_message(signable_message))
+        return self._sync_account.sign_message(signable_message)
 
     def sign_transaction(self, transaction_dict: TransactionDictType) -> SignedTransaction:
         """Sign a transaction.
@@ -109,7 +218,7 @@ class EvmLocalAccount(BaseAccount):
             SignedTransaction: The signed transaction.
 
         """
-        return _run_async(self._server_account.sign_transaction(transaction_dict))
+        return self._sync_account.sign_transaction(transaction_dict)
 
     def sign_typed_data(
         self,
@@ -136,6 +245,7 @@ class EvmLocalAccount(BaseAccount):
             ValueError: If the primaryType cannot be inferred from message_types.
 
         """
+        track_action(action="sign_typed_data", account_type="evm_local")
         if full_message is not None:
             typed_data = full_message
         elif message_types is not None and message_data is not None:
@@ -172,7 +282,7 @@ class EvmLocalAccount(BaseAccount):
         signable_message = encode_typed_data(full_message=typed_data)
         message_hash = _hash_eip191_message(signable_message)
 
-        return _run_async(self._server_account.unsafe_sign_hash(message_hash))
+        return self._sync_account.unsafe_sign_hash(message_hash)
 
     def _get_types_for_eip712_domain(
         self, domain: dict[str, Any] | None = None

--- a/python/cdp/evm_local_account.py
+++ b/python/cdp/evm_local_account.py
@@ -158,6 +158,10 @@ class EvmLocalAccount(BaseAccount):
 
         """
         cdp_client = server_account.api_clients._cdp_client
+        # EvmLocalAccount exposes a synchronous interface (required by eth_account's BaseAccount).
+        # To avoid bridging sync→async (which requires nest_asyncio and breaks on Python 3.12+),
+        # we use a dedicated synchronous HTTP client (urllib3) for signing requests instead of
+        # reusing the async aiohttp client used by EvmServerAccount.
         http_client = Urllib3AuthClient(
             options=Urllib3AuthClientOptions(
                 api_key_id=cdp_client.api_key_id,

--- a/python/cdp/test/test_e2e.py
+++ b/python/cdp/test/test_e2e.py
@@ -2385,6 +2385,59 @@ async def test_update_evm_smart_account(cdp_client):
 
 
 @pytest.mark.e2e
+def test_evm_local_account_from_sync_context():
+    """Regression test for #591.
+
+    EvmLocalAccount must work from a purely synchronous context (no running event loop)
+    without nest_asyncio.
+    """
+
+    async def _setup():
+        client = CdpClient(**client_args)
+        account = await client.evm.create_account()
+        local_account = EvmLocalAccount(account)
+        await client.close()
+        return local_account
+
+    # asyncio.run() creates a fresh loop, runs setup, then closes the loop.
+    # After it returns we are in a pure sync context with no running event loop.
+    local_account = asyncio.run(_setup())
+
+    message_hash = "0x1234567890123456789012345678901234567890123456789012345678901234"
+    signed_hash = local_account.unsafe_sign_hash(message_hash)
+    assert signed_hash is not None
+    assert signed_hash.signature is not None
+
+    signable_message = encode_defunct(text="Hello from sync context!")
+    signed_message = local_account.sign_message(signable_message)
+    assert signed_message is not None
+    assert signed_message.signature is not None
+
+    signed_transaction = local_account.sign_transaction(
+        transaction_dict={
+            "to": "0x0000000000000000000000000000000000000000",
+            "value": 0,
+            "chainId": 84532,
+            "gas": 21000,
+            "maxFeePerGas": 1000000000,
+            "maxPriorityFeePerGas": 1000000000,
+            "nonce": 0,
+            "type": "0x2",
+        }
+    )
+    assert signed_transaction is not None
+    assert signed_transaction.raw_transaction is not None
+
+    signed_typed_data = local_account.sign_typed_data(
+        domain_data={"name": "Test", "version": "1", "chainId": 1},
+        message_types={"Message": [{"name": "value", "type": "string"}]},
+        message_data={"value": "Hello from sync context!"},
+    )
+    assert signed_typed_data is not None
+    assert signed_typed_data.signature is not None
+
+
+@pytest.mark.e2e
 @pytest.mark.asyncio
 async def test_evm_local_account_sign_hash(cdp_client):
     """Test signing a hash with an EVM local account."""

--- a/python/cdp/test/test_evm_local_account.py
+++ b/python/cdp/test/test_evm_local_account.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from eth_account.messages import encode_defunct
@@ -7,93 +7,123 @@ from hexbytes import HexBytes
 from cdp.evm_local_account import EvmLocalAccount
 
 
-def test_initialization(server_account_model_factory):
+def _make_server_account(address="0x1234567890123456789012345678901234567890"):
+    """Build a minimal EvmServerAccount mock with the attributes EvmLocalAccount.__init__ needs."""
+    server_account = MagicMock()
+    server_account.address = address
+    cdp_client = server_account.api_clients._cdp_client
+    cdp_client.api_key_id = "test-key-id"
+    cdp_client.api_key_secret = "test-key-secret"
+    cdp_client.wallet_secret = "test-wallet-secret"
+    cdp_client.source = "sdk"
+    cdp_client.source_version = "1.0.0"
+    cdp_client.configuration.host = "https://api.cdp.coinbase.com/platform"
+    return server_account
+
+
+@patch("cdp.evm_local_account.Urllib3AuthClient")
+def test_initialization(mock_auth_client):
     """Test that the EvmLocalAccount initializes correctly."""
     address = "0x1234567890123456789012345678901234567890"
-    server_account_model = server_account_model_factory(address)
-    evm_local_account = EvmLocalAccount(server_account_model)
-    assert evm_local_account.address == server_account_model.address
+    server_account = _make_server_account(address)
+    evm_local_account = EvmLocalAccount(server_account)
+    assert evm_local_account.address == address
 
 
-def test_str_representation(server_account_model_factory):
+@patch("cdp.evm_local_account.Urllib3AuthClient")
+def test_str_representation(mock_auth_client):
     """Test the string representation of the EvmLocalAccount."""
     address = "0x1234567890123456789012345678901234567890"
-    server_account_model = server_account_model_factory(address)
-    evm_local_account = EvmLocalAccount(server_account_model)
+    server_account = _make_server_account(address)
+    evm_local_account = EvmLocalAccount(server_account)
     assert str(evm_local_account) == f"Ethereum Account Address: {address}"
 
 
-def test_repr_representation(server_account_model_factory):
+@patch("cdp.evm_local_account.Urllib3AuthClient")
+def test_repr_representation(mock_auth_client):
     """Test the repr representation of the EvmLocalAccount."""
     address = "0x1234567890123456789012345678901234567890"
-    server_account_model = server_account_model_factory(address)
-    evm_local_account = EvmLocalAccount(server_account_model)
+    server_account = _make_server_account(address)
+    evm_local_account = EvmLocalAccount(server_account)
     assert repr(evm_local_account) == f"Ethereum Account Address: {address}"
 
 
-@pytest.mark.asyncio
-@patch("cdp.evm_local_account.EvmServerAccount")
-async def test_unsafe_sign_hash(mock_server_account):
+@patch("cdp.evm_local_account._EvmServerAccountSync")
+@patch("cdp.evm_local_account.Urllib3AuthClient")
+def test_unsafe_sign_hash(mock_auth_client, mock_sync_account):
     """Test that the EvmLocalAccount can sign a hash."""
+    mock_sync = mock_sync_account.return_value
     signature_response = MagicMock()
-    # Create a real bytes-like object for the signature (65 bytes: 32 for r, 32 for s, 1 for v)
     mock_signature = bytes.fromhex("1234" * 32 + "5678" * 32 + "1b")
     signature_response.signature = mock_signature
-    mock_server_account.unsafe_sign_hash = AsyncMock(return_value=signature_response)
-    evm_local_account = EvmLocalAccount(mock_server_account)
+    mock_sync.unsafe_sign_hash.return_value = signature_response
+
+    server_account = _make_server_account()
+    evm_local_account = EvmLocalAccount(server_account)
     message_hash = b"test"
     signed_message = evm_local_account.unsafe_sign_hash(message_hash)
-    mock_server_account.unsafe_sign_hash.assert_called_once_with(message_hash)
+
+    mock_sync.unsafe_sign_hash.assert_called_once_with(message_hash)
     assert signed_message == signature_response
     assert signed_message.signature == HexBytes(mock_signature)
 
 
-@pytest.mark.asyncio
-@patch("cdp.evm_local_account.EvmServerAccount")
-async def test_sign_message(mock_server_account):
+@patch("cdp.evm_local_account._EvmServerAccountSync")
+@patch("cdp.evm_local_account.Urllib3AuthClient")
+def test_sign_message(mock_auth_client, mock_sync_account):
     """Test that the EvmLocalAccount can sign a message."""
+    mock_sync = mock_sync_account.return_value
     signature_response = MagicMock()
     mock_signature = bytes.fromhex("1234" * 32 + "5678" * 32 + "1b")
     signature_response.signature = mock_signature
-    mock_server_account.sign_message = AsyncMock(return_value=signature_response)
-    evm_local_account = EvmLocalAccount(mock_server_account)
+    mock_sync.sign_message.return_value = signature_response
+
+    server_account = _make_server_account()
+    evm_local_account = EvmLocalAccount(server_account)
     message = encode_defunct(text="test")
     signed_message = evm_local_account.sign_message(message)
-    mock_server_account.sign_message.assert_called_once_with(message)
+
+    mock_sync.sign_message.assert_called_once_with(message)
     assert signed_message == signature_response
     assert signed_message.signature == HexBytes(mock_signature)
 
 
-@pytest.mark.asyncio
-@patch("cdp.evm_local_account.EvmServerAccount")
-async def test_sign_transaction(mock_server_account):
+@patch("cdp.evm_local_account._EvmServerAccountSync")
+@patch("cdp.evm_local_account.Urllib3AuthClient")
+def test_sign_transaction(mock_auth_client, mock_sync_account):
     """Test that the EvmLocalAccount can sign a transaction."""
+    mock_sync = mock_sync_account.return_value
     signature_response = MagicMock()
-    mock_server_account.sign_transaction = AsyncMock(return_value=signature_response)
-    evm_local_account = EvmLocalAccount(mock_server_account)
+    mock_sync.sign_transaction.return_value = signature_response
+
+    server_account = _make_server_account()
+    evm_local_account = EvmLocalAccount(server_account)
     transaction = MagicMock()
     signed_transaction = evm_local_account.sign_transaction(transaction)
-    mock_server_account.sign_transaction.assert_called_once_with(transaction)
+
+    mock_sync.sign_transaction.assert_called_once_with(transaction)
     assert signed_transaction == signature_response
 
 
-@pytest.mark.asyncio
+@patch("cdp.evm_local_account._EvmServerAccountSync")
+@patch("cdp.evm_local_account.Urllib3AuthClient")
 @patch("cdp.evm_local_account.encode_typed_data")
 @patch("cdp.evm_local_account._hash_eip191_message")
-@patch("cdp.evm_local_account.EvmServerAccount")
-async def test_sign_typed_data_with_full_message(
-    mock_server_account, mock_hash_eip191, mock_encode_typed_data
+def test_sign_typed_data_with_full_message(
+    mock_hash_eip191, mock_encode_typed_data, mock_auth_client, mock_sync_account
 ):
     """Test that the EvmLocalAccount can sign typed data with a full message."""
+    mock_sync = mock_sync_account.return_value
     signature_response = MagicMock()
-    mock_server_account.unsafe_sign_hash = AsyncMock(return_value=signature_response)
-    evm_local_account = EvmLocalAccount(mock_server_account)
+    mock_sync.unsafe_sign_hash.return_value = signature_response
 
     signable_message = MagicMock()
     mock_encode_typed_data.return_value = signable_message
     message_hash = MagicMock()
     mock_hash_eip191.return_value = message_hash
 
+    server_account = _make_server_account()
+    evm_local_account = EvmLocalAccount(server_account)
     signed_message = evm_local_account.sign_typed_data(
         full_message={
             "domain": {
@@ -136,27 +166,29 @@ async def test_sign_typed_data_with_full_message(
         }
     )
     mock_hash_eip191.assert_called_once_with(signable_message)
-    mock_server_account.unsafe_sign_hash.assert_called_once_with(message_hash)
+    mock_sync.unsafe_sign_hash.assert_called_once_with(message_hash)
     assert signed_message == signature_response
 
 
-@pytest.mark.asyncio
+@patch("cdp.evm_local_account._EvmServerAccountSync")
+@patch("cdp.evm_local_account.Urllib3AuthClient")
 @patch("cdp.evm_local_account.encode_typed_data")
 @patch("cdp.evm_local_account._hash_eip191_message")
-@patch("cdp.evm_local_account.EvmServerAccount")
-async def test_sign_typed_data_with_domain_data_message_types_message_data(
-    mock_server_account, mock_hash_eip191, mock_encode_typed_data
+def test_sign_typed_data_with_domain_data_message_types_message_data(
+    mock_hash_eip191, mock_encode_typed_data, mock_auth_client, mock_sync_account
 ):
     """Test that the EvmLocalAccount can sign typed data with domain data, message types, and message data."""
+    mock_sync = mock_sync_account.return_value
     signature_response = MagicMock()
-    mock_server_account.unsafe_sign_hash = AsyncMock(return_value=signature_response)
-    evm_local_account = EvmLocalAccount(mock_server_account)
+    mock_sync.unsafe_sign_hash.return_value = signature_response
 
     signable_message = MagicMock()
     mock_encode_typed_data.return_value = signable_message
     message_hash = MagicMock()
     mock_hash_eip191.return_value = message_hash
 
+    server_account = _make_server_account()
+    evm_local_account = EvmLocalAccount(server_account)
     signed_message = evm_local_account.sign_typed_data(
         domain_data={
             "name": "test",
@@ -200,27 +232,29 @@ async def test_sign_typed_data_with_domain_data_message_types_message_data(
         }
     )
     mock_hash_eip191.assert_called_once_with(signable_message)
-    mock_server_account.unsafe_sign_hash.assert_called_once_with(message_hash)
+    mock_sync.unsafe_sign_hash.assert_called_once_with(message_hash)
     assert signed_message == signature_response
 
 
-@pytest.mark.asyncio
+@patch("cdp.evm_local_account._EvmServerAccountSync")
+@patch("cdp.evm_local_account.Urllib3AuthClient")
 @patch("cdp.evm_local_account.encode_typed_data")
 @patch("cdp.evm_local_account._hash_eip191_message")
-@patch("cdp.evm_local_account.EvmServerAccount")
-async def test_sign_typed_data_with_bytes32_type(
-    mock_server_account, mock_hash_eip191, mock_encode_typed_data
+def test_sign_typed_data_with_bytes32_type(
+    mock_hash_eip191, mock_encode_typed_data, mock_auth_client, mock_sync_account
 ):
     """Test that the EvmLocalAccount can sign typed data with a bytes32 type."""
+    mock_sync = mock_sync_account.return_value
     signature_response = MagicMock()
-    mock_server_account.unsafe_sign_hash = AsyncMock(return_value=signature_response)
-    evm_local_account = EvmLocalAccount(mock_server_account)
+    mock_sync.unsafe_sign_hash.return_value = signature_response
 
     signable_message = MagicMock()
     mock_encode_typed_data.return_value = signable_message
     message_hash = MagicMock()
     mock_hash_eip191.return_value = message_hash
 
+    server_account = _make_server_account()
+    evm_local_account = EvmLocalAccount(server_account)
     signed_message = evm_local_account.sign_typed_data(
         full_message={
             "domain": {
@@ -269,26 +303,29 @@ async def test_sign_typed_data_with_bytes32_type(
         }
     )
     mock_hash_eip191.assert_called_once_with(signable_message)
-    mock_server_account.unsafe_sign_hash.assert_called_once_with(message_hash)
+    mock_sync.unsafe_sign_hash.assert_called_once_with(message_hash)
     assert signed_message == signature_response
 
 
-@pytest.mark.asyncio
+@patch("cdp.evm_local_account._EvmServerAccountSync")
+@patch("cdp.evm_local_account.Urllib3AuthClient")
 @patch("cdp.evm_local_account.encode_typed_data")
 @patch("cdp.evm_local_account._hash_eip191_message")
-@patch("cdp.evm_local_account.EvmServerAccount")
-async def test_sign_typed_data_with_bytes32_type_without_eip712_domain_type(
-    mock_server_account, mock_hash_eip191, mock_encode_typed_data
+def test_sign_typed_data_with_bytes32_type_without_eip712_domain_type(
+    mock_hash_eip191, mock_encode_typed_data, mock_auth_client, mock_sync_account
 ):
     """Test that the EvmLocalAccount can sign typed data with a bytes32 type without the EIP712Domain type."""
+    mock_sync = mock_sync_account.return_value
     signature_response = MagicMock()
-    mock_server_account.unsafe_sign_hash = AsyncMock(return_value=signature_response)
-    evm_local_account = EvmLocalAccount(mock_server_account)
+    mock_sync.unsafe_sign_hash.return_value = signature_response
 
     signable_message = MagicMock()
     mock_encode_typed_data.return_value = signable_message
     message_hash = MagicMock()
     mock_hash_eip191.return_value = message_hash
+
+    server_account = _make_server_account()
+    evm_local_account = EvmLocalAccount(server_account)
 
     signed_message = evm_local_account.sign_typed_data(
         full_message={
@@ -332,7 +369,7 @@ async def test_sign_typed_data_with_bytes32_type_without_eip712_domain_type(
         }
     )
     mock_hash_eip191.assert_called_with(signable_message)
-    mock_server_account.unsafe_sign_hash.assert_called_with(message_hash)
+    mock_sync.unsafe_sign_hash.assert_called_with(message_hash)
     assert signed_message == signature_response
 
     signed_message = evm_local_account.sign_typed_data(
@@ -374,15 +411,17 @@ async def test_sign_typed_data_with_bytes32_type_without_eip712_domain_type(
         }
     )
     mock_hash_eip191.assert_called_with(signable_message)
-    mock_server_account.unsafe_sign_hash.assert_called_with(message_hash)
+    mock_sync.unsafe_sign_hash.assert_called_with(message_hash)
     assert signed_message == signature_response
 
 
-@pytest.mark.asyncio
-@patch("cdp.evm_local_account.EvmServerAccount")
-async def test_sign_typed_data_with_bad_arguments(mock_server_account):
+@patch("cdp.evm_local_account._EvmServerAccountSync")
+@patch("cdp.evm_local_account.Urllib3AuthClient")
+def test_sign_typed_data_with_bad_arguments(mock_auth_client, mock_sync_account):
     """Test that the EvmLocalAccount raises the correct error if the arguments are bad."""
-    evm_local_account = EvmLocalAccount(mock_server_account)
+    server_account = _make_server_account()
+    evm_local_account = EvmLocalAccount(server_account)
+
     with pytest.raises(
         ValueError,
         match="Must provide either full_message or both message_types and message_data",

--- a/python/cdp/test/test_evm_server_account.py
+++ b/python/cdp/test/test_evm_server_account.py
@@ -1,4 +1,3 @@
-import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -474,9 +473,7 @@ async def test_use_network(server_account_model_factory):
     account = EvmServerAccount(server_account_model, dummy_api, dummy_api)
 
     # Test the use_network method
-    network_account = asyncio.get_event_loop().run_until_complete(
-        account.__experimental_use_network__(network)
-    )
+    network_account = await account.__experimental_use_network__(network)
 
     assert network_account.address == address
     assert network_account.network == network

--- a/python/changelog.d/652.bugfix.md
+++ b/python/changelog.d/652.bugfix.md
@@ -1,0 +1,1 @@
+Removed nest_asyncio dependency

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -17,7 +17,6 @@ dependencies = [
     "web3>=7.6.0,<=7.10.0",
     "solana>=0.36.6",
     "solders>=0.26.0",
-    "nest-asyncio>=1.6.0,<2",
     "base58>=2.1.1",
 ]
 

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -310,7 +310,6 @@ dependencies = [
     { name = "aiohttp-retry" },
     { name = "base58" },
     { name = "cryptography" },
-    { name = "nest-asyncio" },
     { name = "pydantic" },
     { name = "pyjwt" },
     { name = "python-dateutil" },
@@ -345,7 +344,6 @@ requires-dist = [
     { name = "base58", specifier = ">=2.1.1" },
     { name = "cryptography", specifier = ">=42.0.0" },
     { name = "myst-parser", marker = "extra == 'dev'", specifier = ">=4.0.1" },
-    { name = "nest-asyncio", specifier = ">=1.6.0,<2" },
     { name = "pydantic", specifier = ">=2.10.3" },
     { name = "pyjwt", specifier = ">=2.10.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
@@ -1305,15 +1303,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/a5/9626ba4f73555b3735ad86247a8077d4603aa8628537687c839ab08bfe44/myst_parser-4.0.1.tar.gz", hash = "sha256:5cfea715e4f3574138aecbf7d54132296bfd72bb614d31168f48c477a830a7c4", size = 93985, upload-time = "2025-02-12T10:53:03.833Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5f/df/76d0321c3797b54b60fef9ec3bd6f4cfd124b9e422182156a1dd418722cf/myst_parser-4.0.1-py3-none-any.whl", hash = "sha256:9134e88959ec3b5780aedf8a99680ea242869d012e8821db3126d427edc9c95d", size = 84579, upload-time = "2025-02-12T10:53:02.078Z" },
-]
-
-[[package]]
-name = "nest-asyncio"
-version = "1.6.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!--
Thanks for contributing to CDP SDK!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

This PR removes the `nest_asyncio` dependency.

- `nest_asyncio` is unmaintained and breaks on Python 3.12+ (`loop_factory` parameter mismatch).
- Introduce `_EvmServerAccountSync`, a private class backing `EvmLocalAccount` that calls the three CDP signing endpoints synchronously via the existing `Urllib3AuthClient`. No new dependencies
- Remove `nest-asyncio` from `pyproject.toml` and regenerates lock files for `python/` and `examples/python/`

## Why not a sync-to-async bridge?

The thread-based approaches (e.g. `run_coroutine_threadsafe`, `ThreadPoolExecutor`) are patches that create new problems. The fundamental design tension would remain. The real fix is a native sync HTTP path for the subset of operations `EvmLocalAccount` needs.

## Why not generate a second OpenAPI client?

Only 3 endpoints are needed (`sign`, `sign/message`, `sign/transaction`). A full generated sync client would duplicate ~250 files for no benefit. `_EvmServerAccountSync` is ~80 lines and entirely self-contained.

Closes https://github.com/coinbase/cdp-sdk/issues/591.

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
 -->

## Tests

Ran the example `examples/python/evm/ecosystem/web3py/evm_local_account.py`:

```
❯ uv run python evm/ecosystem/web3py/evm_local_account.py
Account:  Ethereum Account Address: 0xc689707f26756784105F54c4ED6F5Add524C560A
Account compatible with eth_account:  0xc689707f26756784105F54c4ED6F5Add524C560A

Signing hash...
Signed hash:  SignedMessage(message_hash='0x1234567890123456789012345678901234567890123456789012345678901234', r=57049031682178508804091175920335526583721405066163050094990322523056343807318, s=32387024411922934641529786598997223116757660114616745814065711894492004951358, v=27, signature=HexBytes('0x7e209b90101f84f23e648e4bba412b93af61239d599210cd776f0a638ab6f556479a67fd82fd9a123c358516eaf6c6bd997f05de9f3ff0fda9e2f98c73a7253e1b'))

Signing message...
Signed message:  SignedMessage(message_hash=b"\xb4S\xbdN'\x1e\xed\x98\\\xba\xb8#\x1d\xa6\t\xc4\xce\n\x9c\xf1\xf7c\xb6\xc1YNv1U\x10\xe0\xf1", r=37281278688649902134277016297887397123195561088545803728897652452762120801476, s=23162022271877638489387981734083191566920461287791463242810231539769917352254, v=28, signature=HexBytes('0x526c74ba2ca04d25644efc51679f9e23697d52a1dc70b4319dbf15ad1652ccc433353d72bb695184f9171a5f654b385b705a71be58898994cb2956c485f4a93e1c'))

Signing typed data with domain, types, and message...
Signed typed data for domain, types, and message:  SignedMessage(message_hash=b'L\xc0\x04*\xe2y\x04x!\x9f\xb0\x8cF\xc8\x84\xba+81I8\xad\x9f\x83\xae\xe6\nmV\x11o\xe7', r=107266443067500939413854313789399527890594981381119814998667725749699789847518, s=15453885428980507699597096617208001036297316386222485500001595931329598967832, v=28, signature=HexBytes('0xed26a7bfe224459bd1b4cca5222d1944c09db84af3234b2535038bf1c71dfbde222a96d4da183a52b0fab88c3360424dac2f9a873b0ab20289826fad3829d0181c'))

Signing typed data with full message...
Signed typed data full message:  SignedMessage(message_hash=b'L\xc0\x04*\xe2y\x04x!\x9f\xb0\x8cF\xc8\x84\xba+81I8\xad\x9f\x83\xae\xe6\nmV\x11o\xe7', r=107266443067500939413854313789399527890594981381119814998667725749699789847518, s=15453885428980507699597096617208001036297316386222485500001595931329598967832, v=28, signature=HexBytes('0xed26a7bfe224459bd1b4cca5222d1944c09db84af3234b2535038bf1c71dfbde222a96d4da183a52b0fab88c3360424dac2f9a873b0ab20289826fad3829d0181c'))

Signing typed data with bytes32 type...
Signed typed data with bytes32 type:  SignedMessage(message_hash=b'\xdc\xa4\xe9\r\xb9\xab\xc4Fyh`\xcc\xb8\xcce\xc1(\xc7\xcd\xbf)\xaca\x17&]mT\xc8\x8e\x030', r=12049388963802520052021406745481047750563729256420919116922636096368824510750, s=22071225130946302413119945222290129036807470982698496412919856288352468205610, v=28, signature=HexBytes('0x1aa3b66490cc1b5e22a26a9f7062d2e72df118a68808cafce1218cdc505b691e30cbdee816d119c982de578900b9920244f0f7f535112550c603dfee73a8002a1c'))

Signing typed data with without EIP712Domain type...
Signed typed data without EIP712Domain type:  SignedMessage(message_hash=b'l\xe5\x15o+\xa0(~\x9c\xd0\xffY\xc8\xfb\xce\x8e\xa6\xad\xdc3)\x12\x97\xfd\x14h\xda5\xc6\xb9\x05\xf1', r=21467194425975604222216938815393764240616707750017619813957818133867607634623, s=10500184178148141259044591778704833252369946689249246684299606691393129545293, v=27, signature=HexBytes('0x2f760060073f9cb74a123fb4af6e7342581ff6ad166aa2b4e9b6d16cf36c32bf1736e4c55e8f93ea4f0b26fa77e7a65ee8ea10c08b1e53e3b893cd2f8311fe4d1b'))

Signing transaction...
Signed transaction:  SignedTransaction(raw_transaction=HexBytes('0x02f87283014a340c843b9aca00843b9aca0082520894000000000000000000000000000000000000dead8502540be40080c001a0c85e3f3d2315610dc38749b1e768644e3f26556ad46ff250903792447ab998d2a07877ef1915ba857d6e69be9486bdf4ce5e075180665db83a6d988529e44c4e36'), hash=HexBytes('0x9485f3425c82dbda7b83aec485e6c1d4362a5abb874495ac7270b83891f257a3'), r=1343594100203957376813748127806706357161470955636795865396747980682439950336, s=5460044033801821160132930038842125800782084568080257075633, v=231)

Requesting ETH from faucet for account...
Received funds from faucet...
Transaction sent! Hash: 9485f3425c82dbda7b83aec485e6c1d4362a5abb874495ac7270b83891f257a3
Transaction confirmed in block 40162443
Transaction status: Success
```

<!--
When adding new functionality or fixing a bug, you should be testing your changes with one or more
API method examples in the examples directory.

Please provide samples of the methods you tested with, the outputs for each method,
and any other relevant context, like which network was used.

Use the following format if helpful:

```
Method: <name of method used>
Network: <network used>
Setup: <any other relevant context>

Output:
<example output>
```

For example:

```
Method: createAccount
Network: Base Sepolia

Output:
EVM Account Address:  0xC2c7D554292Bb6AE502fafc3F5c0C46B534d6f31
```
 -->

## Checklist

A couple of things to include in your PR for completeness:

- [ ] Updated the [typescript README](https://github.com/coinbase/cdp-sdk/blob/main/typescript/src/README.md) if relevant
- [ ] Updated the [python README](https://github.com/coinbase/cdp-sdk/blob/main/python/README.md) if relevant
- [x] Added a changelog entry
- [x] Added e2e tests if introducing new functionality

<!--
For instructions on adding changelog entries:
See here for TypeScript: https://github.com/coinbase/cdp-sdk/blob/main/typescript/CONTRIBUTING.md#changelog
and here for Python: https://github.com/coinbase/cdp-sdk/blob/main/python/CONTRIBUTING.md#changelog
-->
