### PR TITLE
chore: bump @coinbase/cdp-sdk to 1.48.0

### DIFF
--- a/typescript/.changeset/wet-bears-wait.md
+++ b/typescript/.changeset/wet-bears-wait.md
@@ -1,5 +1,0 @@
----
-"@coinbase/cdp-sdk": minor
----
-
-Added CreateSubscription for Webhooks Client

--- a/typescript/.changeset/yellow-moons-send.md
+++ b/typescript/.changeset/yellow-moons-send.md
@@ -1,5 +1,0 @@
----
-"@coinbase/cdp-sdk": minor
----
-
-Consume refactored end user operations for delegated signing in end user client

--- a/typescript/src/CHANGELOG.md
+++ b/typescript/src/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CDP SDK Changelog
 
+## 1.48.0
+
+### Minor Changes
+
+- [#634](https://github.com/coinbase/cdp-sdk/pull/634) [`ed47c82`](https://github.com/coinbase/cdp-sdk/commit/ed47c821eca763742137500e3380371dd1b78ec1) Thanks [@milan-cb](https://github.com/milan-cb)! - Added CreateSubscription for Webhooks Client
+
+- [#659](https://github.com/coinbase/cdp-sdk/pull/659) [`48ea200`](https://github.com/coinbase/cdp-sdk/commit/48ea20026283f10aa094af66dab4fc1d8feb051e) Thanks [@sammccord](https://github.com/sammccord)! - Consume refactored end user operations for delegated signing in end user client
+
 ## 1.47.0
 
 ### Minor Changes

--- a/typescript/src/package.json
+++ b/typescript/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cdp-sdk",
-  "version": "1.47.0",
+  "version": "1.48.0",
   "description": "SDK for interacting with the Coinbase Developer Platform Wallet API",
   "type": "module",
   "main": "./_cjs/index.js",

--- a/typescript/src/version.ts
+++ b/typescript/src/version.ts
@@ -1,1 +1,1 @@
-export const version = "1.47.0";
+export const version = "1.48.0";


### PR DESCRIPTION
## Summary

- Bumps `@coinbase/cdp-sdk` from `1.47.0` to `1.48.0`
- Consumes two pending minor changesets:
  - Added `CreateSubscription` for Webhooks Client (#634)
  - Consume refactored end user operations for delegated signing in end user client (#659)
- Updates `version.ts` to match the new version
- Updates `CHANGELOG.md` with the new release entry