### PR TITLE
feat(rust): add Cargo features to switch TLS backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1104,7 +1104,7 @@ dependencies = [
 
 [[package]]
 name = "cdp-sdk"
-version = "0.5.0"
+version = "0.4.0"
 dependencies = [
  "alloy",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1104,7 +1104,7 @@ dependencies = [
 
 [[package]]
 name = "cdp-sdk"
-version = "0.5.0"
+version = "0.4.0"
 dependencies = [
  "alloy",
  "async-trait",
@@ -2078,6 +2078,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -2699,6 +2700,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.0+3.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2706,6 +2716,7 @@ checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -3329,6 +3340,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3521,6 +3533,18 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1104,7 +1104,7 @@ dependencies = [
 
 [[package]]
 name = "cdp-sdk"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "alloy",
  "async-trait",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -18,7 +18,7 @@ async-trait = "^0.1"
 bon = { version = "3.7.1" }
 chrono = { version = "0.4", features = ["serde"] }
 progenitor-middleware-client = { version = "^0.12.0" }
-reqwest = { version = "0.12.4", features = ["json", "stream"] }
+reqwest = { version = "0.12.4", default-features = false, features = ["json", "stream"] }
 base64 = "0.22"
 rand = "0.9"
 regress = "0.10"
@@ -33,6 +33,15 @@ urlencoding = "2.1"
 http = "1.0"
 hex = "0.4"
 reqwest-middleware = { version = "0.4.2", default-features = false, features = ["json"] }
+
+[features]
+default = ["native-tls"]
+native-tls = ["reqwest/native-tls"]
+native-tls-alpn = ["reqwest/native-tls-alpn"]
+native-tls-vendored = ["reqwest/native-tls-vendored"]
+rustls-tls = ["reqwest/rustls-tls"]
+rustls-tls-native-roots = ["reqwest/rustls-tls-native-roots"]
+rustls-tls-webpki-roots = ["reqwest/rustls-tls-webpki-roots"]
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["full"] }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cdp-sdk"
-version = "0.5.0"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.86"
 authors = ["Coinbase Inc."]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cdp-sdk"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.86"
 authors = ["Coinbase Inc."]

--- a/rust/changelog.d/656.feature.md
+++ b/rust/changelog.d/656.feature.md
@@ -1,0 +1,1 @@
+Add Cargo feature flags to switch between TLS backends (native-tls, rustls-tls, etc.) for reqwest, enabling use of rustls instead of OpenSSL.


### PR DESCRIPTION
## Description

Adds Cargo feature flags to the Rust SDK so consumers can choose their TLS backend for `reqwest`, instead of being locked into the default `native-tls` (OpenSSL on Linux).

Closes #656

### Changes

- Disabled `reqwest`'s default features in `Cargo.toml`
- Added a `[features]` section exposing TLS backend options:
  - `native-tls` (default) — backward compatible, OS native TLS
  - `native-tls-alpn` — OpenSSL with ALPN for HTTP/2
  - `native-tls-vendored` — statically linked OpenSSL (musl/Alpine/Docker)
  - `rustls-tls` — pure Rust TLS with webpki roots
  - `rustls-tls-native-roots` — rustls with OS certificate store
  - `rustls-tls-webpki-roots` — rustls with explicit webpki roots

### Consumer usage

```toml
# Default (backward compatible, native-tls):
cdp-sdk = "0.4.0"

# Rustls:
cdp-sdk = { version = "0.4.0", default-features = false, features = ["rustls-tls"] }

# Vendored OpenSSL (musl/Alpine):
cdp-sdk = { version = "0.4.0", features = ["native-tls-vendored"] }
```

## Tests

Verified compilation with multiple feature combinations:

```
cargo check                                                    # default (native-tls) ✅
cargo check --no-default-features --features rustls-tls        # rustls ✅
cargo check --no-default-features --features rustls-tls-native-roots  # rustls + native roots ✅
make test                                                      # 9/9 unit tests pass ✅
```

No code changes — only `Cargo.toml` feature forwarding. reqwest's API surface is identical across TLS backends.

## Checklist

- [ ] Updated the [typescript README](https://github.com/coinbase/cdp-sdk/blob/main/typescript/src/README.md) if relevant
- [ ] Updated the [python README](https://github.com/coinbase/cdp-sdk/blob/main/python/README.md) if relevant
- [x] Added a changelog entry
- [ ] Added e2e tests if introducing new functionality