### PR TITLE
chore: Skip sponsored Solana e2e tests on 429 rate limit

### DIFF
--- a/python/cdp/test/test_e2e.py
+++ b/python/cdp/test/test_e2e.py
@@ -1475,13 +1475,19 @@ async def test_solana_send_transaction(cdp_client, solana_account):
 @pytest.mark.asyncio
 async def test_solana_send_sponsored_transaction(cdp_client, solana_account):
     """Test sending a fee-sponsored transaction."""
-    response = await cdp_client.solana.send_transaction(
-        network="solana-devnet",
-        transaction=_get_transaction(
-            solana_account.address, "EeVPcnRE1mhcY85wAh3uPJG1uFiTNya9dCJjNUPABXzo", 10
-        ),
-        use_cdp_sponsor=True,
-    )
+    try:
+        response = await cdp_client.solana.send_transaction(
+            network="solana-devnet",
+            transaction=_get_transaction(
+                solana_account.address, "EeVPcnRE1mhcY85wAh3uPJG1uFiTNya9dCJjNUPABXzo", 10
+            ),
+            use_cdp_sponsor=True,
+        )
+    except ApiError as e:
+        if e.http_code == 429:
+            pytest.skip(f"Skipping due to rate limit: {e}")
+        raise
+
     assert response is not None
     assert response.transaction_signature is not None
 

--- a/typescript/src/e2e.test.ts
+++ b/typescript/src/e2e.test.ts
@@ -45,6 +45,7 @@ import type {
 } from "./client/evm/evm.types.js";
 import type { ImportAccountOptions } from "./client/solana/solana.types.js";
 import { TimeoutError } from "./errors.js";
+import { APIError } from "./openapi-client/errors.js";
 import { SignEvmTransactionRule } from "./policies/evmSchema.js";
 import type { CreatePolicyBody, Policy } from "./policies/types.js";
 import { SpendPermission } from "./spend-permissions/types.js";
@@ -1824,15 +1825,23 @@ describe("CDP Client E2E Tests", () => {
           process.env.CDP_E2E_SOLANA_RPC_URL ?? "https://api.devnet.solana.com",
         );
 
-        const { signature } = await cdp.solana.sendTransaction({
-          network: "solana-devnet",
-          transaction: createAndEncodeTransaction(
-            testSolanaAccount.address,
-            "EeVPcnRE1mhcY85wAh3uPJG1uFiTNya9dCJjNUPABXzo",
-            10,
-          ),
-          useCdpSponsor: true,
-        });
+        let signature: string | undefined;
+        try {
+          ({ signature } = await cdp.solana.sendTransaction({
+            network: "solana-devnet",
+            transaction: createAndEncodeTransaction(
+              testSolanaAccount.address,
+              "EeVPcnRE1mhcY85wAh3uPJG1uFiTNya9dCJjNUPABXzo",
+              10,
+            ),
+            useCdpSponsor: true,
+          }));
+        } catch (e) {
+          if (e instanceof APIError && e.statusCode === 429) {
+            return;
+          }
+          throw e;
+        }
 
         expect(signature).toBeDefined();
 


### PR DESCRIPTION
<!--
Thanks for contributing to CDP SDK!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

To prevent e2e test failures due to sponsored Solana transactions for the e2e test project hitting rate limits.

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
 -->

## Tests

<!--
When adding new functionality or fixing a bug, you should be testing your changes with one or more
API method examples in the examples directory.

Please provide samples of the methods you tested with, the outputs for each method,
and any other relevant context, like which network was used.

Use the following format if helpful:

```
Method: <name of method used>
Network: <network used>
Setup: <any other relevant context>

Output:
<example output>
```

For example:

```
Method: createAccount
Network: Base Sepolia

Output:
EVM Account Address:  0xC2c7D554292Bb6AE502fafc3F5c0C46B534d6f31
```
 -->

## Checklist

A couple of things to include in your PR for completeness:

- [ ] Updated the [typescript README](https://github.com/coinbase/cdp-sdk/blob/main/typescript/src/README.md) if relevant
- [ ] Updated the [python README](https://github.com/coinbase/cdp-sdk/blob/main/python/README.md) if relevant
- [ ] Added a changelog entry
- [ ] Added e2e tests if introducing new functionality

<!--
For instructions on adding changelog entries:
See here for TypeScript: https://github.com/coinbase/cdp-sdk/blob/main/typescript/CONTRIBUTING.md#changelog
and here for Python: https://github.com/coinbase/cdp-sdk/blob/main/python/CONTRIBUTING.md#changelog
-->
