### PR TITLE
fix(go): reconcile walletHeaderFn with canonical TS requiresWalletAuth logic

### DIFF
--- a/go/cdp.go
+++ b/go/cdp.go
@@ -85,9 +85,6 @@ func getRequestHost(options ClientOptions, req *http.Request) string {
 // requiresWalletAuth returns true if the request method and path require wallet
 // authentication via the X-Wallet-Auth header.
 //
-// This logic mirrors the TypeScript SDK's requiresWalletAuth function:
-// cdp-sdk/typescript/src/auth/utils/http.ts
-//
 // The /accounts and /spend-permissions checks use strings.Contains intentionally —
 // this matches the TypeScript canonical's includes() behaviour. The looser matching
 // is acceptable because all current routes that contain these segments require wallet

--- a/go/cdp.go
+++ b/go/cdp.go
@@ -82,7 +82,18 @@ func getRequestHost(options ClientOptions, req *http.Request) string {
 	return req.Host
 }
 
-// requiresWalletAuth returns true if the request method and path require wallet authentication.
+// requiresWalletAuth returns true if the request method and path require wallet
+// authentication via the X-Wallet-Auth header.
+//
+// This logic mirrors the TypeScript SDK's requiresWalletAuth function:
+// cdp-sdk/typescript/src/auth/utils/http.ts
+//
+// The /accounts and /spend-permissions checks use strings.Contains intentionally —
+// this matches the TypeScript canonical's includes() behaviour. The looser matching
+// is acceptable because all current routes that contain these segments require wallet
+// auth, and tightening would diverge from the canonical without benefit.
+//
+// TODO: Make this configurable by route rather than substring/regex matching.
 func requiresWalletAuth(method, path string) bool {
 	if method != "POST" && method != "DELETE" && method != "PUT" {
 		return false

--- a/go/cdp.go
+++ b/go/cdp.go
@@ -7,10 +7,17 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
 	"strings"
 
 	"github.com/coinbase/cdp-sdk/go/auth"
 	"github.com/coinbase/cdp-sdk/go/openapi"
+)
+
+var (
+	endUserEvmRe             = regexp.MustCompile(`/end-users/[^/]+/evm$`)
+	endUserEvmSmartAccountRe = regexp.MustCompile(`/end-users/[^/]+/evm-smart-account$`)
+	endUserSolanaRe          = regexp.MustCompile(`/end-users/[^/]+/solana$`)
 )
 
 // ClientOptions contains configuration options for the CDP client.
@@ -75,6 +82,23 @@ func getRequestHost(options ClientOptions, req *http.Request) string {
 	return req.Host
 }
 
+// requiresWalletAuth returns true if the request method and path require wallet authentication.
+func requiresWalletAuth(method, path string) bool {
+	if method != "POST" && method != "DELETE" && method != "PUT" {
+		return false
+	}
+
+	return strings.Contains(path, "/accounts") ||
+		strings.Contains(path, "/spend-permissions") ||
+		strings.Contains(path, "/user-operations/prepare-and-send") ||
+		strings.Contains(path, "/embedded-wallet-api/") ||
+		strings.HasSuffix(path, "/end-users") ||
+		strings.HasSuffix(path, "/end-users/import") ||
+		endUserEvmRe.MatchString(path) ||
+		endUserEvmSmartAccountRe.MatchString(path) ||
+		endUserSolanaRe.MatchString(path)
+}
+
 // apiKeyHeaderFn generates a JWT for the API key and adds it to the request headers.
 func apiKeyHeaderFn(options ClientOptions) openapi.RequestEditorFn {
 	return func(_ context.Context, req *http.Request) error {
@@ -107,13 +131,11 @@ func apiKeyHeaderFn(options ClientOptions) openapi.RequestEditorFn {
 // walletHeaderFn generates a JWT for the wallet and adds it to the request headers.
 func walletHeaderFn(options ClientOptions) openapi.RequestEditorFn {
 	return func(_ context.Context, req *http.Request) error {
-		if req.Method != "POST" && req.Method != "DELETE" {
+		if options.WalletSecret == "" {
 			return nil
 		}
 
-		if !strings.Contains(req.URL.Path, "/accounts") &&
-			!strings.Contains(req.URL.Path, "/spend-permissions") &&
-			!strings.Contains(req.URL.Path, "/user-operations/prepare-and-send") {
+		if !requiresWalletAuth(req.Method, req.URL.Path) {
 			return nil
 		}
 

--- a/go/cdp.go
+++ b/go/cdp.go
@@ -85,7 +85,7 @@ func getRequestHost(options ClientOptions, req *http.Request) string {
 // requiresWalletAuth returns true if the request method and path require wallet
 // authentication via the X-Wallet-Auth header.
 //
-// The /accounts and /spend-permissions checks use strings.Contains intentionally —
+// The /accounts and /spend-permissions checks use strings.Contains intentionally.
 // The looser matching is acceptable because all current routes that contain
 // these segments require wallet auth, and tightening would diverge from the
 // canonical without benefit.

--- a/go/cdp.go
+++ b/go/cdp.go
@@ -95,7 +95,7 @@ func getRequestHost(options ClientOptions, req *http.Request) string {
 //
 // TODO: Make this configurable by route rather than substring/regex matching.
 func requiresWalletAuth(method, path string) bool {
-	if method != "POST" && method != "DELETE" && method != "PUT" {
+	if method != http.MethodPost && method != http.MethodDelete && method != http.MethodPut {
 		return false
 	}
 

--- a/go/cdp.go
+++ b/go/cdp.go
@@ -86,9 +86,9 @@ func getRequestHost(options ClientOptions, req *http.Request) string {
 // authentication via the X-Wallet-Auth header.
 //
 // The /accounts and /spend-permissions checks use strings.Contains intentionally —
-// this matches the TypeScript canonical's includes() behaviour. The looser matching
-// is acceptable because all current routes that contain these segments require wallet
-// auth, and tightening would diverge from the canonical without benefit.
+// The looser matching is acceptable because all current routes that contain
+// these segments require wallet auth, and tightening would diverge from the
+// canonical without benefit.
 //
 // TODO: Make this configurable by route rather than substring/regex matching.
 func requiresWalletAuth(method, path string) bool {

--- a/go/cdp_test.go
+++ b/go/cdp_test.go
@@ -1,0 +1,154 @@
+package cdp
+
+import (
+	"testing"
+)
+
+func TestRequiresWalletAuth(t *testing.T) {
+	tests := map[string]struct {
+		method string
+		path   string
+		want   bool
+	}{
+		// Method filtering
+		"GET skipped": {
+			method: "GET",
+			path:   "/platform/v2/accounts",
+			want:   false,
+		},
+		"PATCH skipped": {
+			method: "PATCH",
+			path:   "/platform/v2/accounts",
+			want:   false,
+		},
+
+		// /accounts
+		"POST /accounts": {
+			method: "POST",
+			path:   "/platform/v2/accounts",
+			want:   true,
+		},
+		"DELETE /accounts/{id}": {
+			method: "DELETE",
+			path:   "/platform/v2/accounts/abc-123",
+			want:   true,
+		},
+		"PUT /accounts/{id}": {
+			method: "PUT",
+			path:   "/platform/v2/accounts/abc-123",
+			want:   true,
+		},
+
+		// /spend-permissions
+		"POST /spend-permissions": {
+			method: "POST",
+			path:   "/platform/v2/spend-permissions",
+			want:   true,
+		},
+		"DELETE /spend-permissions/{id}": {
+			method: "DELETE",
+			path:   "/platform/v2/spend-permissions/abc-123",
+			want:   true,
+		},
+
+		// /user-operations/prepare-and-send
+		"POST /user-operations/prepare-and-send": {
+			method: "POST",
+			path:   "/platform/v2/evm/accounts/0xabc/user-operations/prepare-and-send",
+			want:   true,
+		},
+
+		// bare /prepare-and-send should NOT match
+		"POST /prepare-and-send (bare) does not match": {
+			method: "POST",
+			path:   "/platform/v2/prepare-and-send",
+			want:   false,
+		},
+
+		// /embedded-wallet-api/
+		"POST /embedded-wallet-api/ route": {
+			method: "POST",
+			path:   "/platform/v2/embedded-wallet-api/end-users/uid-123/evm",
+			want:   true,
+		},
+		"PUT /embedded-wallet-api/ route": {
+			method: "PUT",
+			path:   "/platform/v2/embedded-wallet-api/end-users/uid-123/wallet-secrets",
+			want:   true,
+		},
+		"DELETE /embedded-wallet-api/ route": {
+			method: "DELETE",
+			path:   "/platform/v2/embedded-wallet-api/end-users/uid-123/address/0xabc/delegation",
+			want:   true,
+		},
+		"GET /embedded-wallet-api/ skipped": {
+			method: "GET",
+			path:   "/platform/v2/embedded-wallet-api/end-users/uid-123",
+			want:   false,
+		},
+
+		// /end-users (endsWith)
+		"POST /v2/end-users": {
+			method: "POST",
+			path:   "/platform/v2/end-users",
+			want:   true,
+		},
+		"GET /v2/end-users skipped": {
+			method: "GET",
+			path:   "/platform/v2/end-users",
+			want:   false,
+		},
+		"POST /v2/end-users/{id} does not match endsWith": {
+			method: "POST",
+			path:   "/platform/v2/end-users/uid-123",
+			want:   false,
+		},
+
+		// /end-users/import (endsWith)
+		"POST /v2/end-users/import": {
+			method: "POST",
+			path:   "/platform/v2/end-users/import",
+			want:   true,
+		},
+
+		// /end-users/{id}/evm (regex)
+		"POST /v2/end-users/{id}/evm": {
+			method: "POST",
+			path:   "/platform/v2/end-users/uid-123/evm",
+			want:   true,
+		},
+		"POST /v2/end-users/{id}/evm/sign does not match regex": {
+			method: "POST",
+			path:   "/platform/v2/end-users/uid-123/evm/sign",
+			want:   false,
+		},
+
+		// /end-users/{id}/evm-smart-account (regex)
+		"POST /v2/end-users/{id}/evm-smart-account": {
+			method: "POST",
+			path:   "/platform/v2/end-users/uid-123/evm-smart-account",
+			want:   true,
+		},
+
+		// /end-users/{id}/solana (regex)
+		"POST /v2/end-users/{id}/solana": {
+			method: "POST",
+			path:   "/platform/v2/end-users/uid-123/solana",
+			want:   true,
+		},
+		"POST /v2/end-users/{id}/solana/sign does not match regex": {
+			method: "POST",
+			path:   "/platform/v2/end-users/uid-123/solana/sign",
+			want:   false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := requiresWalletAuth(tc.method, tc.path)
+			if got != tc.want {
+				t.Errorf("requiresWalletAuth(%q, %q) = %v, want %v", tc.method, tc.path, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

The Go SDK's `walletHeaderFn` had diverged from the canonical route-matching logic defined in the TypeScript SDK's `requiresWalletAuth` function. This PR aligns them.

**Changes in `go/cdp.go`:**
- Extracted `requiresWalletAuth(method, path string) bool` helper to consolidate all routing decisions in one place
- Added `PUT` to the allowed methods set (required for embedded wallet routes like `registerTemporaryWalletSecret`)
- Added missing paths that require `X-Wallet-Auth`:
  - `/embedded-wallet-api/` (covers all embedded wallet API routes)
  - `/end-users` (endsWith — `createEndUser`)
  - `/end-users/import` (endsWith — `importEndUser`)
  - `/end-users/{id}/evm` (regex — `addEndUserEvmAccount`)
  - `/end-users/{id}/evm-smart-account` (regex — `addEndUserEvmSmartAccount`)
  - `/end-users/{id}/solana` (regex — `addEndUserSolanaAccount`)
- Added `WalletSecret == ""` early-return guard in `walletHeaderFn` — previously the function was always registered as a request editor regardless of whether a wallet secret was configured, which could cause a silent no-op JWT generation attempt with an empty secret

**Changes in `go/cdp_test.go`:**
- New file with table-driven unit tests covering all path patterns and all three methods (POST, DELETE, PUT)

## Tests

Unit tests only — `requiresWalletAuth` is pure logic with no network calls.

```
go test ./...

ok  github.com/coinbase/cdp-sdk/go        0.308s
ok  github.com/coinbase/cdp-sdk/go/auth   0.724s
```

## Checklist

- [ ] Updated the [typescript README](https://github.com/coinbase/cdp-sdk/blob/main/typescript/src/README.md) if relevant
- [ ] Updated the [python README](https://github.com/coinbase/cdp-sdk/blob/main/python/README.md) if relevant
- [ ] Added a changelog entry
- [ ] Added e2e tests if introducing new functionality