### PR TITLE
fix(python,rust): add missing path checks to requires_wallet_auth

### DIFF
--- a/python/cdp/auth/test/test_http.py
+++ b/python/cdp/auth/test/test_http.py
@@ -78,6 +78,13 @@ def test_get_auth_headers_missing_wallet_auth(mock_jwt, auth_options_factory):
         ("POST", "/v2/end-users", True),
         ("POST", "/v2/end-users/import", True),
         ("GET", "/v2/end-users", False),
+        ("POST", "/embedded-wallet-api/some-route", True),
+        ("PUT", "/embedded-wallet-api/other-route", True),
+        ("GET", "/embedded-wallet-api/some-route", False),
+        ("POST", "/user-operations/prepare-and-send", True),
+        ("POST", "/v2/end-users/user123/evm", True),
+        ("POST", "/v2/end-users/user123/evm-smart-account", True),
+        ("POST", "/v2/end-users/user123/solana", True),
     ],
 )
 def test_requires_wallet_auth(request_method, request_path, expected):

--- a/python/cdp/auth/utils/http.py
+++ b/python/cdp/auth/utils/http.py
@@ -113,6 +113,7 @@ def _requires_wallet_auth(method: str, path: str) -> bool:
         "/accounts" in path
         or "/spend-permissions" in path
         or "/user-operations/prepare-and-send" in path
+        or "/embedded-wallet-api/" in path
         or path.endswith("/end-users")
         or path.endswith("/end-users/import")
         or bool(re.search(r"/end-users/[^/]+/evm$", path))

--- a/python/changelog.d/fix-wallet-auth-embedded-wallet-api.fix.md
+++ b/python/changelog.d/fix-wallet-auth-embedded-wallet-api.fix.md
@@ -1,0 +1,1 @@
+Add missing `/embedded-wallet-api/` path check to wallet auth header generation, ensuring X-Wallet-Auth is sent for all embedded wallet API operations

--- a/rust/changelog.d/fix-wallet-auth-missing-paths.fix.md
+++ b/rust/changelog.d/fix-wallet-auth-missing-paths.fix.md
@@ -1,0 +1,1 @@
+Add missing path checks to wallet auth header generation for `/embedded-wallet-api/`, `/user-operations/prepare-and-send`, `/end-users`, and end-user account creation routes

--- a/rust/src/auth.rs
+++ b/rust/src/auth.rs
@@ -454,8 +454,37 @@ impl WalletAuth {
     }
 
     fn requires_wallet_auth(&self, method: &str, path: &str) -> bool {
-        (path.contains("/accounts") || path.contains("/spend-permissions"))
-            && (method == "POST" || method == "DELETE" || method == "PUT")
+        if method != "POST" && method != "DELETE" && method != "PUT" {
+            return false;
+        }
+
+        path.contains("/accounts")
+            || path.contains("/spend-permissions")
+            || path.contains("/user-operations/prepare-and-send")
+            || path.contains("/embedded-wallet-api/")
+            || path.ends_with("/end-users")
+            || path.ends_with("/end-users/import")
+            || Self::matches_end_user_pattern(path, "/evm")
+            || Self::matches_end_user_pattern(path, "/evm-smart-account")
+            || Self::matches_end_user_pattern(path, "/solana")
+    }
+
+    /// Checks if path matches `/end-users/{id}/{suffix}` pattern.
+    /// Equivalent to regex `/end-users/[^/]+/{suffix}$`.
+    fn matches_end_user_pattern(path: &str, suffix: &str) -> bool {
+        if let Some(pos) = path.find("/end-users/") {
+            let after = &path[pos + "/end-users/".len()..];
+            // after should be "{id}/{suffix}" with no extra segments
+            if let Some(slash_pos) = after.find('/') {
+                let id_part = &after[..slash_pos];
+                let rest = &after[slash_pos..];
+                !id_part.is_empty() && rest == suffix
+            } else {
+                false
+            }
+        } else {
+            false
+        }
     }
 
     fn get_correlation_data(&self) -> String {
@@ -716,10 +745,26 @@ mod tests {
         // Should require wallet auth for spend-permissions
         assert!(auth.requires_wallet_auth("POST", "/v2/spend-permissions"));
 
+        // Should require wallet auth for user-operations/prepare-and-send
+        assert!(auth.requires_wallet_auth("POST", "/v2/user-operations/prepare-and-send"));
+
+        // Should require wallet auth for embedded-wallet-api routes
+        assert!(auth.requires_wallet_auth("POST", "/embedded-wallet-api/some-route"));
+        assert!(auth.requires_wallet_auth("PUT", "/embedded-wallet-api/other-route"));
+        assert!(!auth.requires_wallet_auth("GET", "/embedded-wallet-api/some-route"));
+
+        // Should require wallet auth for end-users endpoints
+        assert!(auth.requires_wallet_auth("POST", "/v2/end-users"));
+        assert!(auth.requires_wallet_auth("POST", "/v2/end-users/import"));
+        assert!(auth.requires_wallet_auth("POST", "/v2/end-users/user123/evm"));
+        assert!(auth.requires_wallet_auth("POST", "/v2/end-users/user123/evm-smart-account"));
+        assert!(auth.requires_wallet_auth("POST", "/v2/end-users/user123/solana"));
+
         // Should NOT require wallet auth for GET requests
         assert!(!auth.requires_wallet_auth("GET", "/v2/evm/accounts"));
+        assert!(!auth.requires_wallet_auth("GET", "/v2/end-users"));
 
-        // Should NOT require wallet auth for non-account endpoints
+        // Should NOT require wallet auth for non-matching endpoints
         assert!(!auth.requires_wallet_auth("POST", "/v2/other/endpoint"));
     }
 


### PR DESCRIPTION
## Description

Python and Rust SDKs were missing path checks in their `requires_wallet_auth` functions, causing `X-Wallet-Auth` headers to not be sent for certain routes. The TypeScript implementation is the source of truth.

**Python** was missing:
- `/embedded-wallet-api/`

**Rust** was missing 7 of 9 patterns (only had `/accounts` and `/spend-permissions`):
- `/user-operations/prepare-and-send`
- `/embedded-wallet-api/`
- `/end-users` (suffix)
- `/end-users/import` (suffix)
- `/end-users/{id}/evm` (pattern)
- `/end-users/{id}/evm-smart-account` (pattern)
- `/end-users/{id}/solana` (pattern)

**Go** was already up to date — no changes needed.

All SDKs now match the canonical TypeScript `requiresWalletAuth` logic.

fix #710 

## Tests

Unit tests added/expanded for both Python and Rust covering all 9 path patterns.

```
Python: 832 passed (make test)
Rust: 19 passed (cargo test --lib)
```

## Checklist

- [x] Updated the [typescript README](https://github.com/coinbase/cdp-sdk/blob/main/typescript/src/README.md) if relevant — N/A, no TS changes
- [x] Updated the [python README](https://github.com/coinbase/cdp-sdk/blob/main/python/README.md) if relevant — N/A, bugfix only
- [x] Added a changelog entry
- [x] Added e2e tests if introducing new functionality — N/A, bugfix with unit tests