### PR TITLE
 docs(typescript): custom doc generation router with semantic structure and MDX safety

### DIFF
--- a/typescript/typedoc-router-backend.mjs
+++ b/typescript/typedoc-router-backend.mjs
@@ -1,0 +1,216 @@
+/**
+ * Custom TypeDoc router for the CDP backend TypeScript SDK.
+ * Adapted from cdp-web's typedoc-router-module-group.mjs.
+ *
+ * Uses @group JSDoc tags to organize members into directories.
+ * Falls back to the parent Module name (from @module tag) when
+ * no explicit @group is present — so @module Client → Client/,
+ * @module Types → Types/, etc. with no extra per-declaration tags needed.
+ */
+import * as fs from "fs";
+import * as path from "path";
+import { MemberRouter, MarkdownPageEvent } from "typedoc-plugin-markdown";
+import { Comment, ReflectionKind, ReferenceReflection } from "typedoc";
+
+class BackendGroupRouter extends MemberRouter {
+  groupReferencesByType = this.application.options.getValue("groupReferencesByType") ?? false;
+
+  /**
+   * Read @group tags from a reflection's JSDoc comment.
+   * Returns a Set of group names (empty if none found).
+   */
+  getGroups(reflection) {
+    const groups = new Set();
+
+    function extractGroupTags(comment) {
+      if (!comment) return;
+      for (const tag of comment.blockTags) {
+        if (tag.tag === "@group") {
+          groups.add(Comment.combineDisplayParts(tag.content).trim());
+        }
+      }
+    }
+
+    if (reflection.isDeclaration()) {
+      extractGroupTags(reflection.comment);
+      for (const sig of reflection.getNonIndexSignatures()) {
+        extractGroupTags(sig.comment);
+      }
+      if (reflection.type?.type === "reflection") {
+        extractGroupTags(reflection.type.declaration.comment);
+        for (const sig of reflection.type.declaration.getNonIndexSignatures()) {
+          extractGroupTags(sig.comment);
+        }
+      }
+    }
+
+    groups.delete("");
+    return groups;
+  }
+
+  /**
+   * Determine the group directory for a reflection:
+   * 1. Explicit @group tag on the declaration
+   * 2. Parent Module name (from @module tag at the top of the file)
+   * 3. TypeDoc kind plural string (fallback)
+   */
+  getGroupForReflection(reflection) {
+    if (!reflection.isDeclaration() && !reflection.isDocument()) return null;
+
+    const groups = this.getGroups(reflection);
+    if (groups.size > 0) return groups.values().next().value;
+
+    // Use parent Module name as the group directory — this means @module Client
+    // in a file automatically puts all exports in the Client/ directory.
+    if (reflection.parent?.kind === ReflectionKind.Module) {
+      return reflection.parent.name;
+    }
+
+    if (reflection instanceof ReferenceReflection && this.groupReferencesByType) {
+      return ReflectionKind.pluralString(reflection.getTargetReflectionDeep().kind).toLowerCase();
+    }
+
+    return ReflectionKind.pluralString(reflection.kind).toLowerCase();
+  }
+
+  /**
+   * Override directory resolution to use the group-based path.
+   * With entryPointStrategy: "resolve", top-level exports are children
+   * of a Module (kind=1). We strip the module path segment so files
+   * land directly in the group directory within the output root.
+   */
+  getReflectionDirectory(reflection) {
+    if (!reflection.parent) return "";
+
+    const group = this.getGroupForReflection(reflection);
+    const groupDir = group ?? "Other";
+
+    // Top-level within a Module (each resolve entry point → Module)
+    if (reflection.parent.kind === ReflectionKind.Module) {
+      return groupDir;
+    }
+
+    // Top-level within the Project root
+    if (reflection.parent.kind === ReflectionKind.Project) {
+      return groupDir;
+    }
+
+    // Nested within another declaration (e.g. class methods — anchors, not pages)
+    return `${this.getReflectionAlias(reflection.parent)}/${groupDir}`;
+  }
+}
+
+export function load(app) {
+  app.renderer.defineRouter("backend-group", BackendGroupRouter);
+
+  // After all pages are written, merge index-N.mdx files (TypeDoc's conflict resolution
+  // when multiple @module entries share the same name, e.g. @module Types) into the
+  // primary index.mdx so each directory has exactly one flat page.
+  app.renderer.on("endRender", event => {
+    const outDir = event.outputDirectory;
+    if (!outDir || !fs.existsSync(outDir)) return;
+
+    // Track all index-N paths that get merged so we can rewrite cross-links.
+    const mergedPaths = new Map(); // "dir/index-N" → "dir/index"
+
+    function mergeIndexFiles(dir) {
+      const entries = fs.readdirSync(dir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (entry.isDirectory()) {
+          mergeIndexFiles(path.join(dir, entry.name));
+        }
+      }
+      const numbered = entries
+        .filter(e => e.isFile() && /^index-\d+\.mdx$/.test(e.name))
+        .sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true }));
+
+      if (numbered.length === 0) return;
+
+      const primary = path.join(dir, "index.mdx");
+      if (!fs.existsSync(primary)) return;
+
+      let merged = fs.readFileSync(primary, "utf-8");
+      for (const n of numbered) {
+        const nPath = path.join(dir, n.name);
+        let extra = fs.readFileSync(nPath, "utf-8");
+        extra = extra.replace(/^---[\s\S]*?---\n/, "");
+        merged = merged.trimEnd() + "\n\n" + extra.trimStart();
+        // Record the relative path mapping (without .mdx) for link rewriting.
+        const relDir = path.relative(outDir, dir).replace(/\\/g, "/");
+        const stem = n.name.replace(/\.mdx$/, "");
+        mergedPaths.set(`${relDir}/${stem}`, `${relDir}/index`);
+        fs.unlinkSync(nPath);
+      }
+      fs.writeFileSync(primary, merged, "utf-8");
+    }
+
+    mergeIndexFiles(outDir);
+
+    // Rewrite all cross-links that still point to the now-deleted index-N paths.
+    if (mergedPaths.size > 0) {
+      function rewriteLinks(dir) {
+        for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+          const full = path.join(dir, entry.name);
+          if (entry.isDirectory()) { rewriteLinks(full); continue; }
+          if (!entry.name.endsWith(".mdx")) continue;
+          let content = fs.readFileSync(full, "utf-8");
+          let changed = false;
+          for (const [oldRel, newRel] of mergedPaths) {
+            // Escape all regex special characters in the path before interpolating.
+            const escaped = oldRel.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+            const pattern = new RegExp(
+              `(\\]\\([^)]*?)${escaped}((?:#[^)]*)?\\))`, "g"
+            );
+            const updated = content.replace(pattern, `$1${newRel}$2`);
+            if (updated !== content) { content = updated; changed = true; }
+          }
+          if (changed) fs.writeFileSync(full, content, "utf-8");
+        }
+      }
+      rewriteLinks(outDir);
+    }
+  });
+
+  // Strip .mdx extension from internal links so Mintlify can resolve them.
+  // TypeDoc generates links like [Foo](/path/Foo.mdx) but Mintlify expects /path/Foo.
+  app.renderer.on(MarkdownPageEvent.END, event => {
+    if (!event.contents) return;
+
+    // Strip .mdx from links.
+    event.contents = event.contents.replace(/(\]\([^)#]+)\.mdx((?:#[^)]*)?)\)/g, "$1$2)");
+
+    // Escape bare {identifier} and {orgId/keyId} patterns outside code blocks/spans.
+    // In MDX, {expr} is a JSX expression — unrecognised identifiers cause production build failures.
+    // Strategy: walk the content line by line, skip fenced code blocks, then within each
+    // text line replace {word} outside of backtick spans.
+    let inFence = false;
+    event.contents = event.contents.split("\n").map(line => {
+      if (/^```/.test(line)) { inFence = !inFence; return line; }
+      if (inFence) return line;
+      // Replace {word} outside inline code spans (backtick pairs are kept intact).
+      return line.replace(/(`[^`]*`)|(\{[^}]*\})/g, (match, code, expr) => {
+        if (code) return code; // inside inline code — leave unchanged
+        // Use HTML entities so MDX treats them as literal characters.
+        // Avoids incomplete backslash-escaping when expr contains backslashes.
+        return expr.replace(/\{/g, "&#123;").replace(/\}/g, "&#125;");
+      });
+    }).join("\n");
+  });
+
+  // Escape pipe characters inside @pattern values in table cells so they don't
+  // break Markdown table column alignment. Ported from cdp-web/typedoc-markdown.mjs.
+  app.renderer.on(MarkdownPageEvent.END, event => {
+    if (!event.contents?.includes("**Pattern**")) return;
+
+    event.contents = event.contents.replace(
+      /^(\|.+)\*\*Pattern\*\*\s+(.+)(\s\|)$/gm,
+      (_, before, pattern, end) =>
+        `${before}\`Pattern: ${pattern.replace(/\|/g, "&#124;")}\`${end}`,
+    );
+
+    event.contents = event.contents.replace(
+      /(\*\*Pattern\*\*\s+)([^`\n]+)/g,
+      (_, label, pattern) => `${label}\`${pattern.trim()}\``,
+    );
+  });
+}

--- a/typescript/typedoc.auth.json
+++ b/typescript/typedoc.auth.json
@@ -9,16 +9,29 @@
   ],
   "entryPointStrategy": "resolve",
   "out": "./docs-md/auth",
-  "flattenOutputFiles": true,
-  "plugin": ["typedoc-plugin-markdown", "typedoc-plugin-frontmatter"],
+  "plugin": [
+    "typedoc-plugin-markdown",
+    "typedoc-plugin-frontmatter",
+    "./typedoc-router-backend.mjs",
+    "./ts-frontmatter.mjs"
+  ],
   "excludePrivate": true,
   "excludeInternal": true,
   "excludeProtected": false,
   "readme": "./packages/cdp-sdk/src/auth/README.md",
   "name": "index",
   "includeVersion": true,
-  "sort": ["kind"],
-  "kindSortOrder": ["Function", "Class", "Interface", "TypeAlias", "Enum", "Variable"],
+  "sort": [
+    "kind"
+  ],
+  "kindSortOrder": [
+    "Function",
+    "Class",
+    "Interface",
+    "TypeAlias",
+    "Enum",
+    "Variable"
+  ],
   "categorizeByGroup": true,
   "exclude": [
     "**/tests/**/*",
@@ -29,7 +42,7 @@
     "**/_types/**/*",
     "**/openapi-client/**/*"
   ],
-  "skipErrorChecking": false,
+  "skipErrorChecking": true,
   "treatWarningsAsErrors": false,
   "validation": {
     "notExported": true,
@@ -46,5 +59,15 @@
   "publicPath": "/sdks/cdp-sdks-v2/typescript/auth",
   "expandObjects": true,
   "expandParameters": true,
-  "router": "module"
+  "router": "backend-group",
+  "parametersFormat": "list",
+  "propertiesFormat": "list",
+  "typeDeclarationFormat": "list",
+  "membersWithOwnFile": [
+    "Class",
+    "Function",
+    "Enum",
+    "Variable",
+    "TypeAlias"
+  ]
 }

--- a/typescript/typedoc.client.json
+++ b/typescript/typedoc.client.json
@@ -1,19 +1,44 @@
 {
-  "entryPoints": ["./packages/cdp-sdk/src/client/cdp.ts"],
+  "entryPoints": [
+    "./packages/cdp-sdk/src/client/cdp.ts"
+  ],
   "entryPointStrategy": "resolve",
   "out": "./docs-md/client",
-  "plugin": ["typedoc-plugin-markdown", "typedoc-plugin-frontmatter", "./ts-frontmatter.mjs"],
+  "plugin": [
+    "typedoc-plugin-markdown",
+    "typedoc-plugin-frontmatter",
+    "./ts-frontmatter.mjs",
+    "./typedoc-router-backend.mjs"
+  ],
   "excludePrivate": true,
   "excludeInternal": true,
   "excludeProtected": false,
   "readme": "none",
   "name": "CDP Client",
   "includeVersion": true,
-  "sort": ["kind", "alphabetical"],
-  "kindSortOrder": ["Class", "Interface", "Function", "TypeAlias", "Enum", "Variable", "Module"],
+  "sort": [
+    "kind",
+    "alphabetical"
+  ],
+  "kindSortOrder": [
+    "Class",
+    "Interface",
+    "Function",
+    "TypeAlias",
+    "Enum",
+    "Variable",
+    "Module"
+  ],
   "categorizeByGroup": true,
   "defaultCategory": "Other",
-  "categoryOrder": ["Client", "EndUser", "Types", "Utilities", "*", "Other"],
+  "categoryOrder": [
+    "Client",
+    "EndUser",
+    "Types",
+    "Utilities",
+    "*",
+    "Other"
+  ],
   "exclude": [
     "**/tests/**/*",
     "**/*.test.ts",
@@ -23,7 +48,7 @@
     "**/_types/**/*",
     "**/openapi-client/**/*"
   ],
-  "skipErrorChecking": false,
+  "skipErrorChecking": true,
   "treatWarningsAsErrors": false,
   "validation": {
     "notExported": true,
@@ -40,5 +65,14 @@
   "publicPath": "/sdks/cdp-sdks-v2/typescript/client",
   "expandObjects": true,
   "expandParameters": true,
-  "router": "module"
+  "router": "backend-group",
+  "parametersFormat": "list",
+  "propertiesFormat": "list",
+  "typeDeclarationFormat": "list",
+  "membersWithOwnFile": [
+    "Function",
+    "Enum",
+    "Variable",
+    "TypeAlias"
+  ]
 }

--- a/typescript/typedoc.evm.json
+++ b/typescript/typedoc.evm.json
@@ -6,20 +6,43 @@
     "./packages/cdp-sdk/src/actions/evm/types.ts"
   ],
   "entryPointStrategy": "resolve",
-  "flattenOutputFiles": true,
   "out": "./docs-md/evm",
-  "plugin": ["typedoc-plugin-markdown", "typedoc-plugin-frontmatter"],
+  "plugin": [
+    "typedoc-plugin-markdown",
+    "typedoc-plugin-frontmatter",
+    "./typedoc-router-backend.mjs",
+    "./ts-frontmatter.mjs"
+  ],
   "excludePrivate": true,
   "excludeInternal": true,
   "excludeProtected": false,
   "readme": "none",
   "name": "Overview",
   "includeVersion": true,
-  "sort": ["kind", "alphabetical"],
-  "kindSortOrder": ["Class", "Interface", "Function", "TypeAlias", "Enum", "Variable", "Module"],
+  "sort": [
+    "kind",
+    "alphabetical"
+  ],
+  "kindSortOrder": [
+    "Class",
+    "Interface",
+    "Function",
+    "TypeAlias",
+    "Enum",
+    "Variable",
+    "Module"
+  ],
   "categorizeByGroup": true,
   "defaultCategory": "Other",
-  "categoryOrder": ["Client", "Accounts", "Actions", "Types", "Utilities", "*", "Other"],
+  "categoryOrder": [
+    "Client",
+    "Accounts",
+    "Actions",
+    "Types",
+    "Utilities",
+    "*",
+    "Other"
+  ],
   "exclude": [
     "**/tests/**/*",
     "**/*.test.ts",
@@ -29,7 +52,7 @@
     "**/_types/**/*",
     "**/openapi-client/**/*"
   ],
-  "skipErrorChecking": false,
+  "skipErrorChecking": true,
   "treatWarningsAsErrors": false,
   "validation": {
     "notExported": true,
@@ -46,5 +69,15 @@
   "publicPath": "/sdks/cdp-sdks-v2/typescript/evm",
   "expandObjects": true,
   "expandParameters": true,
-  "router": "module"
+  "router": "backend-group",
+  "parametersFormat": "list",
+  "propertiesFormat": "list",
+  "typeDeclarationFormat": "list",
+  "membersWithOwnFile": [
+    "Class",
+    "Function",
+    "Enum",
+    "Variable",
+    "TypeAlias"
+  ]
 }

--- a/typescript/typedoc.policies.json
+++ b/typescript/typedoc.policies.json
@@ -1,20 +1,45 @@
 {
-  "entryPoints": ["./packages/cdp-sdk/src/client/policies/policies.ts", "./packages/cdp-sdk/src/client/policies/policies.types.ts"],
+  "entryPoints": [
+    "./packages/cdp-sdk/src/client/policies/policies.ts",
+    "./packages/cdp-sdk/src/client/policies/policies.types.ts"
+  ],
   "entryPointStrategy": "resolve",
-  "flattenOutputFiles": true,
   "out": "./docs-md/policies",
-  "plugin": ["typedoc-plugin-markdown", "typedoc-plugin-frontmatter"],
+  "plugin": [
+    "typedoc-plugin-markdown",
+    "typedoc-plugin-frontmatter",
+    "./typedoc-router-backend.mjs",
+    "./ts-frontmatter.mjs"
+  ],
   "excludePrivate": true,
   "excludeInternal": true,
   "excludeProtected": false,
   "readme": "none",
   "name": "Overview",
   "includeVersion": true,
-  "sort": ["kind", "alphabetical"],
-  "kindSortOrder": ["Class", "Interface", "Function", "TypeAlias", "Enum", "Variable", "Module"],
+  "sort": [
+    "kind",
+    "alphabetical"
+  ],
+  "kindSortOrder": [
+    "Class",
+    "Interface",
+    "Function",
+    "TypeAlias",
+    "Enum",
+    "Variable",
+    "Module"
+  ],
   "categorizeByGroup": true,
   "defaultCategory": "Other",
-  "categoryOrder": ["Client", "Policies", "Types", "Utilities", "*", "Other"],
+  "categoryOrder": [
+    "Client",
+    "Policies",
+    "Types",
+    "Utilities",
+    "*",
+    "Other"
+  ],
   "exclude": [
     "**/tests/**/*",
     "**/*.test.ts",
@@ -24,7 +49,7 @@
     "**/_types/**/*",
     "**/openapi-client/**/*"
   ],
-  "skipErrorChecking": false,
+  "skipErrorChecking": true,
   "treatWarningsAsErrors": false,
   "validation": {
     "notExported": true,
@@ -41,5 +66,15 @@
   "publicPath": "/sdks/cdp-sdks-v2/typescript/policies",
   "expandObjects": true,
   "expandParameters": true,
-  "router": "module"
+  "router": "backend-group",
+  "parametersFormat": "list",
+  "propertiesFormat": "list",
+  "typeDeclarationFormat": "list",
+  "membersWithOwnFile": [
+    "Class",
+    "Function",
+    "Enum",
+    "Variable",
+    "TypeAlias"
+  ]
 }

--- a/typescript/typedoc.solana.json
+++ b/typescript/typedoc.solana.json
@@ -6,20 +6,43 @@
     "./packages/cdp-sdk/src/actions/solana/types.ts"
   ],
   "entryPointStrategy": "resolve",
-  "flattenOutputFiles": true,
   "out": "./docs-md/solana",
-  "plugin": ["typedoc-plugin-markdown", "typedoc-plugin-frontmatter"],
+  "plugin": [
+    "typedoc-plugin-markdown",
+    "typedoc-plugin-frontmatter",
+    "./typedoc-router-backend.mjs",
+    "./ts-frontmatter.mjs"
+  ],
   "excludePrivate": true,
   "excludeInternal": true,
   "excludeProtected": false,
   "readme": "none",
   "name": "Overview",
   "includeVersion": true,
-  "sort": ["kind", "alphabetical"],
-  "kindSortOrder": ["Class", "Interface", "Function", "TypeAlias", "Enum", "Variable", "Module"],
+  "sort": [
+    "kind",
+    "alphabetical"
+  ],
+  "kindSortOrder": [
+    "Class",
+    "Interface",
+    "Function",
+    "TypeAlias",
+    "Enum",
+    "Variable",
+    "Module"
+  ],
   "categorizeByGroup": true,
   "defaultCategory": "Other",
-  "categoryOrder": ["Client", "Accounts", "Actions", "Types", "Utilities", "*", "Other"],
+  "categoryOrder": [
+    "Client",
+    "Accounts",
+    "Actions",
+    "Types",
+    "Utilities",
+    "*",
+    "Other"
+  ],
   "exclude": [
     "**/tests/**/*",
     "**/*.test.ts",
@@ -29,7 +52,7 @@
     "**/_types/**/*",
     "**/openapi-client/**/*"
   ],
-  "skipErrorChecking": false,
+  "skipErrorChecking": true,
   "treatWarningsAsErrors": false,
   "validation": {
     "notExported": true,
@@ -46,5 +69,15 @@
   "publicPath": "/sdks/cdp-sdks-v2/typescript/solana",
   "expandObjects": true,
   "expandParameters": true,
-  "router": "module"
+  "router": "backend-group",
+  "parametersFormat": "list",
+  "propertiesFormat": "list",
+  "typeDeclarationFormat": "list",
+  "membersWithOwnFile": [
+    "Class",
+    "Function",
+    "Enum",
+    "Variable",
+    "TypeAlias"
+  ]
 }


### PR DESCRIPTION
<!--
Thanks for contributing to CDP SDK!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description
- Adds typedoc-router-backend.mjs — a custom TypeDoc router that uses existing @module tags to organize docs into semantic directories (Client/, Accounts/, Actions/, Types/) instead of TypeDoc's default flat names (Client.Class.EvmClient.mdx)
- Switches all format options to list (parametersFormat, propertiesFormat, typeDeclarationFormat) — table format breaks Mintlify's strict MDX production build when cells contain TypeScript generics or template literals like ${string}
- Adds ts-frontmatter.mjs to all typedoc configs so every generated page has title and sidebarTitle frontmatter (required for Mintlify to render)
- Strips .mdx extension from generated cross-links and lowercases kind-based fallback directory names to avoid case-sensitivity 404s on Mintlify's Linux build server
- skipErrorChecking: true added to suppress unrelated node_modules TypeScript errors; flattenOutputFiles removed
<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
 -->

## Tests

<!--
When adding new functionality or fixing a bug, you should be testing your changes with one or more
API method examples in the examples directory.

Please provide samples of the methods you tested with, the outputs for each method,
and any other relevant context, like which network was used.

Use the following format if helpful:

```
Method: <name of method used>
Network: <network used>
Setup: <any other relevant context>

Output:
<example output>
```

For example:

```
Method: createAccount
Network: Base Sepolia

Output:
EVM Account Address:  0xC2c7D554292Bb6AE502fafc3F5c0C46B534d6f31
```
 -->

## Checklist

A couple of things to include in your PR for completeness:

- [ ] Updated the [typescript README](https://github.com/coinbase/cdp-sdk/blob/main/typescript/packages/cdp-sdk/README.md) if relevant
- [ ] Updated the [python README](https://github.com/coinbase/cdp-sdk/blob/main/python/README.md) if relevant
- [ ] Added a changelog entry
- [ ] Added e2e tests if introducing new functionality

<!--
For instructions on adding changelog entries:
See here for TypeScript: https://github.com/coinbase/cdp-sdk/blob/main/typescript/CONTRIBUTING.md#changelog
and here for Python: https://github.com/coinbase/cdp-sdk/blob/main/python/CONTRIBUTING.md#changelog
-->
