### PR TITLE
fix(examples): add typescript devDependency to typescript examples

### DIFF
--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -13,6 +13,9 @@
     "tsx": "4.21.0",
     "viem": "2.47.0"
   },
+  "devDependencies": {
+    "typescript": "5.8.3"
+  },
   "scripts": {
     "build": "tsc"
   },

--- a/examples/typescript/pnpm-lock.yaml
+++ b/examples/typescript/pnpm-lock.yaml
@@ -38,6 +38,10 @@ importers:
       viem:
         specifier: 2.47.0
         version: 2.47.0(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+    devDependencies:
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
 
   ../../typescript/packages/cdp-sdk:
     dependencies:
@@ -1662,8 +1666,7 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  typescript@5.8.3:
-    optional: true
+  typescript@5.8.3: {}
 
   uncrypto@0.1.3: {}
 


### PR DESCRIPTION
## What

Adds `typescript` (5.8.3) as a direct `devDependency` of `examples/typescript`.

## Why

The examples `build` script runs `tsc`, but `typescript` was only present **transitively** (pulled in by `viem`, `@solana/kit`, `permissionless`, etc.). pnpm therefore does not place a `tsc` binary in `examples/typescript/node_modules/.bin/`, so on a clean install `pnpm build` fails with:

```
sh: 1: tsc: not found
```

Declaring `typescript` directly (matching the version already resolved in the tree, 5.8.3) makes `tsc` available and the examples typecheck (`tsconfig` is `noEmit`) again.

## Testing

- `pnpm install` in `examples/typescript` now provides `node_modules/.bin/tsc`.
- After building the SDK (`pnpm build` at repo root), `pnpm build` in `examples/typescript` exits 0.