### PR TITLE
feat(typescript): add CdpX402Client for paying x402-protected APIs [CDPAI-1379]

### DIFF
--- a/examples/typescript/x402/payX402Endpoint.ts
+++ b/examples/typescript/x402/payX402Endpoint.ts
@@ -1,0 +1,90 @@
+/**
+ * Pay for an x402-protected API endpoint using a CDP-managed wallet.
+ *
+ * This example demonstrates the CDP Dev journey: provision a CDP wallet,
+ * wrap fetch with automatic x402 payment handling, and call a protected API.
+ *
+ * Usage:
+ *   pnpm tsx x402/payX402Endpoint.ts
+ *
+ * Required environment variables:
+ *   CDP_API_KEY_ID       - Your CDP API key ID
+ *   CDP_API_KEY_SECRET   - Your CDP API key secret
+ *   CDP_WALLET_SECRET    - Your CDP wallet secret
+ *
+ * Optional environment variables:
+ *   CDP_X402_RPC_URLS    - JSON object mapping CAIP-2 network IDs to RPC URLs
+ *                          e.g. '{"eip155:8453":"https://base.rpc"}'
+ */
+
+// pnpm tsx x402/payX402Endpoint.ts
+import "dotenv/config";
+import { CdpX402Client } from "@coinbase/cdp-sdk/x402";
+import { wrapFetchWithPayment } from "@x402/fetch";
+
+// ─── CDP Dev: Pay using a CDP-managed wallet ──────────────────────────────────
+//
+// CdpX402Client is a drop-in replacement for x402Client. It auto-provisions a
+// CDP Server Wallet, registers payment schemes, and initializes lazily on the
+// first payment call. No private keys to manage.
+
+const client = new CdpX402Client();
+
+// Check what wallet address will be used for payments (triggers lazy init)
+const evmAddress = await client.getEvmAddress();
+console.log("Paying from EVM address:", evmAddress);
+
+// Wrap fetch with automatic x402 payment handling.
+// When the server returns 402, wrapFetchWithPayment automatically:
+//   1. Parses payment requirements from the response
+//   2. Creates a signed payment payload via CdpX402Client
+//   3. Retries the request with the payment header
+const fetchWithPayment = wrapFetchWithPayment(fetch, client);
+
+// ─── Make a paid API call ────────────────────────────────────────────────────
+// Replace with any x402-protected API endpoint.
+const X402_API_URL = process.env.X402_API_URL ?? "https://x402.org/protected";
+
+console.log(`Calling ${X402_API_URL}...`);
+
+const response = await fetchWithPayment(X402_API_URL);
+
+if (response.ok) {
+  const data = await response.json().catch(() => response.text());
+  console.log("Response:", data);
+} else {
+  console.error(`Request failed with status ${response.status}`);
+}
+
+// ─── x402 Dev migration: swap a self-managed signer for CDP ──────────────────
+//
+// Before (self-managed key):
+//
+//   import { x402Client } from "@x402/core/client";
+//   import { registerExactEvmScheme } from "@x402/evm/exact/client";
+//   import { wrapFetchWithPayment } from "@x402/fetch";
+//   import { createWalletClient } from "viem";
+//
+//   const client = new x402Client();
+//   registerExactEvmScheme(client, { signer: yourOwnSigner });
+//   const fetchWithPayment = wrapFetchWithPayment(fetch, client);
+//
+//
+// After (CDP-managed wallet — same wrapFetchWithPayment call):
+//
+//   import { CdpX402Client } from "@coinbase/cdp-sdk/x402";
+//   import { wrapFetchWithPayment } from "@x402/fetch";
+//
+//   const client = new CdpX402Client();  // extends x402Client, drop-in ready
+//   const fetchWithPayment = wrapFetchWithPayment(fetch, client);  // unchanged
+
+// ─── Eager init: get wallet address before first payment ──────────────────────
+//
+// Use createCdpX402Client() when you need to know the wallet address up front
+// (e.g. to fund the wallet before making any payments):
+//
+//   import { createCdpX402Client } from "@coinbase/cdp-sdk/x402";
+//
+//   const { client, evmAddress, svmAddress } = await createCdpX402Client();
+//   console.log("Fund this address before making payments:", evmAddress);
+//   const fetchWithPayment = wrapFetchWithPayment(fetch, client);

--- a/typescript/packages/cdp-sdk/README.md
+++ b/typescript/packages/cdp-sdk/README.md
@@ -35,6 +35,11 @@
   - [Solana Sending](#solana-sending)
 - [Webhooks](#webhooks)
   - [Create Subscription](#create-subscription)
+- [x402 Payment Protocol](#x402-payment-protocol)
+  - [CDP Dev: Pay for an x402-protected API](#cdp-dev-pay-for-an-x402-protected-api)
+  - [x402 Dev: Swap a self-managed signer for a CDP-managed wallet](#x402-dev-swap-a-self-managed-signer-for-a-cdp-managed-wallet)
+  - [x402 Dev: Source a CDP signer inside an existing x402Client](#x402-dev-source-a-cdp-signer-inside-an-existing-x402client)
+  - [Eager wallet initialization with createCdpX402Client](#eager-wallet-initialization-with-createcdpx402client)
 - [Authentication tools](#authentication-tools)
 - [Error Reporting](#error-reporting)
 - [Usage Tracking](#usage-tracking)
@@ -1625,6 +1630,144 @@ const result = await endUser.sendSolanaAsset({
   network: "solana-devnet",
 });
 console.log(result.transactionSignature);
+```
+
+## x402 Payment Protocol
+
+The x402 client lets you pay for x402-protected APIs using CDP-managed wallets. Import from `@coinbase/cdp-sdk/x402`.
+
+**Prerequisites:** install the x402 peer dependency.
+
+```bash
+npm install @x402/fetch
+```
+
+### CDP Dev: Pay for an x402-protected API
+
+`CdpX402Client` extends `x402Client` and initializes lazily — CDP accounts are provisioned on the first payment call, keeping the constructor synchronous.
+
+```typescript
+// Set: CDP_API_KEY_ID, CDP_API_KEY_SECRET, CDP_WALLET_SECRET
+import { CdpX402Client } from "@coinbase/cdp-sdk/x402";
+import { wrapFetchWithPayment } from "@x402/fetch";
+
+const client = new CdpX402Client();
+const fetchWithPayment = wrapFetchWithPayment(fetch, client);
+const response = await fetchWithPayment("https://api.example.com/paid-endpoint");
+```
+
+**Configuration options:**
+
+| Option | Environment variable | Description |
+| --- | --- | --- |
+| `apiKeyId` | `CDP_API_KEY_ID` | CDP API key ID |
+| `apiKeySecret` | `CDP_API_KEY_SECRET` | CDP API key secret |
+| `walletSecret` | `CDP_WALLET_SECRET` | CDP wallet secret |
+| `rpcUrls` | `CDP_X402_RPC_URLS` (JSON) | Custom RPC endpoints keyed by CAIP-2 network ID |
+| `disablePreflightBalanceCheck` | `CDP_DISABLE_PREFLIGHT_BALANCE_CHECK=true` | Skip pre-payment balance check |
+
+**Smart Contract Wallet:**
+
+```typescript
+const client = new CdpX402Client({
+  walletConfig: {
+    type: "smart",
+    accountName: "my-scw",
+    ownerAccountName: "my-owner",
+  },
+});
+const fetchWithPayment = wrapFetchWithPayment(fetch, client);
+```
+
+**Custom RPC endpoints:**
+
+```typescript
+const client = new CdpX402Client({
+  rpcUrls: {
+    "eip155:8453": { rpcUrl: "https://base-mainnet.g.alchemy.com/v2/YOUR_KEY" },
+  },
+});
+```
+
+Or via environment variable:
+
+```bash
+CDP_X402_RPC_URLS='{"eip155:8453":"https://base-mainnet.g.alchemy.com/v2/KEY"}'
+```
+
+### x402 Dev: Swap a self-managed signer for a CDP-managed wallet
+
+`CdpX402Client` extends `x402Client` — it's a drop-in replacement. Existing `wrapFetchWithPayment` calls from `@x402/fetch` work unchanged.
+
+```typescript
+// Before — self-managed key
+import { x402Client } from "@x402/core/client";
+import { registerExactEvmScheme } from "@x402/evm/exact/client";
+import { wrapFetchWithPayment } from "@x402/fetch";
+
+const client = new x402Client();
+registerExactEvmScheme(client, { signer: yourOwnSigner });
+const fetchWithPayment = wrapFetchWithPayment(fetch, client);
+
+// After — CDP-managed wallet (same wrapFetchWithPayment call, unchanged)
+import { CdpX402Client } from "@coinbase/cdp-sdk/x402";
+import { wrapFetchWithPayment } from "@x402/fetch";
+
+const client = new CdpX402Client(); // extends x402Client, auto-provisions wallet
+const fetchWithPayment = wrapFetchWithPayment(fetch, client); // unchanged
+```
+
+### x402 Dev: Source a CDP signer inside an existing x402Client
+
+When you want to keep your own `x402Client` instance and only source the signer from CDP:
+
+```typescript
+import { CdpClient } from "@coinbase/cdp-sdk";
+import { fromCdpEvmAccount } from "@coinbase/cdp-sdk/x402";
+import { x402Client } from "@x402/core/client";
+import { registerExactEvmScheme } from "@x402/evm/exact/client";
+
+const cdp = new CdpClient();
+const account = await cdp.evm.getOrCreateAccount({ name: "my-signer" });
+const signer = fromCdpEvmAccount(account); // bridges EvmServerAccount → x402 ClientEvmSigner
+
+const client = new x402Client();
+registerExactEvmScheme(client, { signer });
+// ... rest of existing setup unchanged
+```
+
+### Eager wallet initialization with createCdpX402Client
+
+Use `createCdpX402Client()` when you need the wallet address before making any payments (e.g. to fund the wallet first):
+
+```typescript
+import { createCdpX402Client } from "@coinbase/cdp-sdk/x402";
+import { wrapFetchWithPayment } from "@x402/fetch";
+
+const { client, evmAddress, svmAddress } = await createCdpX402Client();
+console.log("Fund this address before making payments:", evmAddress);
+
+const fetchWithPayment = wrapFetchWithPayment(fetch, client);
+```
+
+**Pre-flight balance check:**
+
+By default, `CdpX402Client` queries the CDP balance API before each payment and throws `InsufficientFundsError` when the wallet lacks sufficient funds:
+
+```typescript
+import { InsufficientFundsError } from "@coinbase/cdp-sdk/x402";
+import { wrapFetchWithPayment } from "@x402/fetch";
+
+const client = new CdpX402Client();
+const fetchWithPayment = wrapFetchWithPayment(fetch, client);
+
+try {
+  const response = await fetchWithPayment("https://api.example.com/paid");
+} catch (err) {
+  if (err instanceof InsufficientFundsError) {
+    console.log(`Need ${err.required} but have ${err.available} of ${err.asset}`);
+  }
+}
 ```
 
 ## Webhooks

--- a/typescript/packages/cdp-sdk/package.json
+++ b/typescript/packages/cdp-sdk/package.json
@@ -16,6 +16,11 @@
       "types": "./_types/auth/index.d.ts",
       "import": "./_esm/auth/index.js",
       "default": "./_cjs/auth/index.js"
+    },
+    "./x402": {
+      "types": "./_types/x402/index.d.ts",
+      "import": "./_esm/x402/index.js",
+      "default": "./_cjs/x402/index.js"
     }
   },
   "scripts": {
@@ -40,6 +45,10 @@
     "@solana-program/system": "^0.10.0",
     "@solana-program/token": "^0.9.0",
     "@solana/kit": "^5.5.1",
+    "@x402/core": "^2.16.0",
+    "@x402/evm": "^2.16.0",
+    "@x402/fetch": "^2.16.0",
+    "@x402/svm": "^2.16.0",
     "abitype": "1.0.6",
     "axios": "1.16.0",
     "axios-retry": "^4.5.0",

--- a/typescript/packages/cdp-sdk/src/e2e.test.ts
+++ b/typescript/packages/cdp-sdk/src/e2e.test.ts
@@ -4272,6 +4272,79 @@ describe("CDP Client E2E Tests", () => {
   });
 });
 
+describe("x402 Client E2E Tests", () => {
+  // Import the x402 client lazily to avoid issues when the module is not available
+  // during non-x402 e2e runs. These tests require a live CDP account.
+
+  it("CdpX402Client provisions EVM and SVM addresses", async () => {
+    const { CdpX402Client } = await import("./x402/client.js");
+
+    const client = new CdpX402Client({
+      walletConfig: {
+        type: "eoa",
+        accountName: `x402-e2e-eoa-${Date.now()}`,
+      },
+    });
+
+    const evmAddress = await client.getEvmAddress();
+    expect(evmAddress).toMatch(/^0x[0-9a-fA-F]{40}$/);
+
+    const svmAddress = await client.getSvmAddress();
+    expect(svmAddress).toBeTruthy();
+    expect(typeof svmAddress).toBe("string");
+  });
+
+  it("CdpX402Client initializes lazily — no CDP calls at construction", async () => {
+    const { CdpX402Client } = await import("./x402/client.js");
+
+    // Construction must be synchronous and not contact the CDP API
+    const start = Date.now();
+    const client = new CdpX402Client({
+      walletConfig: {
+        type: "eoa",
+        accountName: `x402-e2e-lazy-${Date.now()}`,
+      },
+    });
+    expect(Date.now() - start).toBeLessThan(50);
+    expect(client).toBeDefined();
+  });
+
+  it("createCdpX402Client returns evmAddress and svmAddress eagerly", async () => {
+    const { createCdpX402Client } = await import("./x402/client.js");
+
+    const result = await createCdpX402Client({
+      walletConfig: {
+        type: "eoa",
+        accountName: `x402-e2e-eager-${Date.now()}`,
+      },
+    });
+
+    expect(result.evmAddress).toMatch(/^0x[0-9a-fA-F]{40}$/);
+    expect(result.svmAddress).toBeTruthy();
+    expect(result.client).toBeDefined();
+    expect(result.cdpClient).toBeDefined();
+    expect(result.ownerWallet).toBeUndefined();
+  });
+
+  it("CdpX402Client RPC URL override is reflected in balance check config", async () => {
+    const { CdpX402Client } = await import("./x402/client.js");
+
+    const client = new CdpX402Client({
+      walletConfig: {
+        type: "eoa",
+        accountName: `x402-e2e-rpc-${Date.now()}`,
+      },
+      rpcUrls: {
+        "eip155:8453": { rpcUrl: "https://mainnet.base.org" },
+      },
+    });
+
+    // Initialization should succeed with the custom RPC URL
+    const evmAddress = await client.getEvmAddress();
+    expect(evmAddress).toMatch(/^0x[0-9a-fA-F]{40}$/);
+  });
+});
+
 function timeout(ms: number) {
   return new Promise((_, reject) =>
     setTimeout(() => reject(new TimeoutError(`Test took too long (${ms}ms)`)), ms),

--- a/typescript/packages/cdp-sdk/src/x402/__tests__/balance-check.test.ts
+++ b/typescript/packages/cdp-sdk/src/x402/__tests__/balance-check.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createBalanceCheckHook, InsufficientFundsError } from "../balance-check.js";
+import type { CdpClient } from "../../client/cdp.js";
+
+const USDC_BASE = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913";
+const EVM_ADDRESS = "0x1234567890123456789012345678901234567890" as `0x${string}`;
+const SVM_ADDRESS = "So11111111111111111111111111111111111111112";
+const BASE_NETWORK = "eip155:8453";
+const BASE_SEPOLIA_NETWORK = "eip155:84532";
+const SOLANA_NETWORK = "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp";
+
+function makeRequirements(overrides: Record<string, unknown> = {}) {
+  return {
+    scheme: "exact",
+    network: BASE_NETWORK,
+    asset: USDC_BASE,
+    amount: "1000000",
+    payTo: "0xrecipient",
+    ...overrides,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+function makeContext(req: unknown) {
+  return { selectedRequirements: req } as Parameters<ReturnType<typeof createBalanceCheckHook>>[0];
+}
+
+function makeCdpClient(evmBalance = 0n, svmBalance = 0n): CdpClient {
+  return {
+    evm: {
+      listTokenBalances: vi.fn().mockResolvedValue({
+        balances: [
+          {
+            token: { contractAddress: USDC_BASE },
+            amount: { amount: evmBalance },
+          },
+        ],
+        nextPageToken: undefined,
+      }),
+    },
+    solana: {
+      listTokenBalances: vi.fn().mockResolvedValue({
+        balances: [
+          {
+            token: { mintAddress: "SomeMint111" },
+            amount: { amount: svmBalance },
+          },
+        ],
+        nextPageToken: undefined,
+      }),
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any as CdpClient;
+}
+
+describe("InsufficientFundsError", () => {
+  it("has the correct code and message", () => {
+    const err = new InsufficientFundsError({
+      required: 1000n,
+      available: 500n,
+      asset: USDC_BASE,
+      network: BASE_NETWORK,
+      address: EVM_ADDRESS,
+    });
+    expect(err.code).toBe("insufficient_funds");
+    expect(err.name).toBe("InsufficientFundsError");
+    expect(err.required).toBe(1000n);
+    expect(err.available).toBe(500n);
+    expect(err.message).toContain("500");
+    expect(err.message).toContain("1000");
+  });
+});
+
+describe("createBalanceCheckHook", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("EVM (CDP indexed balance — Base / Base Sepolia)", () => {
+    it("passes through when balance is sufficient", async () => {
+      const cdpClient = makeCdpClient(2_000_000n);
+      const hook = createBalanceCheckHook({
+        cdpClient,
+        evmAddress: EVM_ADDRESS,
+        svmAddress: SVM_ADDRESS,
+      });
+      const ctx = makeContext(makeRequirements({ amount: "1000000", network: BASE_NETWORK }));
+      await expect(hook(ctx)).resolves.toBeUndefined();
+    });
+
+    it("throws InsufficientFundsError when balance is below required", async () => {
+      const cdpClient = makeCdpClient(500_000n);
+      const hook = createBalanceCheckHook({
+        cdpClient,
+        evmAddress: EVM_ADDRESS,
+        svmAddress: SVM_ADDRESS,
+      });
+      const ctx = makeContext(makeRequirements({ amount: "1000000", network: BASE_NETWORK }));
+      await expect(hook(ctx)).rejects.toThrow(InsufficientFundsError);
+    });
+
+    it("uses Base Sepolia network for eip155:84532", async () => {
+      const cdpClient = makeCdpClient(0n);
+      const hook = createBalanceCheckHook({
+        cdpClient,
+        evmAddress: EVM_ADDRESS,
+        svmAddress: SVM_ADDRESS,
+      });
+      const ctx = makeContext(makeRequirements({ amount: "1000", network: BASE_SEPOLIA_NETWORK }));
+      await expect(hook(ctx)).rejects.toThrow(InsufficientFundsError);
+      expect(
+        (cdpClient.evm.listTokenBalances as ReturnType<typeof vi.fn>).mock.calls[0][0],
+      ).toMatchObject({
+        network: "base-sepolia",
+      });
+    });
+
+    it("returns undefined when amount is 0", async () => {
+      const cdpClient = makeCdpClient(0n);
+      const hook = createBalanceCheckHook({
+        cdpClient,
+        evmAddress: EVM_ADDRESS,
+        svmAddress: SVM_ADDRESS,
+      });
+      const ctx = makeContext(makeRequirements({ amount: "0" }));
+      await expect(hook(ctx)).resolves.toBeUndefined();
+    });
+
+    it("returns undefined when amount field is missing", async () => {
+      const cdpClient = makeCdpClient(0n);
+      const hook = createBalanceCheckHook({
+        cdpClient,
+        evmAddress: EVM_ADDRESS,
+        svmAddress: SVM_ADDRESS,
+      });
+      const ctx = makeContext(makeRequirements({ amount: undefined }));
+      await expect(hook(ctx)).resolves.toBeUndefined();
+    });
+  });
+
+  describe("EVM (on-chain RPC fallback — custom network)", () => {
+    it("skips check for unknown network without custom RPC", async () => {
+      const cdpClient = makeCdpClient(0n);
+      const hook = createBalanceCheckHook({
+        cdpClient,
+        evmAddress: EVM_ADDRESS,
+        svmAddress: SVM_ADDRESS,
+      });
+      const ctx = makeContext(makeRequirements({ network: "eip155:999" }));
+      await expect(hook(ctx)).resolves.toBeUndefined();
+      expect(cdpClient.evm.listTokenBalances as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("SVM (Solana balance check)", () => {
+    const USDC_SOLANA = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+
+    it("throws InsufficientFundsError when Solana balance is zero", async () => {
+      const cdpClient = makeCdpClient(0n, 0n);
+      const hook = createBalanceCheckHook({
+        cdpClient,
+        evmAddress: EVM_ADDRESS,
+        svmAddress: SVM_ADDRESS,
+      });
+      const ctx = makeContext(
+        makeRequirements({ network: SOLANA_NETWORK, asset: USDC_SOLANA, amount: "1000" }),
+      );
+      await expect(hook(ctx)).rejects.toThrow(InsufficientFundsError);
+    });
+
+    it("passes when Solana balance is sufficient", async () => {
+      const cdpClientCustom: CdpClient = {
+        solana: {
+          listTokenBalances: vi.fn().mockResolvedValue({
+            balances: [
+              {
+                token: { mintAddress: USDC_SOLANA },
+                amount: { amount: 5000n },
+              },
+            ],
+            nextPageToken: undefined,
+          }),
+        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any as CdpClient;
+
+      const hook = createBalanceCheckHook({
+        cdpClient: cdpClientCustom,
+        evmAddress: EVM_ADDRESS,
+        svmAddress: SVM_ADDRESS,
+      });
+      const ctx = makeContext(
+        makeRequirements({ network: SOLANA_NETWORK, asset: USDC_SOLANA, amount: "1000" }),
+      );
+      await expect(hook(ctx)).resolves.toBeUndefined();
+    });
+  });
+
+  describe("error handling", () => {
+    it("skips check and warns when balance API throws", async () => {
+      const cdpClient: CdpClient = {
+        evm: {
+          listTokenBalances: vi.fn().mockRejectedValue(new Error("network error")),
+        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any as CdpClient;
+      const onWarning = vi.fn();
+      const hook = createBalanceCheckHook({
+        cdpClient,
+        evmAddress: EVM_ADDRESS,
+        svmAddress: SVM_ADDRESS,
+        onWarning,
+      });
+      const ctx = makeContext(makeRequirements());
+      await expect(hook(ctx)).resolves.toBeUndefined();
+      expect(onWarning).toHaveBeenCalledWith(
+        expect.stringContaining("Pre-flight balance check failed"),
+        expect.any(Error),
+      );
+    });
+
+    it("supports custom onWarning callback", async () => {
+      const cdpClient: CdpClient = {
+        evm: {
+          listTokenBalances: vi.fn().mockRejectedValue(new Error("oops")),
+        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any as CdpClient;
+      const warn = vi.fn();
+      const hook = createBalanceCheckHook({
+        cdpClient,
+        evmAddress: EVM_ADDRESS,
+        svmAddress: SVM_ADDRESS,
+        onWarning: warn,
+      });
+      const ctx = makeContext(makeRequirements());
+      await hook(ctx);
+      expect(warn).toHaveBeenCalled();
+    });
+  });
+
+  describe("RPC URL override", () => {
+    it("uses custom RPC URL from rpcUrls config for unknown EVM network", async () => {
+      const cdpClient = makeCdpClient(0n);
+      // Simulate a token not in CDP indexed networks: polygon (eip155:137)
+      // Since it's not base/base-sepolia, and we provide a custom RPC URL,
+      // it should attempt on-chain lookup instead. The ERC-20 lookup will fail
+      // without a real RPC, but a thrown error → skip (best-effort).
+      const onWarning = vi.fn();
+      const hook = createBalanceCheckHook({
+        cdpClient,
+        evmAddress: EVM_ADDRESS,
+        svmAddress: SVM_ADDRESS,
+        rpcUrls: {
+          "eip155:137": { rpcUrl: "https://polygon.fake.rpc" },
+        },
+        onWarning,
+      });
+      const ctx = makeContext(makeRequirements({ network: "eip155:137", asset: USDC_BASE }));
+      // The on-chain call will fail since it's a fake RPC — should skip gracefully
+      await expect(hook(ctx)).resolves.toBeUndefined();
+      expect(onWarning).toHaveBeenCalledWith(
+        expect.stringContaining("Pre-flight balance check failed"),
+        expect.anything(),
+      );
+    });
+  });
+});

--- a/typescript/packages/cdp-sdk/src/x402/__tests__/client.test.ts
+++ b/typescript/packages/cdp-sdk/src/x402/__tests__/client.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { MockedFunction } from "vitest";
+
+// ─── Mock @x402/core/client ───────────────────────────────────────────────────
+vi.mock("@x402/core/client", () => {
+  class MockX402Client {
+    private _beforeHooks: Array<(...args: unknown[]) => unknown> = [];
+    private _schemes: Map<string, unknown> = new Map();
+    register(network: string, scheme: unknown) {
+      this._schemes.set(network, scheme);
+      return this;
+    }
+    onBeforePaymentCreation(hook: (...args: unknown[]) => unknown) {
+      this._beforeHooks.push(hook);
+      return this;
+    }
+    async createPaymentPayload(paymentRequired: unknown) {
+      return { mockPayload: true, paymentRequired };
+    }
+  }
+  return { x402Client: MockX402Client };
+});
+
+// ─── Mock @x402/evm/exact/client ─────────────────────────────────────────────
+vi.mock("@x402/evm/exact/client", () => ({
+  registerExactEvmScheme: vi.fn().mockReturnValue(undefined),
+}));
+
+// ─── Mock @x402/evm/upto/client ──────────────────────────────────────────────
+vi.mock("@x402/evm/upto/client", () => ({
+  UptoEvmScheme: vi.fn().mockImplementation(() => ({ scheme: "upto" })),
+}));
+
+// ─── Mock @x402/svm/exact/client ─────────────────────────────────────────────
+vi.mock("@x402/svm/exact/client", () => ({
+  registerExactSvmScheme: vi.fn().mockReturnValue(undefined),
+}));
+
+// ─── Mock wallets provisioning ────────────────────────────────────────────────
+vi.mock("../wallets.js", () => ({
+  provisionCdpAccounts: vi.fn().mockResolvedValue({
+    cdpClient: { evm: {}, solana: {} },
+    evmAddress: "0xabc123" as `0x${string}`,
+    svmAddress: "SvmAddr123",
+    ownerWallet: undefined,
+    evmSigner: { address: "0xabc123", signTypedData: vi.fn() },
+    svmSigner: { address: "SvmAddr123", signTransactions: vi.fn() },
+  }),
+}));
+
+// ─── Mock balance check ───────────────────────────────────────────────────────
+vi.mock("../balance-check.js", () => ({
+  createBalanceCheckHook: vi.fn().mockReturnValue(vi.fn().mockResolvedValue(undefined)),
+}));
+
+import { CdpX402Client, createCdpX402Client } from "../client.js";
+import { provisionCdpAccounts } from "../wallets.js";
+import { createBalanceCheckHook } from "../balance-check.js";
+import { registerExactEvmScheme } from "@x402/evm/exact/client";
+import { registerExactSvmScheme } from "@x402/svm/exact/client";
+import { UptoEvmScheme } from "@x402/evm/upto/client";
+
+const mockedProvision = provisionCdpAccounts as MockedFunction<typeof provisionCdpAccounts>;
+const mockedBalanceCheck = createBalanceCheckHook as MockedFunction<typeof createBalanceCheckHook>;
+const mockedRegisterEvm = registerExactEvmScheme as MockedFunction<typeof registerExactEvmScheme>;
+const mockedRegisterSvm = registerExactSvmScheme as MockedFunction<typeof registerExactSvmScheme>;
+const MockedUptoScheme = UptoEvmScheme as unknown as MockedFunction<typeof UptoEvmScheme>;
+
+describe("CdpX402Client", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = {
+      ...originalEnv,
+      CDP_API_KEY_ID: "test-key-id",
+      CDP_API_KEY_SECRET: "test-key-secret",
+      CDP_WALLET_SECRET: "test-wallet-secret",
+    };
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe("constructor config", () => {
+    it("creates a CdpX402Client instance without throwing", () => {
+      expect(() => new CdpX402Client()).not.toThrow();
+    });
+
+    it("accepts explicit config", () => {
+      expect(
+        () =>
+          new CdpX402Client({
+            apiKeyId: "id",
+            apiKeySecret: "secret",
+            walletSecret: "wallet",
+          }),
+      ).not.toThrow();
+    });
+
+    it("does not provision accounts at construction time", () => {
+      new CdpX402Client();
+      expect(mockedProvision).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("lazy initialization", () => {
+    it("provisions accounts on first createPaymentPayload call", async () => {
+      const client = new CdpX402Client();
+      await client.createPaymentPayload({ scheme: "exact", network: "eip155:8453" } as never);
+      expect(mockedProvision).toHaveBeenCalledOnce();
+    });
+
+    it("provisions accounts only once for multiple createPaymentPayload calls", async () => {
+      const client = new CdpX402Client();
+      const req = { scheme: "exact", network: "eip155:8453" } as never;
+      await client.createPaymentPayload(req);
+      await client.createPaymentPayload(req);
+      await client.createPaymentPayload(req);
+      expect(mockedProvision).toHaveBeenCalledOnce();
+    });
+
+    it("retries provisioning after a transient failure", async () => {
+      mockedProvision.mockRejectedValueOnce(new Error("transient error")).mockResolvedValueOnce({
+        cdpClient: {},
+        evmAddress: "0xretry" as `0x${string}`,
+        svmAddress: "SvmRetry",
+        ownerWallet: undefined,
+        evmSigner: { address: "0xretry", signTypedData: vi.fn() },
+        svmSigner: { address: "SvmRetry", signTransactions: vi.fn() },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+
+      const client = new CdpX402Client();
+      const req = { scheme: "exact", network: "eip155:8453" } as never;
+
+      await expect(client.createPaymentPayload(req)).rejects.toThrow("transient error");
+      await expect(client.createPaymentPayload(req)).resolves.toBeDefined();
+      expect(mockedProvision).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("payment signing path", () => {
+    it("registers EVM and SVM schemes after initialization", async () => {
+      const client = new CdpX402Client();
+      await client.createPaymentPayload({ scheme: "exact", network: "eip155:8453" } as never);
+      expect(mockedRegisterEvm).toHaveBeenCalledOnce();
+      expect(mockedRegisterSvm).toHaveBeenCalledOnce();
+      expect(MockedUptoScheme).toHaveBeenCalledOnce();
+    });
+
+    it("wires the balance check hook by default", async () => {
+      const client = new CdpX402Client();
+      await client.createPaymentPayload({ scheme: "exact", network: "eip155:8453" } as never);
+      expect(mockedBalanceCheck).toHaveBeenCalledOnce();
+    });
+
+    it("skips balance check when disablePreflightBalanceCheck is true", async () => {
+      const client = new CdpX402Client({ disablePreflightBalanceCheck: true });
+      await client.createPaymentPayload({ scheme: "exact", network: "eip155:8453" } as never);
+      expect(mockedBalanceCheck).not.toHaveBeenCalled();
+    });
+
+    it("skips balance check when CDP_DISABLE_PREFLIGHT_BALANCE_CHECK=true", async () => {
+      process.env.CDP_DISABLE_PREFLIGHT_BALANCE_CHECK = "true";
+      const client = new CdpX402Client();
+      await client.createPaymentPayload({ scheme: "exact", network: "eip155:8453" } as never);
+      expect(mockedBalanceCheck).not.toHaveBeenCalled();
+      delete process.env.CDP_DISABLE_PREFLIGHT_BALANCE_CHECK;
+    });
+  });
+
+  describe("getEvmAddress", () => {
+    it("triggers initialization and returns the EVM address", async () => {
+      const client = new CdpX402Client();
+      const address = await client.getEvmAddress();
+      expect(address).toBe("0xabc123");
+    });
+
+    it("does not re-initialize on second call", async () => {
+      const client = new CdpX402Client();
+      await client.getEvmAddress();
+      await client.getEvmAddress();
+      expect(mockedProvision).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("getSvmAddress", () => {
+    it("triggers initialization and returns the SVM address", async () => {
+      const client = new CdpX402Client();
+      const address = await client.getSvmAddress();
+      expect(address).toBe("SvmAddr123");
+    });
+  });
+
+  describe("RPC URL override behavior", () => {
+    it("passes explicit rpcUrls config to balance check hook", async () => {
+      const rpcUrls = { "eip155:137": { rpcUrl: "https://polygon.rpc" } };
+      const client = new CdpX402Client({ rpcUrls });
+      await client.createPaymentPayload({ scheme: "exact", network: "eip155:8453" } as never);
+      expect(mockedBalanceCheck).toHaveBeenCalledWith(
+        expect.objectContaining({ rpcUrls: expect.objectContaining(rpcUrls) }),
+      );
+    });
+
+    it("merges env-var rpcUrls with explicit config (explicit wins)", async () => {
+      process.env.CDP_X402_RPC_URLS = JSON.stringify({
+        "eip155:8453": "https://env-base.rpc",
+        "eip155:137": "https://env-polygon.rpc",
+      });
+      const rpcUrls = { "eip155:8453": { rpcUrl: "https://config-base.rpc" } };
+      const client = new CdpX402Client({ rpcUrls });
+      await client.createPaymentPayload({ scheme: "exact", network: "eip155:8453" } as never);
+      expect(mockedBalanceCheck).toHaveBeenCalledWith(
+        expect.objectContaining({
+          rpcUrls: expect.objectContaining({
+            "eip155:8453": { rpcUrl: "https://config-base.rpc" }, // explicit wins
+            "eip155:137": { rpcUrl: "https://env-polygon.rpc" }, // env fills the rest
+          }),
+        }),
+      );
+      delete process.env.CDP_X402_RPC_URLS;
+    });
+  });
+});
+
+describe("createCdpX402Client", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = {
+      ...originalEnv,
+      CDP_API_KEY_ID: "test-key-id",
+      CDP_API_KEY_SECRET: "test-key-secret",
+      CDP_WALLET_SECRET: "test-wallet-secret",
+    };
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("returns a result with evmAddress, svmAddress, and client", async () => {
+    const result = await createCdpX402Client();
+    expect(result.evmAddress).toBe("0xabc123");
+    expect(result.svmAddress).toBe("SvmAddr123");
+    expect(result.client).toBeDefined();
+    expect(result.cdpClient).toBeDefined();
+  });
+
+  it("provisions accounts eagerly on call", async () => {
+    await createCdpX402Client();
+    expect(mockedProvision).toHaveBeenCalledOnce();
+  });
+
+  it("accepts optional config", async () => {
+    await createCdpX402Client({
+      apiKeyId: "id",
+      apiKeySecret: "secret",
+      walletSecret: "wallet",
+    });
+    expect(mockedProvision).toHaveBeenCalledOnce();
+  });
+});

--- a/typescript/packages/cdp-sdk/src/x402/__tests__/credentials.test.ts
+++ b/typescript/packages/cdp-sdk/src/x402/__tests__/credentials.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { resolveCredentials, resolveWalletConfig, parseRpcUrlsFromEnv } from "../credentials.js";
+import type { CdpX402ClientConfig } from "../credentials.js";
+
+describe("resolveCredentials", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.CDP_API_KEY_ID;
+    delete process.env.CDP_API_KEY_SECRET;
+    delete process.env.CDP_WALLET_SECRET;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("returns credentials from explicit config", () => {
+    const config: CdpX402ClientConfig = {
+      apiKeyId: "key-id",
+      apiKeySecret: "key-secret",
+      walletSecret: "wallet-secret",
+    };
+    const result = resolveCredentials(config);
+    expect(result).toEqual({
+      apiKeyId: "key-id",
+      apiKeySecret: "key-secret",
+      walletSecret: "wallet-secret",
+    });
+  });
+
+  it("falls back to environment variables when config fields are absent", () => {
+    process.env.CDP_API_KEY_ID = "env-key-id";
+    process.env.CDP_API_KEY_SECRET = "env-key-secret";
+    process.env.CDP_WALLET_SECRET = "env-wallet-secret";
+
+    const result = resolveCredentials(undefined);
+    expect(result).toEqual({
+      apiKeyId: "env-key-id",
+      apiKeySecret: "env-key-secret",
+      walletSecret: "env-wallet-secret",
+    });
+  });
+
+  it("explicit config takes precedence over environment variables", () => {
+    process.env.CDP_API_KEY_ID = "env-key-id";
+    process.env.CDP_API_KEY_SECRET = "env-key-secret";
+    process.env.CDP_WALLET_SECRET = "env-wallet-secret";
+
+    const config: CdpX402ClientConfig = {
+      apiKeyId: "config-key-id",
+      apiKeySecret: "config-key-secret",
+      walletSecret: "config-wallet-secret",
+    };
+    const result = resolveCredentials(config);
+    expect(result.apiKeyId).toBe("config-key-id");
+    expect(result.apiKeySecret).toBe("config-key-secret");
+    expect(result.walletSecret).toBe("config-wallet-secret");
+  });
+
+  it("throws when CDP_API_KEY_ID is missing", () => {
+    process.env.CDP_API_KEY_SECRET = "secret";
+    process.env.CDP_WALLET_SECRET = "wallet";
+    expect(() => resolveCredentials(undefined)).toThrow("CDP_API_KEY_ID");
+  });
+
+  it("throws when CDP_API_KEY_SECRET is missing", () => {
+    process.env.CDP_API_KEY_ID = "id";
+    process.env.CDP_WALLET_SECRET = "wallet";
+    expect(() => resolveCredentials(undefined)).toThrow("CDP_API_KEY_SECRET");
+  });
+
+  it("throws when CDP_WALLET_SECRET is missing", () => {
+    process.env.CDP_API_KEY_ID = "id";
+    process.env.CDP_API_KEY_SECRET = "secret";
+    expect(() => resolveCredentials(undefined)).toThrow("CDP_WALLET_SECRET");
+  });
+
+  it("lists all missing credentials in the error message", () => {
+    expect(() => resolveCredentials(undefined)).toThrow(
+      /CDP_API_KEY_ID.*CDP_API_KEY_SECRET.*CDP_WALLET_SECRET/,
+    );
+  });
+});
+
+describe("resolveWalletConfig", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.CDP_WALLET_TYPE;
+    delete process.env.CDP_ACCOUNT_NAME;
+    delete process.env.CDP_OWNER_ACCOUNT_NAME;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("defaults to eoa type with default account name", () => {
+    const result = resolveWalletConfig(undefined);
+    expect(result.type).toBe("eoa");
+    expect(result.accountName).toBe("x402-client-wallet-1");
+    expect(result.ownerAccountName).toBeUndefined();
+  });
+
+  it("uses CDP_ACCOUNT_NAME env var when accountName is absent", () => {
+    process.env.CDP_ACCOUNT_NAME = "my-account";
+    const result = resolveWalletConfig(undefined);
+    expect(result.accountName).toBe("my-account");
+  });
+
+  it("resolves eoa config", () => {
+    const result = resolveWalletConfig({ type: "eoa", accountName: "payer" });
+    expect(result).toEqual({ type: "eoa", accountName: "payer", ownerAccountName: undefined });
+  });
+
+  it("resolves smart config with explicit ownerAccountName", () => {
+    const result = resolveWalletConfig({
+      type: "smart",
+      accountName: "my-scw",
+      ownerAccountName: "my-owner",
+    });
+    expect(result).toEqual({ type: "smart", accountName: "my-scw", ownerAccountName: "my-owner" });
+  });
+
+  it("resolves smart config with ownerAccountName from env", () => {
+    process.env.CDP_OWNER_ACCOUNT_NAME = "env-owner";
+    const result = resolveWalletConfig({ type: "smart", ownerAccountName: "env-owner" });
+    expect(result.ownerAccountName).toBe("env-owner");
+  });
+
+  it("throws for smart type without ownerAccountName", () => {
+    expect(() =>
+      resolveWalletConfig({ type: "smart", ownerAccountName: undefined as unknown as string }),
+    ).toThrow("ownerAccountName");
+  });
+
+  it("reads wallet type from CDP_WALLET_TYPE env var", () => {
+    process.env.CDP_WALLET_TYPE = "eoa";
+    const result = resolveWalletConfig(undefined);
+    expect(result.type).toBe("eoa");
+  });
+
+  it("throws for unsupported wallet type", () => {
+    process.env.CDP_WALLET_TYPE = "invalid-type";
+    expect(() => resolveWalletConfig(undefined)).toThrow('Unsupported wallet type "invalid-type"');
+  });
+});
+
+describe("parseRpcUrlsFromEnv", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.CDP_X402_RPC_URLS;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("returns undefined when CDP_X402_RPC_URLS is not set", () => {
+    expect(parseRpcUrlsFromEnv()).toBeUndefined();
+  });
+
+  it("parses valid JSON object", () => {
+    process.env.CDP_X402_RPC_URLS = JSON.stringify({
+      "eip155:8453": "https://mainnet.base.org",
+    });
+    const result = parseRpcUrlsFromEnv();
+    expect(result).toEqual({ "eip155:8453": { rpcUrl: "https://mainnet.base.org" } });
+  });
+
+  it("parses multiple networks", () => {
+    process.env.CDP_X402_RPC_URLS = JSON.stringify({
+      "eip155:8453": "https://base.rpc",
+      "eip155:84532": "https://sepolia.rpc",
+    });
+    const result = parseRpcUrlsFromEnv();
+    expect(result).toEqual({
+      "eip155:8453": { rpcUrl: "https://base.rpc" },
+      "eip155:84532": { rpcUrl: "https://sepolia.rpc" },
+    });
+  });
+
+  it("throws for invalid JSON", () => {
+    process.env.CDP_X402_RPC_URLS = "not-json";
+    expect(() => parseRpcUrlsFromEnv()).toThrow("CDP_X402_RPC_URLS must be valid JSON");
+  });
+
+  it("throws for JSON array", () => {
+    process.env.CDP_X402_RPC_URLS = "[]";
+    expect(() => parseRpcUrlsFromEnv()).toThrow("CDP_X402_RPC_URLS must be a JSON object");
+  });
+
+  it("throws when a value is not a string URL", () => {
+    process.env.CDP_X402_RPC_URLS = JSON.stringify({ "eip155:8453": 42 });
+    expect(() => parseRpcUrlsFromEnv()).toThrow('value for "eip155:8453" must be a string URL');
+  });
+});

--- a/typescript/packages/cdp-sdk/src/x402/balance-check.ts
+++ b/typescript/packages/cdp-sdk/src/x402/balance-check.ts
@@ -1,0 +1,320 @@
+/*
+ * Client-side pre-flight balance check.
+ *
+ * Wires a BeforePaymentCreationHook that queries the configured CDP wallet's
+ * token balance for the requested asset/network and fails fast with a clear
+ * InsufficientFundsError when the balance is below the amount the server is
+ * asking for. Balance lookup is best-effort and silently skipped on unsupported
+ * networks, missing tokens, or API failures.
+ */
+import { createPublicClient, http } from "viem";
+
+import {
+  CDP_EVM_RPC_URLS,
+  baseMainnetCaip2,
+  baseSepoliaCaip2,
+  solanaDevnetCaip2,
+  solanaMainnetCaip2,
+} from "./constants.js";
+
+import type { CdpClient } from "../client/cdp.js";
+import type { BeforePaymentCreationHook } from "@x402/core/client";
+import type { PaymentRequirements } from "@x402/core/types";
+
+/** CAIP-2 → CDP indexed balance API network slug for CDP-supported EVM networks. */
+const CAIP_TO_CDP_EVM_BALANCE_NETWORK: Record<string, "base" | "base-sepolia"> = {
+  [baseMainnetCaip2]: "base",
+  [baseSepoliaCaip2]: "base-sepolia",
+};
+
+/** Minimal ERC-20 ABI fragment for `balanceOf`. */
+const ERC20_BALANCE_OF_ABI = [
+  {
+    name: "balanceOf",
+    type: "function",
+    inputs: [{ name: "owner", type: "address" }],
+    outputs: [{ name: "", type: "uint256" }],
+    stateMutability: "view",
+  },
+] as const;
+
+/** CAIP-2 → CDP Solana balance API network. */
+const CAIP_TO_CDP_SVM_BALANCE_NETWORK: Record<string, "solana" | "solana-devnet"> = {
+  [solanaMainnetCaip2]: "solana",
+  [solanaDevnetCaip2]: "solana-devnet",
+};
+
+/**
+ * Thrown when the configured wallet's balance is below the amount required by
+ * the server's `PaymentRequirements`.
+ */
+export class InsufficientFundsError extends Error {
+  readonly code = "insufficient_funds" as const;
+  readonly required: bigint;
+  readonly available: bigint;
+  readonly asset: string;
+  readonly network: string;
+  readonly address: string;
+
+  /**
+   * Constructs an InsufficientFundsError.
+   *
+   * @param params - Error context.
+   * @param params.required - Required amount in atomic units.
+   * @param params.available - Available amount in atomic units.
+   * @param params.asset - Asset identifier (contract address or mint).
+   * @param params.network - CAIP-2 network identifier.
+   * @param params.address - Wallet address being checked.
+   */
+  constructor(params: {
+    required: bigint;
+    available: bigint;
+    asset: string;
+    network: string;
+    address: string;
+  }) {
+    super(
+      `Insufficient funds for x402 payment: wallet ${params.address} on ${params.network} has ` +
+        `${params.available} of asset ${params.asset}, but ${params.required} is required.`,
+    );
+    this.name = "InsufficientFundsError";
+    this.required = params.required;
+    this.available = params.available;
+    this.asset = params.asset;
+    this.network = params.network;
+    this.address = params.address;
+  }
+}
+
+interface BalanceCheckOptions {
+  cdpClient: CdpClient;
+  evmAddress: `0x${string}`;
+  svmAddress: string;
+  /**
+   * Optional warning sink for skipped-check diagnostics. Defaults to
+   * `console.warn`. Pass a no-op to silence completely.
+   */
+  onWarning?: (message: string, cause?: unknown) => void;
+  /**
+   * Override the public JSON-RPC endpoints used for on-chain balance lookups,
+   * keyed by CAIP-2 network identifier. Merged over the built-in
+   * `CDP_EVM_RPC_URLS` defaults.
+   */
+  rpcUrls?: Partial<Record<string, { rpcUrl: string }>>;
+}
+
+const defaultWarning = (message: string, cause?: unknown): void => {
+  if (cause === undefined)
+    // eslint-disable-next-line no-console
+    console.warn(`[@coinbase/cdp-sdk/x402] ${message}`);
+  // eslint-disable-next-line no-console
+  else console.warn(`[@coinbase/cdp-sdk/x402] ${message}`, cause);
+};
+
+/**
+ * Parses the atomic amount from a payment requirements object.
+ *
+ * Handles both v1 (`maxAmountRequired`) and v2+ (`amount`) wire formats.
+ * Returns `undefined` when the field is absent or not parseable as a BigInt.
+ *
+ * @param req - Payment requirements from the server.
+ * @returns The required amount in atomic units, or `undefined` if unparseable.
+ */
+function tryParseAtomicFromRequirement(req: PaymentRequirements): bigint | undefined {
+  const raw =
+    "amount" in req && req.amount !== undefined
+      ? req.amount
+      : (req as unknown as { maxAmountRequired?: string }).maxAmountRequired;
+  if (raw === undefined || raw === null) return undefined;
+  try {
+    const parsed = BigInt(raw as string);
+    return parsed < 0n ? undefined : parsed;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Normalizes an EVM asset identifier for comparisons.
+ * EVM contract addresses (`0x` + 40 hex chars) are lower-cased.
+ *
+ * @param asset - Raw asset identifier string.
+ * @returns Lower-cased EVM address, or the original string for non-EVM assets.
+ */
+function normalizeAsset(asset: string): string {
+  const trimmed = asset.trim();
+  if (/^0x[0-9a-fA-F]{40}$/.test(trimmed)) {
+    return trimmed.toLowerCase();
+  }
+  return trimmed;
+}
+
+/**
+ * Builds a `BeforePaymentCreationHook` that performs a pre-flight balance check
+ * against the configured CDP wallet.
+ *
+ * The hook is intentionally lenient: any condition under which the check
+ * cannot be performed (unsupported network, missing token, API error) is
+ * treated as a pass so we never block legitimate payments on pre-check noise.
+ *
+ * @param opts - Options including CDP client, wallet addresses, and RPC overrides.
+ * @returns A hook that throws `InsufficientFundsError` when the balance is too low.
+ */
+export function createBalanceCheckHook(opts: BalanceCheckOptions): BeforePaymentCreationHook {
+  const { cdpClient, evmAddress, svmAddress } = opts;
+  const warn = opts.onWarning ?? defaultWarning;
+  const rpcUrls: Record<string, { rpcUrl: string }> = opts.rpcUrls
+    ? ({ ...CDP_EVM_RPC_URLS, ...opts.rpcUrls } as Record<string, { rpcUrl: string }>)
+    : CDP_EVM_RPC_URLS;
+
+  return async context => {
+    const req = context.selectedRequirements;
+    const required = tryParseAtomicFromRequirement(req);
+    if (required === undefined) return undefined;
+    if (required === 0n) return undefined;
+
+    const normalizedAsset = normalizeAsset(req.asset);
+
+    const evmNetwork = CAIP_TO_CDP_EVM_BALANCE_NETWORK[req.network];
+    const evmRpcUrl = rpcUrls[req.network]?.rpcUrl;
+    const svmNetwork = CAIP_TO_CDP_SVM_BALANCE_NETWORK[req.network];
+
+    let available: bigint;
+    let address: string;
+
+    const assetLabel = svmNetwork ? req.asset : normalizedAsset;
+
+    try {
+      if (evmNetwork) {
+        address = evmAddress;
+        available = await getEvmBalance(cdpClient, {
+          address: evmAddress,
+          network: evmNetwork,
+          asset: normalizedAsset,
+        });
+      } else if (evmRpcUrl) {
+        if (!normalizedAsset.startsWith("0x")) return undefined;
+        address = evmAddress;
+        available = await readOnChainErc20Balance(
+          evmRpcUrl,
+          normalizedAsset as `0x${string}`,
+          evmAddress,
+        );
+      } else if (svmNetwork) {
+        address = svmAddress;
+        available = await getSvmBalance(cdpClient, {
+          address: svmAddress,
+          network: svmNetwork,
+          asset: req.asset,
+        });
+      } else {
+        return undefined;
+      }
+    } catch (error) {
+      warn(
+        `Pre-flight balance check failed for ${req.network} (${assetLabel}); ` +
+          "proceeding without check.",
+        error,
+      );
+      return undefined;
+    }
+
+    if (available >= required) return undefined;
+
+    throw new InsufficientFundsError({
+      required,
+      available,
+      asset: req.asset,
+      network: req.network,
+      address,
+    });
+  };
+}
+
+/**
+ * Reads the ERC-20 `balanceOf` for `walletAddress` directly on-chain via the
+ * supplied public JSON-RPC endpoint. Used for EVM networks not covered by the
+ * CDP indexed token-balance API.
+ *
+ * @param rpcUrl - Public JSON-RPC URL for the target network.
+ * @param contractAddress - ERC-20 contract address to query.
+ * @param walletAddress - Wallet address to check balance for.
+ * @returns The balance in atomic (wei) units.
+ */
+async function readOnChainErc20Balance(
+  rpcUrl: string,
+  contractAddress: `0x${string}`,
+  walletAddress: `0x${string}`,
+): Promise<bigint> {
+  const client = createPublicClient({ transport: http(rpcUrl) });
+  return client.readContract({
+    address: contractAddress,
+    abi: ERC20_BALANCE_OF_ABI,
+    functionName: "balanceOf",
+    args: [walletAddress],
+  });
+}
+
+/**
+ * Returns the balance (in atomic units) of `params.asset` held by
+ * `params.address` on the CDP indexed balance API, or `0n` when absent.
+ *
+ * @param cdpClient - Configured CDP client.
+ * @param params - Query parameters.
+ * @param params.address - EVM wallet address.
+ * @param params.network - CDP network slug (`"base"` or `"base-sepolia"`).
+ * @param params.asset - Normalized ERC-20 contract address.
+ * @returns Balance in atomic units, or `0n` if the asset is not found.
+ */
+async function getEvmBalance(
+  cdpClient: CdpClient,
+  params: { address: `0x${string}`; network: "base" | "base-sepolia"; asset: string },
+): Promise<bigint> {
+  let pageToken: string | undefined;
+  do {
+    const page = await cdpClient.evm.listTokenBalances({
+      address: params.address,
+      network: params.network,
+      pageToken,
+    });
+    for (const entry of page.balances) {
+      if (normalizeAsset(entry.token.contractAddress) === params.asset) {
+        return entry.amount.amount;
+      }
+    }
+    pageToken = page.nextPageToken;
+  } while (pageToken);
+  return 0n;
+}
+
+/**
+ * Returns the balance (in atomic units) of `params.asset` held by
+ * `params.address` on Solana, or `0n` when absent.
+ *
+ * @param cdpClient - Configured CDP client.
+ * @param params - Query parameters.
+ * @param params.address - Solana wallet address.
+ * @param params.network - CDP Solana network slug.
+ * @param params.asset - SPL token mint address.
+ * @returns Balance in atomic units, or `0n` if the asset is not found.
+ */
+async function getSvmBalance(
+  cdpClient: CdpClient,
+  params: { address: string; network: "solana" | "solana-devnet"; asset: string },
+): Promise<bigint> {
+  let pageToken: string | undefined;
+  do {
+    const page = await cdpClient.solana.listTokenBalances({
+      address: params.address,
+      network: params.network,
+      pageToken,
+    });
+    for (const entry of page.balances) {
+      if (entry.token.mintAddress === params.asset) {
+        return entry.amount.amount;
+      }
+    }
+    pageToken = page.nextPageToken;
+  } while (pageToken);
+  return 0n;
+}

--- a/typescript/packages/cdp-sdk/src/x402/client.ts
+++ b/typescript/packages/cdp-sdk/src/x402/client.ts
@@ -1,0 +1,230 @@
+/*
+ * CDP-powered x402 payment client.
+ *
+ * Provides a streamlined setup experience for making paid HTTP requests
+ * using CDP wallets (Server Wallets or Smart Contract Wallets) and the CDP
+ * hosted facilitator.
+ */
+import { x402Client } from "@x402/core/client";
+import { registerExactEvmScheme } from "@x402/evm/exact/client";
+import { UptoEvmScheme } from "@x402/evm/upto/client";
+import { registerExactSvmScheme } from "@x402/svm/exact/client";
+
+import { createBalanceCheckHook } from "./balance-check.js";
+import { CDP_EVM_RPC_URLS } from "./constants.js";
+import { parseRpcUrlsFromEnv, resolveWalletConfig } from "./credentials.js";
+import { provisionCdpAccounts } from "./wallets.js";
+
+import type { CdpX402ClientConfig } from "./credentials.js";
+import type { CdpClient } from "../client/cdp.js";
+import type { Network, PaymentPayload, PaymentRequired } from "@x402/core/types";
+
+/**
+ * Result from eagerly creating a CDP x402 client.
+ */
+export interface CdpX402ClientResult {
+  /** Configured `x402Client` with EVM and SVM schemes registered. */
+  client: x402Client;
+  /** The underlying `CdpClient` instance for direct CDP API access. */
+  cdpClient: CdpClient;
+  /** The EVM address used for payments. */
+  evmAddress: `0x${string}`;
+  /** The Solana account address. */
+  svmAddress: string;
+  /**
+   * The owner account name. Only set when `walletConfig.type` is `"smart"`.
+   * The owner signs EIP-712 typed data on behalf of the smart account.
+   */
+  ownerWallet?: string;
+}
+
+type CdpSignerSetup = {
+  cdpClient: CdpClient;
+  evmAddress: `0x${string}`;
+  svmAddress: string;
+  ownerWallet?: string;
+};
+
+/**
+ * Provisions CDP accounts, registers EVM and SVM signers on the given client,
+ * and wires the pre-flight balance check hook.
+ *
+ * @param client - The x402Client to register schemes on.
+ * @param config - Optional credential and wallet configuration.
+ * @returns Resolved signer setup with addresses and CDP client.
+ */
+async function setupCdpSigners(
+  client: x402Client,
+  config: CdpX402ClientConfig | undefined,
+): Promise<CdpSignerSetup> {
+  const walletConfig = resolveWalletConfig(config?.walletConfig);
+  const { cdpClient, evmAddress, svmAddress, ownerWallet, evmSigner, svmSigner } =
+    await provisionCdpAccounts(config, walletConfig);
+
+  // Explicit config takes precedence over env var; both are merged over defaults.
+  const resolvedRpcUrls = { ...parseRpcUrlsFromEnv(), ...config?.rpcUrls };
+  const mergedRpcUrls: Record<string, { rpcUrl: string }> = {
+    ...CDP_EVM_RPC_URLS,
+    ...resolvedRpcUrls,
+  } as Record<string, { rpcUrl: string }>;
+
+  /*
+   * UptoEvmScheme expects RPC URLs keyed by numeric EIP-155 chain ID.
+   * Convert from our CAIP-2-keyed map before passing.
+   */
+  const uptoRpcUrls: Record<number, { rpcUrl: string }> = {};
+  for (const [caip2, cfg] of Object.entries(mergedRpcUrls)) {
+    const [namespace, chainId] = caip2.split(":");
+    if (namespace === "eip155" && chainId) uptoRpcUrls[Number(chainId)] = cfg;
+  }
+
+  registerExactEvmScheme(client, { signer: evmSigner });
+  registerExactSvmScheme(client, { signer: svmSigner });
+  client.register("eip155:*" as Network, new UptoEvmScheme(evmSigner, uptoRpcUrls));
+
+  /*
+   * Register the balance pre-check before any other hook so it short-circuits
+   * payment creation when the wallet lacks sufficient funds.
+   */
+  const disablePreflightBalanceCheck =
+    config?.disablePreflightBalanceCheck ??
+    process.env.CDP_DISABLE_PREFLIGHT_BALANCE_CHECK === "true";
+  if (!disablePreflightBalanceCheck) {
+    client.onBeforePaymentCreation(
+      createBalanceCheckHook({
+        cdpClient,
+        evmAddress,
+        svmAddress,
+        rpcUrls: resolvedRpcUrls,
+      }),
+    );
+  }
+
+  return { cdpClient, evmAddress, svmAddress, ownerWallet };
+}
+
+/**
+ * A Coinbase CDP-powered x402 client that initializes lazily on first payment.
+ *
+ * Extends `x402Client` with automatic wallet provisioning and scheme registration.
+ * All configuration is read from environment variables by default and can be
+ * overridden via explicit config. Wallet setup is deferred to the first
+ * `createPaymentPayload` call, keeping construction synchronous and cheap.
+ *
+ * Wallet type is controlled by `walletConfig.type` (or `CDP_WALLET_TYPE` env var):
+ * - `"eoa"` (default): CDP Server Wallet
+ * - `"smart"`: CDP Smart Contract Wallet
+ *
+ * @example
+ * ```typescript
+ * import { CdpX402Client } from "@coinbase/cdp-sdk/x402";
+ * import { wrapFetchWithPayment } from "@x402/fetch";
+ *
+ * const client = new CdpX402Client();
+ * const fetchWithPayment = wrapFetchWithPayment(fetch, client);
+ * const response = await fetchWithPayment("https://api.example.com/paid");
+ * ```
+ */
+export class CdpX402Client extends x402Client {
+  private readonly _config: CdpX402ClientConfig | undefined;
+  private _initPromise: Promise<CdpSignerSetup> | null = null;
+
+  /**
+   * Constructs a CdpX402Client. Construction is synchronous — CDP accounts are
+   * provisioned lazily on the first `createPaymentPayload` or `getEvmAddress` call.
+   *
+   * @param config - Optional configuration. All fields fall back to environment variables.
+   */
+  constructor(config?: CdpX402ClientConfig) {
+    super();
+    this._config = config;
+  }
+
+  /**
+   * Creates a signed payment payload for the given requirements.
+   *
+   * Triggers lazy initialization on first call, then delegates to the parent
+   * `x402Client.createPaymentPayload` implementation.
+   *
+   * @param paymentRequired - Payment requirements from the server's 402 response.
+   * @returns A signed payment payload ready to be sent to the server.
+   */
+  override async createPaymentPayload(paymentRequired: PaymentRequired): Promise<PaymentPayload> {
+    await this._ensureInitialized();
+    return super.createPaymentPayload(paymentRequired);
+  }
+
+  /**
+   * Returns the EVM address of the provisioned CDP wallet.
+   *
+   * Triggers lazy initialization on first call. Subsequent calls return
+   * immediately once initialization is complete.
+   *
+   * @returns The EVM address (EOA or smart contract wallet address).
+   */
+  async getEvmAddress(): Promise<`0x${string}`> {
+    const setup = await this._ensureInitialized();
+    return setup.evmAddress;
+  }
+
+  /**
+   * Returns the Solana address of the provisioned CDP wallet.
+   *
+   * Triggers lazy initialization on first call.
+   *
+   * @returns The Solana account address.
+   */
+  async getSvmAddress(): Promise<string> {
+    const setup = await this._ensureInitialized();
+    return setup.svmAddress;
+  }
+
+  /**
+   * Returns the initialization promise, creating it on first call.
+   *
+   * Resets on failure so subsequent calls can retry after transient errors.
+   *
+   * @returns Promise that resolves to the initialized signer setup.
+   */
+  private _ensureInitialized(): Promise<CdpSignerSetup> {
+    if (!this._initPromise) {
+      this._initPromise = setupCdpSigners(this, this._config).catch(error => {
+        // Reset so the next call can retry after a transient failure.
+        this._initPromise = null;
+        throw error;
+      });
+    }
+    return this._initPromise;
+  }
+}
+
+/**
+ * Creates a fully configured CDP x402 client, eagerly provisioning wallets.
+ *
+ * Use this when you need the wallet address(es) before making any payments
+ * (e.g. to fund the wallet first). For most use cases, prefer `CdpX402Client`
+ * which defers initialization to the first payment.
+ *
+ * @param config - Optional configuration. All fields fall back to env vars.
+ * @returns A configured client plus wallet addresses.
+ *
+ * @example
+ * ```typescript
+ * const { client, evmAddress } = await createCdpX402Client();
+ * console.log("Paying from:", evmAddress);
+ * ```
+ */
+export async function createCdpX402Client(
+  config?: CdpX402ClientConfig,
+): Promise<CdpX402ClientResult> {
+  const client = new x402Client();
+  const { cdpClient, evmAddress, svmAddress, ownerWallet } = await setupCdpSigners(client, config);
+
+  return {
+    client,
+    cdpClient,
+    evmAddress,
+    svmAddress,
+    ownerWallet,
+  };
+}

--- a/typescript/packages/cdp-sdk/src/x402/constants.ts
+++ b/typescript/packages/cdp-sdk/src/x402/constants.ts
@@ -1,0 +1,42 @@
+/* Network and RPC constants for the CDP x402 client. */
+
+/** CAIP-2 network identifiers for CDP-supported chains. */
+export const baseMainnetCaip2 = "eip155:8453" as const;
+export const baseSepoliaCaip2 = "eip155:84532" as const;
+export const polygonCaip2 = "eip155:137" as const;
+export const arbitrumCaip2 = "eip155:42161" as const;
+export const worldCaip2 = "eip155:480" as const;
+export const worldSepoliaCaip2 = "eip155:4801" as const;
+export const solanaMainnetCaip2 = "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp" as const;
+export const solanaDevnetCaip2 = "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1" as const;
+
+/**
+ * Public JSON-RPC endpoints for CDP-supported EVM networks, keyed by CAIP-2
+ * network identifier.
+ *
+ * These are free-tier public RPCs. For production workloads consider supplying
+ * a dedicated RPC URL via `rpcUrls` config or `CDP_X402_RPC_URLS` env var.
+ */
+export const CDP_EVM_RPC_URLS: Record<string, { rpcUrl: string }> = {
+  [baseMainnetCaip2]: { rpcUrl: "https://mainnet.base.org" },
+  [baseSepoliaCaip2]: { rpcUrl: "https://sepolia.base.org" },
+  [polygonCaip2]: { rpcUrl: "https://polygon-bor-rpc.publicnode.com" },
+  [arbitrumCaip2]: { rpcUrl: "https://arb1.arbitrum.io/rpc" },
+  [worldCaip2]: { rpcUrl: "https://worldchain-mainnet.g.alchemy.com/public" },
+  [worldSepoliaCaip2]: { rpcUrl: "https://worldchain-sepolia.g.alchemy.com/public" },
+};
+
+/**
+ * Per-network USDC contract / mint addresses for CDP-supported networks,
+ * keyed by CAIP-2 network identifier.
+ */
+export const CDP_USDC_ADDRESSES = {
+  [baseMainnetCaip2]: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+  [baseSepoliaCaip2]: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+  [polygonCaip2]: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
+  [arbitrumCaip2]: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+  [worldCaip2]: "0x79A02482A880bCE3F13e09Da970dC34db4CD24d1",
+  [worldSepoliaCaip2]: "0x66145f38cBAC35Ca6F1Dfb4914dF98F1614aeA88",
+  [solanaMainnetCaip2]: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+  [solanaDevnetCaip2]: "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+} as const;

--- a/typescript/packages/cdp-sdk/src/x402/credentials.ts
+++ b/typescript/packages/cdp-sdk/src/x402/credentials.ts
@@ -1,0 +1,212 @@
+/* CDP credential resolution for the x402 client. */
+
+/**
+ * Wallet type for the CDP x402 client.
+ *
+ * - `"eoa"`: CDP Server Wallet (Externally Owned Account)
+ * - `"smart"`: CDP Smart Contract Wallet (ERC-4337)
+ */
+export type WalletType = "eoa" | "smart";
+
+/**
+ * Wallet configuration for the CDP x402 client.
+ *
+ * All fields fall back to environment variables when omitted.
+ */
+export type WalletConfig =
+  | {
+      type: "eoa";
+      /**
+       * Named CDP account. Falls back to `CDP_ACCOUNT_NAME` env var.
+       * Defaults to `"x402-client-wallet-1"`.
+       */
+      accountName?: string;
+    }
+  | {
+      type: "smart";
+      /**
+       * Named CDP smart account. Falls back to `CDP_ACCOUNT_NAME` env var.
+       * Defaults to `"x402-client-wallet-1"`.
+       */
+      accountName?: string;
+      /**
+       * Owner EOA account name for the smart wallet.
+       * Falls back to `CDP_OWNER_ACCOUNT_NAME` env var.
+       */
+      ownerAccountName: string;
+    };
+
+/**
+ * Configuration options for the CDP x402 client.
+ *
+ * All credential fields fall back to environment variables when omitted.
+ * The constructor only stores config — accounts are resolved lazily on the
+ * first payment call.
+ */
+export interface CdpX402ClientConfig {
+  /** CDP API key ID. Falls back to `CDP_API_KEY_ID` env var. */
+  apiKeyId?: string;
+  /** CDP API key secret. Falls back to `CDP_API_KEY_SECRET` env var. */
+  apiKeySecret?: string;
+  /** CDP wallet secret for signing. Falls back to `CDP_WALLET_SECRET` env var. */
+  walletSecret?: string;
+  /**
+   * Wallet configuration. Defaults to a CDP Server Wallet (EOA).
+   * Individual fields fall back to environment variables when omitted.
+   */
+  walletConfig?: WalletConfig;
+  /**
+   * Disable the client-side pre-flight balance check before each payment.
+   * When `false` (default), the client queries the CDP balance API and throws
+   * `InsufficientFundsError` early when the balance is too low. Set `true` to skip.
+   * Falls back to `CDP_DISABLE_PREFLIGHT_BALANCE_CHECK=true` env var.
+   */
+  disablePreflightBalanceCheck?: boolean;
+  /**
+   * Override the public JSON-RPC endpoints used for on-chain balance lookups
+   * and payment signing, keyed by CAIP-2 network identifier.
+   *
+   * Merged over the built-in defaults — only supply the networks you want to
+   * override. Explicit values here take precedence over `CDP_X402_RPC_URLS`.
+   *
+   * Falls back to the `CDP_X402_RPC_URLS` environment variable, which must be a
+   * JSON object mapping CAIP-2 network IDs to URL strings:
+   * `CDP_X402_RPC_URLS='{"eip155:8453":"https://base-mainnet.g.alchemy.com/v2/KEY"}'`
+   *
+   * @example
+   * ```typescript
+   * const client = new CdpX402Client({
+   *   rpcUrls: {
+   *     "eip155:8453": { rpcUrl: "https://base-mainnet.g.alchemy.com/v2/YOUR_KEY" },
+   *   },
+   * });
+   * ```
+   */
+  rpcUrls?: Partial<Record<string, { rpcUrl: string }>>;
+}
+
+/** Resolved CDP credentials with all required fields present. */
+export interface ResolvedCdpCredentials {
+  apiKeyId: string;
+  apiKeySecret: string;
+  walletSecret: string;
+}
+
+/** Resolved wallet configuration with all required fields for the selected type. */
+export interface ResolvedWalletConfig {
+  type: WalletType;
+  accountName: string;
+  ownerAccountName?: string;
+}
+
+const DEFAULT_ACCOUNT_NAME = "x402-client-wallet-1";
+const SUPPORTED_WALLET_TYPES: WalletType[] = ["eoa", "smart"];
+
+/**
+ * Parses the `CDP_X402_RPC_URLS` environment variable into the `rpcUrls` shape.
+ *
+ * The env var must be a flat JSON object mapping CAIP-2 network IDs to URL strings:
+ * `CDP_X402_RPC_URLS='{"eip155:8453":"https://base-mainnet.g.alchemy.com/v2/KEY"}'`
+ *
+ * @throws {Error} If the env var is set but is not valid JSON or not an object.
+ * @returns Parsed RPC URL map, or `undefined` if the env var is not set.
+ */
+export function parseRpcUrlsFromEnv(): Partial<Record<string, { rpcUrl: string }>> | undefined {
+  const raw = process.env.CDP_X402_RPC_URLS;
+  if (!raw) return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(
+      "CDP_X402_RPC_URLS must be valid JSON, e.g. " +
+        '\'{"eip155:8453":"https://base-mainnet.g.alchemy.com/v2/KEY"}\'',
+    );
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error(
+      "CDP_X402_RPC_URLS must be a JSON object mapping CAIP-2 network IDs to URL strings",
+    );
+  }
+  return Object.fromEntries(
+    Object.entries(parsed as Record<string, unknown>).map(([network, url]) => {
+      if (typeof url !== "string") {
+        throw new Error(`CDP_X402_RPC_URLS: value for "${network}" must be a string URL`);
+      }
+      return [network, { rpcUrl: url }];
+    }),
+  );
+}
+
+/**
+ * Resolves the wallet type from a string, throwing for unsupported values.
+ *
+ * @param type - Raw wallet type string (e.g. from `CDP_WALLET_TYPE` env var).
+ * @returns The resolved wallet type, defaulting to `"eoa"` when absent.
+ */
+function resolveWalletType(type: string | undefined): WalletType {
+  if (!type) return "eoa";
+  if (SUPPORTED_WALLET_TYPES.includes(type as WalletType)) {
+    return type as WalletType;
+  }
+  throw new Error(
+    `Unsupported wallet type "${type}". Supported values: ${SUPPORTED_WALLET_TYPES.join(", ")}.`,
+  );
+}
+
+/**
+ * Resolves wallet configuration from explicit config and environment variables.
+ *
+ * @param config - Optional wallet configuration to resolve.
+ * @throws {Error} If required fields for the resolved wallet type are missing.
+ * @returns Resolved wallet configuration with all required fields populated.
+ */
+export function resolveWalletConfig(config?: WalletConfig): ResolvedWalletConfig {
+  const type = resolveWalletType(config?.type ?? process.env.CDP_WALLET_TYPE);
+  const accountName = config?.accountName ?? process.env.CDP_ACCOUNT_NAME ?? DEFAULT_ACCOUNT_NAME;
+  const ownerAccountName =
+    type === "smart"
+      ? ((config as { type: "smart"; ownerAccountName: string })?.ownerAccountName ??
+        process.env.CDP_OWNER_ACCOUNT_NAME)
+      : undefined;
+
+  if (type === "smart" && !ownerAccountName) {
+    throw new Error(
+      'Missing required owner account name for wallet type "smart". ' +
+        "Provide it via walletConfig.ownerAccountName or set the CDP_OWNER_ACCOUNT_NAME environment variable.",
+    );
+  }
+
+  return { type, accountName, ownerAccountName };
+}
+
+/**
+ * Resolves CDP credentials from explicit config or environment variables.
+ *
+ * @param config - Optional client configuration with credential overrides.
+ * @throws {Error} If any required credential is missing.
+ * @returns Resolved credentials with all required fields present.
+ */
+export function resolveCredentials(config?: CdpX402ClientConfig): ResolvedCdpCredentials {
+  const apiKeyId = config?.apiKeyId ?? process.env.CDP_API_KEY_ID;
+  const apiKeySecret = config?.apiKeySecret ?? process.env.CDP_API_KEY_SECRET;
+  const walletSecret = config?.walletSecret ?? process.env.CDP_WALLET_SECRET;
+
+  const missing: string[] = [];
+  if (!apiKeyId) missing.push("CDP_API_KEY_ID");
+  if (!apiKeySecret) missing.push("CDP_API_KEY_SECRET");
+  if (!walletSecret) missing.push("CDP_WALLET_SECRET");
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing required CDP credentials: ${missing.join(", ")}. ` +
+        "Provide them via config options or set the corresponding environment variables.",
+    );
+  }
+
+  return {
+    apiKeyId: apiKeyId!,
+    apiKeySecret: apiKeySecret!,
+    walletSecret: walletSecret!,
+  };
+}

--- a/typescript/packages/cdp-sdk/src/x402/index.ts
+++ b/typescript/packages/cdp-sdk/src/x402/index.ts
@@ -1,0 +1,43 @@
+/*
+ * CDP x402 client for paying x402-protected APIs using CDP-managed wallets.
+ * Import from "@coinbase/cdp-sdk/x402".
+ */
+
+export { CdpX402Client, createCdpX402Client } from "./client.js";
+export type { CdpX402ClientResult } from "./client.js";
+
+export type {
+  CdpX402ClientConfig,
+  WalletConfig,
+  WalletType,
+  ResolvedCdpCredentials,
+  ResolvedWalletConfig,
+} from "./credentials.js";
+
+export { InsufficientFundsError } from "./balance-check.js";
+
+export {
+  fromCdpEvmAccount,
+  fromCdpSmartWallet,
+  cdpSolanaAccountToSvmSigner,
+  resolveNetworkFromChainId,
+} from "./wallets.js";
+export type {
+  CdpEvmAccount,
+  CdpSmartAccount,
+  CdpSolanaAccount,
+  CdpAccountProvisionResult,
+} from "./wallets.js";
+
+export {
+  CDP_EVM_RPC_URLS,
+  CDP_USDC_ADDRESSES,
+  baseMainnetCaip2,
+  baseSepoliaCaip2,
+  polygonCaip2,
+  arbitrumCaip2,
+  worldCaip2,
+  worldSepoliaCaip2,
+  solanaMainnetCaip2,
+  solanaDevnetCaip2,
+} from "./constants.js";

--- a/typescript/packages/cdp-sdk/src/x402/wallets.ts
+++ b/typescript/packages/cdp-sdk/src/x402/wallets.ts
@@ -1,0 +1,356 @@
+/*
+ * Wallet adapters and provisioning for the CDP x402 client.
+ *
+ * Bridges CDP SDK account types to x402-compatible signer interfaces,
+ * and provisions EVM/Solana accounts from CDP credentials.
+ */
+import { address as toSolanaAddress, getTransactionEncoder } from "@solana/kit";
+import { toClientEvmSigner } from "@x402/evm";
+
+import { resolveCredentials } from "./credentials.js";
+import { CdpClient } from "../client/cdp.js";
+
+import type { CdpX402ClientConfig, ResolvedWalletConfig } from "./credentials.js";
+import type { TransactionSigner } from "@solana/kit";
+import type { ClientEvmSigner } from "@x402/evm";
+
+// ─── EVM Server Account Adapter ───────────────────────────────────────────────
+
+/**
+ * Minimal interface for a CDP EVM account (EOA).
+ * Matches the relevant methods from CdpClient's EvmServerAccount.
+ */
+export interface CdpEvmAccount {
+  address: `0x${string}`;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  signTypedData(params: any): Promise<`0x${string}`>;
+}
+
+/**
+ * Converts a CDP EVM server account (EOA) into an x402-compatible signer.
+ *
+ * @param account - A CDP EVM account from `cdpClient.evm.getOrCreateAccount()`
+ * @returns A `ClientEvmSigner` compatible with `@x402/evm`'s `registerExactEvmScheme`
+ */
+export function fromCdpEvmAccount(account: CdpEvmAccount): ClientEvmSigner {
+  return toClientEvmSigner(account);
+}
+
+// ─── Smart Contract Wallet Adapter ────────────────────────────────────────────
+
+/** Maps EIP-155 chain IDs to CDP SDK network names for SCW typed-data signing. */
+const CHAIN_ID_TO_CDP_NETWORK: Record<number, string> = {
+  8453: "base",
+  84532: "base-sepolia",
+  42161: "arbitrum",
+  10: "optimism",
+  7777777: "zora",
+  137: "polygon",
+  56: "bnb",
+  43114: "avalanche",
+  11155111: "ethereum-sepolia",
+};
+
+/**
+ * Minimal interface for a CDP Smart Account (EvmSmartAccount).
+ * Matches the relevant methods from CdpClient's EvmSmartAccount.
+ */
+export interface CdpSmartAccount {
+  address: `0x${string}`;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  signTypedData(options: Record<string, any>): Promise<`0x${string}`>;
+}
+
+/**
+ * Resolves a CDP SDK network name from an EIP-712 domain chain ID.
+ *
+ * @param chainId - The EIP-712 domain chain ID to resolve.
+ * @throws {Error} If the chain ID is undefined or not supported.
+ * @returns The CDP SDK network name (e.g. `"base-sepolia"`).
+ */
+export function resolveNetworkFromChainId(chainId: number | undefined): string {
+  if (chainId === undefined) {
+    throw new Error(
+      "Cannot derive CDP network: domain.chainId is missing from the typed data. " +
+        "EIP-712 domain must include chainId when using a Smart Contract Wallet.",
+    );
+  }
+  const network = CHAIN_ID_TO_CDP_NETWORK[chainId];
+  if (!network) {
+    throw new Error(
+      `Unsupported chainId ${chainId} for CDP Smart Contract Wallet. ` +
+        `Supported networks: ${Object.values(CHAIN_ID_TO_CDP_NETWORK).join(", ")}`,
+    );
+  }
+  return network;
+}
+
+/**
+ * Converts a CDP Smart Account (EvmSmartAccount) into an x402-compatible signer.
+ *
+ * CDP Smart Accounts differ from EOAs in that their `signTypedData` requires a
+ * `network` parameter. This adapter derives the network automatically from the
+ * EIP-712 domain's `chainId`.
+ *
+ * @param account - A CDP Smart Account from `cdpClient.evm.getOrCreateSmartAccount()`
+ * @returns A `ClientEvmSigner` compatible with `@x402/evm`'s `registerExactEvmScheme`
+ */
+export function fromCdpSmartWallet(account: CdpSmartAccount): ClientEvmSigner {
+  const signerShape = {
+    address: account.address,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    async signTypedData({ domain, types, primaryType, message }: any): Promise<`0x${string}`> {
+      const chainId = domain?.chainId as number | undefined;
+      const network = resolveNetworkFromChainId(chainId);
+      return account.signTypedData({ domain, types, primaryType, message, network });
+    },
+  };
+  return toClientEvmSigner(signerShape);
+}
+
+// ─── Solana Account Adapter ───────────────────────────────────────────────────
+
+/**
+ * Minimal interface for a CDP Solana account.
+ * Matches the relevant methods from CdpClient's SolanaAccount.
+ */
+export interface CdpSolanaAccount {
+  address: string;
+  signTransaction(options: { transaction: string }): Promise<{ signedTransaction: string }>;
+}
+
+type ShortVecLength = {
+  value: number;
+  bytesRead: number;
+};
+
+/**
+ * Decodes a Solana short-vector length prefix from the start of a byte array.
+ *
+ * @param bytes - Raw transaction bytes to decode.
+ * @returns Decoded length value and number of bytes consumed.
+ */
+function decodeShortVecLength(bytes: Uint8Array): ShortVecLength {
+  let value = 0;
+  let shift = 0;
+  let bytesRead = 0;
+  while (bytesRead < bytes.length) {
+    const byte = bytes[bytesRead]!;
+    value |= (byte & 0x7f) << shift;
+    bytesRead += 1;
+    if ((byte & 0x80) === 0) {
+      return { value, bytesRead };
+    }
+    shift += 7;
+  }
+  throw new Error("Invalid Solana transaction wire format: truncated shortvec length.");
+}
+
+/**
+ * Finds the index of a signer in a compiled Solana transaction's signatures map.
+ *
+ * @param transaction - Compiled Solana transaction object.
+ * @param signerAddress - Base58 signer address to locate.
+ * @returns The zero-based index of the signer in the signatures array.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function resolveSignerIndex(transaction: any, signerAddress: string): number {
+  const signatures = transaction?.signatures;
+  if (signatures && typeof signatures === "object") {
+    const signerOrder = Object.keys(signatures);
+    const index = signerOrder.indexOf(signerAddress);
+    if (index >= 0) return index;
+  }
+  throw new Error(
+    `Unable to locate signer "${signerAddress}" in transaction signatures. ` +
+      "Expected transaction.signatures to contain the signer address.",
+  );
+}
+
+/**
+ * Converts a CDP Solana account into an x402-compatible `TransactionSigner`.
+ *
+ * Handles the translation between CDP's base64-encoded transaction strings and
+ * `@solana/kit`'s compiled transaction objects.
+ *
+ * @param account - A CDP Solana account from `cdpClient.solana.getOrCreateAccount()`
+ * @returns A `TransactionSigner` compatible with `@x402/svm`'s `registerExactSvmScheme`
+ */
+export function cdpSolanaAccountToSvmSigner(account: CdpSolanaAccount): TransactionSigner {
+  const signerAddress = toSolanaAddress(account.address);
+  const signerAddressKey = signerAddress as string;
+  const encoder = getTransactionEncoder();
+
+  return {
+    address: signerAddress,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    async signTransactions(transactions: readonly any[]): Promise<readonly any[]> {
+      const results = [];
+      for (const transaction of transactions) {
+        const signerIndex = resolveSignerIndex(transaction, signerAddressKey);
+        const encodedBytes = encoder.encode(transaction);
+        const base64Transaction = Buffer.from(encodedBytes).toString("base64");
+        const { signedTransaction } = await account.signTransaction({
+          transaction: base64Transaction,
+        });
+        const signedBytes = Buffer.from(signedTransaction, "base64");
+        const { value: signatureCount, bytesRead: signatureSectionOffset } =
+          decodeShortVecLength(signedBytes);
+        if (signerIndex >= signatureCount) {
+          throw new Error(
+            `Signer index ${signerIndex} is out of bounds for ${signatureCount} signatures.`,
+          );
+        }
+        const signatureOffset = signatureSectionOffset + signerIndex * 64;
+        const signatureEnd = signatureOffset + 64;
+        if (signatureEnd > signedBytes.length) {
+          throw new Error(
+            "Invalid Solana transaction wire format: signed transaction is missing signature bytes.",
+          );
+        }
+        const signature = new Uint8Array(signedBytes.slice(signatureOffset, signatureEnd));
+        results.push({ [signerAddressKey]: signature });
+      }
+      return results;
+    },
+  } as TransactionSigner;
+}
+
+// ─── Provisioning ─────────────────────────────────────────────────────────────
+
+/**
+ * The result of provisioning CDP accounts for use with x402.
+ */
+export interface CdpAccountProvisionResult {
+  /** The underlying CdpClient instance. */
+  cdpClient: CdpClient;
+  /** EVM address for the provisioned account (EOA or SCW per walletConfig). */
+  evmAddress: `0x${string}`;
+  /** Solana account address. */
+  svmAddress: string;
+  /**
+   * Owner account name. Only set when `walletConfig.type` is `"smart"`.
+   * The owner signs EIP-712 typed data on behalf of the smart account.
+   */
+  ownerWallet?: string;
+  /** x402-compatible EVM signer. */
+  evmSigner: ClientEvmSigner;
+  /** x402-compatible Solana transaction signer. */
+  svmSigner: TransactionSigner;
+}
+
+/**
+ * Returns true when the CDP API rejected smart account creation because the owner
+ * already has a smart account registered under a different name.
+ *
+ * @param error - Error thrown by `getOrCreateSmartAccount`.
+ * @returns `true` if the error indicates the owner already has a smart account.
+ */
+export function isOwnerAlreadyHasSmartWalletError(error: unknown): boolean {
+  return (
+    error instanceof Error && error.message.includes("Multiple smart wallets with the same owner")
+  );
+}
+
+/**
+ * Finds an existing smart account by owner address, paging through all results.
+ *
+ * Used as a recovery when `getOrCreateSmartAccount` fails because the owner
+ * already owns a smart account under a different name.
+ *
+ * @param cdpClient - Configured CDP client to query.
+ * @param ownerAddress - The owner EOA address to match (case-insensitive).
+ * @returns The first matching smart account address, or `undefined` if none found.
+ */
+export async function findSmartAccountByOwner(
+  cdpClient: CdpClient,
+  ownerAddress: string,
+): Promise<string | undefined> {
+  const normalizedOwner = ownerAddress.toLowerCase();
+  let pageToken: string | undefined;
+  do {
+    const result = await cdpClient.evm.listSmartAccounts({ pageToken });
+    const match = result.accounts.find(a => a.owners[0]?.toLowerCase() === normalizedOwner);
+    if (match) return match.address;
+    pageToken = result.nextPageToken;
+  } while (pageToken);
+  return undefined;
+}
+
+/**
+ * Provisions CDP EVM and Solana accounts and builds x402-compatible signers.
+ *
+ * Used by `CdpX402Client` to resolve wallet addresses and register payment
+ * schemes on first use.
+ *
+ * @param config - Optional credential config. All fields fall back to env vars.
+ * @param walletConfig - Resolved wallet type and account names.
+ * @returns Provisioned accounts, addresses, and x402-compatible signers.
+ */
+export async function provisionCdpAccounts(
+  config: CdpX402ClientConfig | undefined,
+  walletConfig: ResolvedWalletConfig,
+): Promise<CdpAccountProvisionResult> {
+  const credentials = resolveCredentials(config);
+  const cdpClient = new CdpClient({
+    apiKeyId: credentials.apiKeyId,
+    apiKeySecret: credentials.apiKeySecret,
+    walletSecret: credentials.walletSecret,
+  });
+
+  const svmAccount = await cdpClient.solana.getOrCreateAccount({
+    name: walletConfig.accountName,
+  });
+
+  let evmAddress: `0x${string}`;
+  let ownerWallet: string | undefined;
+  let evmSigner: ClientEvmSigner;
+
+  if (walletConfig.type === "smart") {
+    const ownerAccount = await cdpClient.evm.getOrCreateAccount({
+      name: walletConfig.ownerAccountName!,
+    });
+
+    let smartAccount;
+    try {
+      smartAccount = await cdpClient.evm.getOrCreateSmartAccount({
+        name: walletConfig.accountName,
+        owner: ownerAccount,
+      });
+    } catch (error) {
+      /*
+       * CDP allows only one smart wallet per owner. If the owner already has a
+       * smart wallet registered under a different name, recover by finding it.
+       */
+      if (isOwnerAlreadyHasSmartWalletError(error)) {
+        const existingAddress = await findSmartAccountByOwner(cdpClient, ownerAccount.address);
+        if (!existingAddress) throw error;
+        smartAccount = await cdpClient.evm.getSmartAccount({
+          address: existingAddress as `0x${string}`,
+          owner: ownerAccount,
+        });
+      } else {
+        throw error;
+      }
+    }
+
+    evmAddress = smartAccount.address as `0x${string}`;
+    ownerWallet = walletConfig.ownerAccountName!;
+    evmSigner = fromCdpSmartWallet(smartAccount);
+  } else {
+    const evmAccount = await cdpClient.evm.getOrCreateAccount({
+      name: walletConfig.accountName,
+    });
+    evmAddress = evmAccount.address as `0x${string}`;
+    evmSigner = fromCdpEvmAccount(evmAccount);
+  }
+
+  return {
+    cdpClient,
+    evmAddress,
+    svmAddress: svmAccount.address,
+    ownerWallet,
+    evmSigner,
+    svmSigner: cdpSolanaAccountToSvmSigner(svmAccount),
+  };
+}

--- a/typescript/packages/cdp-sdk/tsconfig.cjs.json
+++ b/typescript/packages/cdp-sdk/tsconfig.cjs.json
@@ -6,6 +6,15 @@
     "outDir": "./_cjs",
     "module": "CommonJS",
     "moduleResolution": "node",
-    "sourceMap": true
+    "sourceMap": true,
+    "baseUrl": ".",
+    "paths": {
+      "@x402/core/client": ["node_modules/@x402/core/dist/cjs/client/index.d.ts"],
+      "@x402/core/types": ["node_modules/@x402/core/dist/cjs/types/index.d.ts"],
+      "@x402/evm": ["node_modules/@x402/evm/dist/cjs/index.d.ts"],
+      "@x402/evm/exact/client": ["node_modules/@x402/evm/dist/cjs/exact/client/index.d.ts"],
+      "@x402/evm/upto/client": ["node_modules/@x402/evm/dist/cjs/upto/client/index.d.ts"],
+      "@x402/svm/exact/client": ["node_modules/@x402/svm/dist/cjs/exact/client/index.d.ts"]
+    }
   }
 }

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -106,6 +106,18 @@ importers:
       '@solana/kit':
         specifier: ^5.5.1
         version: 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@x402/core':
+        specifier: ^2.16.0
+        version: 2.16.0
+      '@x402/evm':
+        specifier: ^2.16.0
+        version: 2.16.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@x402/fetch':
+        specifier: ^2.16.0
+        version: 2.16.0
+      '@x402/svm':
+        specifier: ^2.16.0
+        version: 2.16.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
       abitype:
         specifier: 1.0.6
         version: 1.0.6(typescript@5.9.3)(zod@3.25.76)
@@ -1086,10 +1098,21 @@ packages:
   '@sinclair/typebox@0.27.10':
     resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
 
+  '@solana-program/compute-budget@0.11.0':
+    resolution: {integrity: sha512-7f1ePqB/eURkTwTOO9TNIdUXZcyrZoX3Uy2hNo7cXMfNhPFWp9AVgIyRNBc2jf15sdUa9gNpW+PfP2iV8AYAaw==}
+    peerDependencies:
+      '@solana/kit': ^5.0
+
   '@solana-program/system@0.10.0':
     resolution: {integrity: sha512-Go+LOEZmqmNlfr+Gjy5ZWAdY5HbYzk2RBewD9QinEU/bBSzpFfzqDRT55JjFRBGJUvMgf3C2vfXEGT4i8DSI4g==}
     peerDependencies:
       '@solana/kit': ^5.0
+
+  '@solana-program/token-2022@0.6.1':
+    resolution: {integrity: sha512-Ex02cruDMGfBMvZZCrggVR45vdQQSI/unHVpt/7HPt/IwFYB4eTlXtO8otYZyqV/ce5GqZ8S6uwyRf0zy6fdbA==}
+    peerDependencies:
+      '@solana/kit': ^5.0
+      '@solana/sysvars': ^5.0
 
   '@solana-program/token@0.9.0':
     resolution: {integrity: sha512-vnZxndd4ED4Fc56sw93cWZ2djEeeOFxtaPS8SPf5+a+JZjKA/EnKqzbE1y04FuMhIVrLERQ8uR8H2h72eZzlsA==}
@@ -1737,6 +1760,20 @@ packages:
 
   '@vitest/utils@1.6.1':
     resolution: {integrity: sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==}
+
+  '@x402/core@2.16.0':
+    resolution: {integrity: sha512-7MjwOEiE6ICAYtOsK9vQl66Ho4jERDuuoRg/No2Nc2GQ7y/M/yu4DJ65LzeBycQE+Qrg2RqQG7KR51tyT+hzjQ==}
+
+  '@x402/evm@2.16.0':
+    resolution: {integrity: sha512-DGcwATWosIb3hmO/CfWASrn+xbxp7KQyzmMPcIW23XuDjo9YPVRElZWtHBur3euakdM021Hl8SPF1zR0G+W4hw==}
+
+  '@x402/fetch@2.16.0':
+    resolution: {integrity: sha512-skW0XsWzi4NIfqCrY6KxhO3UEJ8qh4nBIKIgwWFCXFHNqRKYWZ7qcCI/DHy7cy3jdYs1MV4PoXX24rP3Umca1Q==}
+
+  '@x402/svm@2.16.0':
+    resolution: {integrity: sha512-hxggK4PYjfI5CdsbDeVe9JDS70uPMlfFrpOaEPBo5aQ/wtFq/7ydkiUxKXozlhRw9KFqOue9zUGrPsHLCokTTw==}
+    peerDependencies:
+      '@solana/kit': '>=5.1.0'
 
   abitype@1.0.6:
     resolution: {integrity: sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A==}
@@ -3133,6 +3170,14 @@ packages:
       typescript:
         optional: true
 
+  ox@0.14.29:
+    resolution: {integrity: sha512-M5j87Ec4V99MQdRct/g09eWXW60g6zhHTUs1lr4deUtrPDnezBdCJTgKd7pxqTpSZBFveV0ALi9jMMuT1qKyNg==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   p-filter@2.1.0:
     resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
     engines: {node: '>=8'}
@@ -3754,6 +3799,14 @@ packages:
       typescript:
         optional: true
 
+  viem@2.53.1:
+    resolution: {integrity: sha512-FhfJ/SW73CVosiyVLmIMVgKDRKYV1AGCLzZoHYvmNayyVff63Qi1ocPCk59LqC/cNw244RbBJjHnmxqXkE7NpA==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   vite-node@1.6.1:
     resolution: {integrity: sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -3876,6 +3929,18 @@ packages:
 
   ws@8.19.0:
     resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -4813,9 +4878,18 @@ snapshots:
 
   '@sinclair/typebox@0.27.10': {}
 
+  '@solana-program/compute-budget@0.11.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana/kit': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
+
   '@solana-program/system@0.10.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))':
     dependencies:
       '@solana/kit': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
+
+  '@solana-program/token-2022@0.6.1(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))':
+    dependencies:
+      '@solana/kit': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@solana/sysvars': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
 
   '@solana-program/token@0.9.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))':
     dependencies:
@@ -5641,6 +5715,34 @@ snapshots:
       estree-walker: 3.0.3
       loupe: 2.3.7
       pretty-format: 29.7.0
+
+  '@x402/core@2.16.0':
+    dependencies:
+      zod: 3.25.76
+
+  '@x402/evm@2.16.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@x402/core': 2.16.0
+      viem: 2.53.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+
+  '@x402/fetch@2.16.0':
+    dependencies:
+      '@x402/core': 2.16.0
+
+  '@x402/svm@2.16.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))':
+    dependencies:
+      '@solana-program/compute-budget': 0.11.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))
+      '@solana-program/token': 0.9.0(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))
+      '@solana-program/token-2022': 0.6.1(@solana/kit@5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
+      '@solana/kit': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@x402/core': 2.16.0
+    transitivePeerDependencies:
+      - '@solana/sysvars'
 
   abitype@1.0.6(typescript@5.9.3)(zod@3.25.76):
     optionalDependencies:
@@ -6811,6 +6913,10 @@ snapshots:
     dependencies:
       ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
+  isows@1.0.7(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
+    dependencies:
+      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+
   istanbul-lib-coverage@3.2.2: {}
 
   istanbul-lib-report@3.0.1:
@@ -7232,6 +7338,21 @@ snapshots:
       safe-push-apply: 1.0.0
 
   ox@0.14.0(typescript@5.9.3)(zod@3.25.76):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - zod
+
+  ox@0.14.29(typescript@5.9.3)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0
@@ -7898,6 +8019,23 @@ snapshots:
       - utf-8-validate
       - zod
 
+  viem@2.53.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
+      isows: 1.0.7(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      ox: 0.14.29(typescript@5.9.3)(zod@3.25.76)
+      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
   vite-node@1.6.1(@types/node@20.19.37):
     dependencies:
       cac: 6.7.14
@@ -8038,6 +8176,11 @@ snapshots:
       utf-8-validate: 6.0.6
 
   ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 6.0.6
+
+  ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     optionalDependencies:
       bufferutil: 4.1.0
       utf-8-validate: 6.0.6


### PR DESCRIPTION
## Summary

Implements [CDPAI-1379](https://linear.app/coinbase/issue/CDPAI-1379/cdp-managed-x402-client) — a `CdpX402Client` that lets CDP users pay x402-protected APIs using CDP-managed wallets, accessible at `@coinbase/cdp-sdk/x402`.

- **`CdpX402Client`** extends `x402Client` with lazy wallet provisioning and scheme registration — works as a drop-in with `wrapFetchWithPayment(fetch, client)` from `@x402/fetch` unchanged
- **`createCdpX402Client()`** for eager initialization when the wallet address is needed before the first payment
- **Wallet adapters** bridging CDP accounts to x402 signers: EOA (`fromCdpEvmAccount`), Smart Contract Wallet (`fromCdpSmartWallet`), Solana (`cdpSolanaAccountToSvmSigner`)
- **Pre-flight balance check** via `InsufficientFundsError` — queries CDP indexed balance API on Base/Base Sepolia and falls back to on-chain `balanceOf` on other EVM networks
- **Environment variables**: `CDP_API_KEY_ID`, `CDP_API_KEY_SECRET`, `CDP_WALLET_SECRET`, `CDP_X402_RPC_URLS`; wallet types `"eoa"` (default) and `"smart"`
- Registers `exact` EVM/SVM schemes + `upto` EVM scheme on the underlying `x402Client`

## Test plan

- Unit tests passing for constructor config, lazy resolution, payment signing path, balance check hook, and RPC URL override behavior
- E2E tests added to `src/e2e.test.ts` (require live CDP credentials)
- Example: `examples/typescript/x402/payX402Endpoint.ts`
- README docs added for CDP Dev and x402 Dev migration flows