### PR TITLE
ci(typescript): pin publish npm to 11.17.0 instead of latest

### DIFF
--- a/.github/workflows/typescript_publish.yml
+++ b/.github/workflows/typescript_publish.yml
@@ -33,13 +33,13 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
-          node-version: 22.x
+          node-version: 22.22.1
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
           cache-dependency-path: ./typescript/pnpm-lock.yaml
 
-      - name: Use latest npm for trusted publishing
-        run: npm install -g npm@latest
+      - name: Use pinned npm for trusted publishing
+        run: npm install -g npm@11.17.0
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/typescript_publish.yml
+++ b/.github/workflows/typescript_publish.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
-          node-version: 22.22.1
+          node-version: 22.x
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
           cache-dependency-path: ./typescript/pnpm-lock.yaml


### PR DESCRIPTION
## Summary

The [Publish @coinbase/cdp-sdk workflow](https://github.com/coinbase/cdp-sdk/actions/runs/29040356152/job/86195690491) failed on the npm-install step with `EBADENGINE`.

`npm@12.0.0` was published 2026-07-08 and raised its Node floor to `^22.22.2 || ^24.15.0 || >=26.0.0`. The publish workflow pinned `node-version: 22.22.1` and ran `npm install -g npm@latest`, so npm 12 refused to install (22.22.1 is one patch below the new minimum).

## Fix

Pin the publish step to `npm@11.17.0` instead of `npm@latest`. That's the exact version that was `latest` at the last successful publish (2026-06-18), and its engine requirement (`^20.17.0 || >=22.9.0`) is satisfied by the pinned Node `22.22.1`.

This keeps npm from silently jumping to a new major that moves the Node floor. Node pin is left at `22.22.1`.

Scoped to `typescript_publish.yml` only — it's the sole workflow that installs npm globally. The test/lint/e2e workflows use pnpm and are unaffected.