### PR TITLE
test(typescript): skip unauthenticated e2e tests on localhost/dev base paths

### DIFF
--- a/typescript/packages/cdp-sdk/src/e2e.test.ts
+++ b/typescript/packages/cdp-sdk/src/e2e.test.ts
@@ -4286,7 +4286,14 @@ describe("CDP Client E2E Tests", () => {
  * (re-)configures it as needed, and the suite restores an authenticated configuration at the
  * end so it doesn't leak into any other test file sharing the same worker process.
  */
-describe("Unauthenticated (public) endpoint access", () => {
+// Skip these tests when running against localhost or the dev host, where the
+// public (unauthenticated) x402 endpoints aren't available or behave differently.
+const shouldSkipUnauthenticatedTests =
+  !!process.env.E2E_BASE_PATH &&
+  (process.env.E2E_BASE_PATH.includes("localhost") ||
+    process.env.E2E_BASE_PATH.includes("cloud-api-dev.cbhq.net"));
+
+describe.skipIf(shouldSkipUnauthenticatedTests)("Unauthenticated (public) endpoint access", () => {
   const basePathOptions: CdpClientOptions = process.env.E2E_BASE_PATH
     ? { basePath: process.env.E2E_BASE_PATH }
     : {};

--- a/typescript/packages/cdp-sdk/src/e2e.test.ts
+++ b/typescript/packages/cdp-sdk/src/e2e.test.ts
@@ -4288,10 +4288,19 @@ describe("CDP Client E2E Tests", () => {
  */
 // Skip these tests when running against localhost or the dev host, where the
 // public (unauthenticated) x402 endpoints aren't available or behave differently.
-const shouldSkipUnauthenticatedTests =
-  !!process.env.E2E_BASE_PATH &&
-  (process.env.E2E_BASE_PATH.includes("localhost") ||
-    process.env.E2E_BASE_PATH.includes("cloud-api-dev.cbhq.net"));
+// Parse the URL and match on the exact hostname rather than a substring so that
+// hosts like `cloud-api-dev.cbhq.net.evil.com` don't spuriously match.
+const shouldSkipUnauthenticatedTests = (() => {
+  const basePath = process.env.E2E_BASE_PATH;
+  if (!basePath) return false;
+  let hostname: string;
+  try {
+    hostname = new URL(basePath).hostname;
+  } catch {
+    return false;
+  }
+  return hostname === "localhost" || hostname === "cloud-api-dev.cbhq.net";
+})();
 
 describe.skipIf(shouldSkipUnauthenticatedTests)("Unauthenticated (public) endpoint access", () => {
   const basePathOptions: CdpClientOptions = process.env.E2E_BASE_PATH


### PR DESCRIPTION
## Description

Skips the `"Unauthenticated (public) endpoint access"` describe block in `typescript/packages/cdp-sdk/src/e2e.test.ts` when `E2E_BASE_PATH` contains `localhost` or `cloud-api-dev.cbhq.net`.

Those tests exercise public (unauthenticated) x402 endpoints, which aren't available / behave differently against localhost and the dev host, causing spurious failures. Uses vitest's `describe.skipIf(...)` so the block still runs against prod/unset base paths.

## Tests

No functional SDK change — only e2e test gating.

- With `E2E_BASE_PATH=http://localhost:8080` (or `...cloud-api-dev.cbhq.net`) the block is skipped.
- With an unset/prod base path the block runs as before.

## Checklist

- [ ] Updated the typescript README if relevant
- [ ] Updated the python README if relevant
- [ ] Added a changelog entry
- [ ] Added e2e tests if introducing new functionality