### PR TITLE
chore: add nextPageToken to listSpendPermissions

### DIFF
--- a/typescript/.changeset/thick-views-enjoy.md
+++ b/typescript/.changeset/thick-views-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/cdp-sdk": patch
+---
+
+Added nextPageToken to listSpendPermissions

--- a/typescript/packages/cdp-sdk/src/actions/evm/listSpendPermissions.test.ts
+++ b/typescript/packages/cdp-sdk/src/actions/evm/listSpendPermissions.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { listSpendPermissions } from "./listSpendPermissions.js";
+
+import type { CdpOpenApiClient } from "../../openapi-client/index.js";
+import type { ListSpendPermissionsOptions } from "../../spend-permissions/types.js";
+import type { Address } from "../../types/misc.js";
+
+describe("listSpendPermissions", () => {
+  let mockClient: typeof CdpOpenApiClient;
+  const mockAddress = "0x1234567890123456789012345678901234567890" as Address;
+
+  const mockPermission = {
+    createdAt: "2024-01-01T00:00:00Z",
+    permissionHash: "0xabc",
+    permission: {
+      account: "0x1111111111111111111111111111111111111111",
+      spender: "0x2222222222222222222222222222222222222222",
+      token: "0x3333333333333333333333333333333333333333",
+      allowance: "1000",
+      period: "86400",
+      start: "0",
+      end: "281474976710655",
+      salt: "1",
+      extraData: "0x",
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockClient = {
+      listSpendPermissions: vi.fn(),
+    } as unknown as typeof CdpOpenApiClient;
+  });
+
+  it("should forward nextPageToken from the underlying response", async () => {
+    (mockClient.listSpendPermissions as any).mockResolvedValue({
+      nextPageToken: "page-2",
+      spendPermissions: [mockPermission],
+    });
+
+    const options: ListSpendPermissionsOptions = { address: mockAddress };
+
+    const result = await listSpendPermissions(mockClient, options);
+
+    expect(result.nextPageToken).toBe("page-2");
+    expect(result.spendPermissions).toHaveLength(1);
+  });
+
+  it("should leave nextPageToken undefined when the response has none", async () => {
+    (mockClient.listSpendPermissions as any).mockResolvedValue({
+      spendPermissions: [],
+    });
+
+    const result = await listSpendPermissions(mockClient, { address: mockAddress });
+
+    expect(result.nextPageToken).toBeUndefined();
+    expect(result.spendPermissions).toEqual([]);
+  });
+
+  it("should forward pagination options to the client", async () => {
+    (mockClient.listSpendPermissions as any).mockResolvedValue({
+      nextPageToken: "page-3",
+      spendPermissions: [],
+    });
+
+    await listSpendPermissions(mockClient, {
+      address: mockAddress,
+      pageSize: 20,
+      pageToken: "page-2",
+    });
+
+    expect(mockClient.listSpendPermissions).toHaveBeenCalledWith(mockAddress, {
+      pageSize: 20,
+      pageToken: "page-2",
+    });
+  });
+
+  it("should transform permission fields to their expected runtime types", async () => {
+    (mockClient.listSpendPermissions as any).mockResolvedValue({
+      spendPermissions: [mockPermission],
+    });
+
+    const result = await listSpendPermissions(mockClient, { address: mockAddress });
+
+    const permission = result.spendPermissions[0].permission;
+    expect(permission.allowance).toBe(BigInt(1000));
+    expect(permission.period).toBe(86400);
+    expect(permission.start).toBe(0);
+    expect(permission.end).toBe(281474976710655);
+    expect(permission.salt).toBe(BigInt(1));
+  });
+});

--- a/typescript/packages/cdp-sdk/src/actions/evm/listSpendPermissions.ts
+++ b/typescript/packages/cdp-sdk/src/actions/evm/listSpendPermissions.ts
@@ -39,6 +39,7 @@ export async function listSpendPermissions(
   });
 
   return {
+    nextPageToken: result.nextPageToken,
     spendPermissions: result.spendPermissions.map(permission => ({
       ...permission,
       permissionHash: permission.permissionHash as Hex,


### PR DESCRIPTION
<!--
Thanks for contributing to CDP SDK!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description
This PR adds `nextPageToken` to the listSpendPermissions function. Previously, this was missing, resulting in an error fetching paginated spend permissions.

## Tests
Unit tests have been added to validate the presence of `nextPageToken` on the listSpendPermissions function.

<!--
When adding new functionality or fixing a bug, you should be testing your changes with one or more
API method examples in the examples directory.

Please provide samples of the methods you tested with, the outputs for each method,
and any other relevant context, like which network was used.

Use the following format if helpful:

```
Method: <name of method used>
Network: <network used>
Setup: <any other relevant context>

Output:
<example output>
```

For example:

```
Method: createAccount
Network: Base Sepolia

Output:
EVM Account Address:  0xC2c7D554292Bb6AE502fafc3F5c0C46B534d6f31
```
 -->

## Checklist

A couple of things to include in your PR for completeness:

- [ ] Updated the [typescript README](https://github.com/coinbase/cdp-sdk/blob/main/typescript/packages/cdp-sdk/README.md) if relevant
- [ ] Updated the [python README](https://github.com/coinbase/cdp-sdk/blob/main/python/README.md) if relevant
- [ ] Added a changelog entry
- [ ] Added e2e tests if introducing new functionality

<!--
For instructions on adding changelog entries:
See here for TypeScript: https://github.com/coinbase/cdp-sdk/blob/main/typescript/CONTRIBUTING.md#changelog
and here for Python: https://github.com/coinbase/cdp-sdk/blob/main/python/CONTRIBUTING.md#changelog
-->
