### PR TITLE
chore: bump @coinbase/cdp-sdk to 1.55.0

### DIFF
--- a/typescript/.changeset/bump-x402-2-21.md
+++ b/typescript/.changeset/bump-x402-2-21.md
@@ -1,5 +1,0 @@
----
-"@coinbase/cdp-sdk": patch
----
-
-Bump the `@x402/core`, `@x402/evm`, `@x402/extensions`, and `@x402/svm` peer dependencies to `^2.21.0`.

--- a/typescript/.changeset/x402-builder-code.md
+++ b/typescript/.changeset/x402-builder-code.md
@@ -1,5 +1,0 @@
----
-"@coinbase/cdp-sdk": minor
----
-
-Add optional `builderCode` on `CdpX402Client` and `createX402Server` to attach the x402 `builder-code` extension for ERC-8021 on-chain attribution. The client accepts a single service code or an array of them; the server advertises its app code on every route with an EVM payment option. Independently of this option, every `CdpX402Client` and every EVM route on `createX402Server` now also always attaches the SDK's own service code, for attributing on-chain activity to the CDP SDK.

--- a/typescript/packages/cdp-sdk/CHANGELOG.md
+++ b/typescript/packages/cdp-sdk/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CDP SDK Changelog
 
+## 1.55.0
+
+### Minor Changes
+
+- [#768](https://github.com/coinbase/cdp-sdk/pull/768) [`3fb682a`](https://github.com/coinbase/cdp-sdk/commit/3fb682ab2e50f136f2d5e8c83ae68c4a7f229229) Thanks [@ethanoroshiba](https://github.com/ethanoroshiba)! - Add optional `builderCode` on `CdpX402Client` and `createX402Server` to attach the x402 `builder-code` extension for ERC-8021 on-chain attribution. The client accepts a single service code or an array of them; the server advertises its app code on every route with an EVM payment option. Independently of this option, every `CdpX402Client` and every EVM route on `createX402Server` now also always attaches the SDK's own service code, for attributing on-chain activity to the CDP SDK.
+
+### Patch Changes
+
+- [#768](https://github.com/coinbase/cdp-sdk/pull/768) [`3fb682a`](https://github.com/coinbase/cdp-sdk/commit/3fb682ab2e50f136f2d5e8c83ae68c4a7f229229) Thanks [@ethanoroshiba](https://github.com/ethanoroshiba)! - Bump the `@x402/core`, `@x402/evm`, `@x402/extensions`, and `@x402/svm` peer dependencies to `^2.21.0`.
+
 ## 1.54.0
 
 ### Minor Changes

--- a/typescript/packages/cdp-sdk/package.json
+++ b/typescript/packages/cdp-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/cdp-sdk",
-  "version": "1.54.0",
+  "version": "1.55.0",
   "description": "SDK for interacting with the Coinbase Developer Platform Wallet API",
   "type": "module",
   "main": "./_cjs/index.js",

--- a/typescript/packages/cdp-sdk/src/version.ts
+++ b/typescript/packages/cdp-sdk/src/version.ts
@@ -1,1 +1,1 @@
-export const version = "1.54.0";
+export const version = "1.55.0";


### PR DESCRIPTION
Version bump release PR for @coinbase/cdp-sdk 1.55.0, generated via pnpm changeset:version.

* Minor: Add optional builderCode on CdpX402Client and createX402Server to attach the x402 builder-code extension for ERC-8021 on-chain attribution.
* Patch: Bump the @x402/core, @x402/evm, @x402/extensions, and @x402/svm peer dependencies to ^2.21.0.