### PR TITLE
fix: Python SDK JWT security improvements and analytics opt-out fix

### DIFF
--- a/python/cdp/auth/utils/jwt.py
+++ b/python/cdp/auth/utils/jwt.py
@@ -1,7 +1,7 @@
 import base64
 import hashlib
 import json
-import random
+import secrets
 import time
 import uuid
 from datetime import datetime
@@ -193,10 +193,11 @@ def generate_jwt(options: JwtOptions) -> str:
         claims = {
             "sub": options.api_key_id,
             "iss": "cdp",
-            "aud": options.audience,
             "nbf": now,
             "exp": now + expires_in,
         }
+        if options.audience:
+            claims["aud"] = options.audience
 
         # Add the uris claim only for JWTs intended for REST API requests, not for websocket connections
         if has_all_uri_params:
@@ -307,4 +308,4 @@ def _generate_nonce() -> str:
         A 16-character random string of digits
 
     """
-    return "".join(random.choices("0123456789", k=16))
+    return "".join(secrets.choice("0123456789") for _ in range(16))

--- a/python/cdp/cdp_client.py
+++ b/python/cdp/cdp_client.py
@@ -77,7 +77,7 @@ class CdpClient:
 
         if api_key_id and (
             os.getenv("DISABLE_CDP_ERROR_REPORTING") != "true"
-            or os.getenv("DISABLE_CDP_USAGE_TRACKING") != "true"
+            and os.getenv("DISABLE_CDP_USAGE_TRACKING") != "true"
         ):
             Analytics["identifier"] = api_key_id
 


### PR DESCRIPTION
Fixes #771, #772, #773

- Replace `random.choices` with `secrets.choice` for CSPRNG-compliant JWT nonces
- Omit `aud` claim when audience is not provided (prevents `"aud": null` serialization)  
- Fix analytics opt-out logic: `or` → `and` so either env var disables its feature