### PR TITLE
fix(ci): update PyPI publishing action

### DIFF
--- a/.github/workflows/python_publish.yml
+++ b/.github/workflows/python_publish.yml
@@ -45,6 +45,6 @@ jobs:
         run: uv build
 
       - name: Publish
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: python/dist/


### PR DESCRIPTION
## Description

Updates `pypa/gh-action-pypi-publish` from v1.12.4 to v1.14.2. The prior action bundles a publisher that rejects Core Metadata 2.5, which caused the [`cdp-sdk` 1.48.0 publish job](https://github.com/coinbase/cdp-sdk/actions/runs/32393773983/job/96505797931) to fail before uploading. v1.14.2 includes Twine 7 support for Core Metadata 2.5.

Generated with Pi

## Tests

- Parsed `.github/workflows/python_publish.yml` with PyYAML and asserted the publish step uses the v1.14.2 commit pin and retains `python/dist/` as its package directory.
- Ran `git diff --check`.

## Checklist

- [x] Updated the [typescript README](https://github.com/coinbase/cdp-sdk/blob/main/typescript/packages/cdp-sdk/README.md) if relevant (not relevant)
- [x] Updated the [python README](https://github.com/coinbase/cdp-sdk/blob/main/python/README.md) if relevant (not relevant)
- [x] Added a changelog entry (not relevant; CI workflow-only fix)
- [x] Added e2e tests if introducing new functionality (not relevant)
