### PR TITLE
chore: sync OpenAPI spec, regenerate clients, add swap deserialization E2E

### DIFF
--- a/go/openapi/client.gen.go
+++ b/go/openapi/client.gen.go
@@ -90,11 +90,6 @@ const (
 	CapabilityStatusUnrequested CapabilityStatus = "unrequested"
 )
 
-// Defines values for CommonSwapResponseLiquidityAvailable.
-const (
-	CommonSwapResponseLiquidityAvailableTrue CommonSwapResponseLiquidityAvailable = true
-)
-
 // Defines values for CreateCryptoDepositDestinationRequestType.
 const (
 	CreateCryptoDepositDestinationRequestTypeCrypto CreateCryptoDepositDestinationRequestType = "crypto"
@@ -119,11 +114,6 @@ const (
 // Defines values for CreateFiatDepositDestinationRequestType.
 const (
 	CreateFiatDepositDestinationRequestTypeFiat CreateFiatDepositDestinationRequestType = "fiat"
-)
-
-// Defines values for CreateSwapQuoteResponseLiquidityAvailable.
-const (
-	CreateSwapQuoteResponseLiquidityAvailableTrue CreateSwapQuoteResponseLiquidityAvailable = true
 )
 
 // Defines values for CryptoDepositDestinationType.
@@ -478,11 +468,6 @@ const (
 // Defines values for FiatDepositDestinationType.
 const (
 	FiatDepositDestinationTypeFiat FiatDepositDestinationType = "fiat"
-)
-
-// Defines values for GetSwapPriceResponseLiquidityAvailable.
-const (
-	True GetSwapPriceResponseLiquidityAvailable = true
 )
 
 // Defines values for IndividualInputEmploymentStatus.
@@ -1239,11 +1224,6 @@ const (
 // Defines values for SplValueCriterionType.
 const (
 	SplValue SplValueCriterionType = "splValue"
-)
-
-// Defines values for SwapUnavailableResponseLiquidityAvailable.
-const (
-	False SwapUnavailableResponseLiquidityAvailable = false
 )
 
 // Defines values for SwiftPaymentMethodPaymentRail.
@@ -2163,8 +2143,14 @@ type Authorization struct {
 	// CreatedAt The UTC ISO 8601 timestamp at which the authorization was created.
 	CreatedAt *time.Time `json:"createdAt,omitempty"`
 
+	// CustomerDisplay Customer-facing display data for this authorization, shown to the payer. Present when supplied on the authorization request or when the session's `orderCode` fallback applies; otherwise omitted.
+	CustomerDisplay *OperationCustomerDisplay `json:"customerDisplay,omitempty"`
+
 	// Error An error that occurred during a payment operation.
 	Error *PaymentError `json:"error,omitempty"`
+
+	// ExternalReferenceId A merchant-provided internal identifier for this authorization, from the merchant's own system—not visible to the payer. Present only when supplied on the authorization request.
+	ExternalReferenceId *ExternalReferenceId `json:"externalReferenceId,omitempty"`
 
 	// Message A human-readable message describing the outcome or status for display. Returned for x402 authorizations; omitted for other authorization flows unless documented otherwise.
 	Message *string `json:"message,omitempty"`
@@ -2349,8 +2335,14 @@ type Capture struct {
 	// CreatedAt The UTC ISO 8601 timestamp at which the capture was created.
 	CreatedAt *time.Time `json:"createdAt,omitempty"`
 
+	// CustomerDisplay Customer-facing display data for this capture, shown to the payer. A manual capture falls back to the session's `orderCode` when `referenceCode` is omitted; an auto-capture reuses the authorization's `referenceCode`.
+	CustomerDisplay *OperationCustomerDisplay `json:"customerDisplay,omitempty"`
+
 	// Error An error that occurred during a payment operation.
 	Error *PaymentError `json:"error,omitempty"`
+
+	// ExternalReferenceId A merchant-provided internal identifier for this capture, from the merchant's own system—not visible to the payer. A manual capture uses the caller-provided value; an auto-capture reuses the authorization's value and omits it when the authorization omitted it. It never falls back to `PaymentSession.externalReferenceId`.
+	ExternalReferenceId *ExternalReferenceId `json:"externalReferenceId,omitempty"`
 
 	// FinalCapture When `true`, this capture is treated as the final one for the authorization. Any remaining capturable balance is released back to the payer immediately after the capture settles. When `false`, the remaining capturable balance stays held and is available for subsequent partial captures (subject to `captureExpiresAt`). Has no effect if `amount` equals the full capturable balance, since no remaining balance exists to release.
 	FinalCapture bool `json:"finalCapture"`
@@ -2376,6 +2368,12 @@ type CaptureId = string
 
 // CoinbaseAuthorizationRequest A request to authorize a payment session using the payer's Coinbase account authenticated via OAuth.
 type CoinbaseAuthorizationRequest struct {
+	// CustomerDisplay Optional customer-facing display data for this authorization, shown to the payer. Falls back to the session's `orderCode` when `referenceCode` is omitted.
+	CustomerDisplay *OperationCustomerDisplay `json:"customerDisplay,omitempty"`
+
+	// ExternalReferenceId An optional merchant-provided internal identifier for this Coinbase authorization, from the merchant's own system—not visible to the payer.
+	ExternalReferenceId *ExternalReferenceId `json:"externalReferenceId,omitempty"`
+
 	// Metadata Optional metadata as key-value pairs. Use this to store additional structured information on a resource, such as customer IDs, order references, or any application-specific data. Up to 10 key/value pairs may be provided. Keys and values are both strings. Keys must be ≤ 40 characters; values must be ≤ 500 characters.
 	Metadata *Metadata `json:"metadata,omitempty"`
 }
@@ -2413,7 +2411,7 @@ type CommonSwapResponse struct {
 	} `json:"issues"`
 
 	// LiquidityAvailable Whether sufficient liquidity is available to settle the swap. All other fields in the response will be empty if this is false.
-	LiquidityAvailable CommonSwapResponseLiquidityAvailable `json:"liquidityAvailable"`
+	LiquidityAvailable bool `json:"liquidityAvailable"`
 
 	// MinToAmount The minimum amount of the `toToken` that must be received for the swap to succeed, in atomic units of the `toToken`.  For example, `1000000000000000000` when receiving ETH equates to 1 ETH, `1000000` when receiving USDC equates to 1 USDC, etc. This value is influenced by the `slippageBps` parameter.
 	MinToAmount string `json:"minToAmount"`
@@ -2424,9 +2422,6 @@ type CommonSwapResponse struct {
 	// ToToken The 0x-prefixed contract address of the token that will be received.
 	ToToken string `json:"toToken"`
 }
-
-// CommonSwapResponseLiquidityAvailable Whether sufficient liquidity is available to settle the swap. All other fields in the response will be empty if this is false.
-type CommonSwapResponseLiquidityAvailable bool
 
 // CommonSwapResponseIssuesAllowance defines model for CommonSwapResponseIssuesAllowance.
 type CommonSwapResponseIssuesAllowance struct {
@@ -2494,6 +2489,12 @@ type CreateAccountRequest struct {
 type CreateCaptureRequest struct {
 	// Amount A decimal representation of the amount to capture, denominated in the session's `asset`. If omitted, the full remaining capturable amount is captured.
 	Amount *string `json:"amount,omitempty"`
+
+	// CustomerDisplay Optional customer-facing display data for this manual capture, shown to the payer. Falls back to the session's `orderCode` when `referenceCode` is omitted.
+	CustomerDisplay *OperationCustomerDisplay `json:"customerDisplay,omitempty"`
+
+	// ExternalReferenceId An optional merchant-provided internal identifier for this manual capture, from the merchant's own system—not visible to the payer.
+	ExternalReferenceId *ExternalReferenceId `json:"externalReferenceId,omitempty"`
 
 	// FinalCapture When `true`, this capture is treated as the final one for the authorization. Any remaining capturable balance is released back to the payer immediately after the capture settles. When `false`, the remaining capturable balance stays held and is available for subsequent partial captures (subject to `captureExpiresAt`). Has no effect if `amount` equals the full capturable balance, since no remaining balance exists to release.
 	FinalCapture bool `json:"finalCapture"`
@@ -2647,6 +2648,9 @@ type CreateDisbursementRequest struct {
 	// Compliance Compliance context for this disbursement. Carries recipient information required by some entity configurations to meet regulatory requirements.
 	Compliance *DisbursementCompliance `json:"compliance,omitempty"`
 
+	// CustomerDisplay Optional customer-facing display data for this disbursement, shown to the payer. If `referenceCode` is omitted, one is auto-generated — disbursements have no payment session to fall back to, unlike every other action type.
+	CustomerDisplay *OperationCustomerDisplay `json:"customerDisplay,omitempty"`
+
 	// ExternalReferenceId A merchant-provided internal identifier for this disbursement, from the merchant's own system—not visible to the payer. It must not contain personally identifiable information (PII) or payment credentials.
 	ExternalReferenceId *string `json:"externalReferenceId,omitempty"`
 
@@ -2758,6 +2762,12 @@ type CreateRefundRequest struct {
 	// Amount A decimal representation of the amount to refund, denominated in the session's `asset`. If omitted, the full remaining refundable amount is refunded.
 	Amount *string `json:"amount,omitempty"`
 
+	// CustomerDisplay Optional customer-facing display data for this refund, shown to the payer. Falls back to the session's `orderCode` when `referenceCode` is omitted.
+	CustomerDisplay *OperationCustomerDisplay `json:"customerDisplay,omitempty"`
+
+	// ExternalReferenceId An optional merchant-provided internal identifier for this refund, from the merchant's own system—not visible to the payer.
+	ExternalReferenceId *ExternalReferenceId `json:"externalReferenceId,omitempty"`
+
 	// Metadata Optional metadata as key-value pairs. Use this to store additional structured information on a resource, such as customer IDs, order references, or any application-specific data. Up to 10 key/value pairs may be provided. Keys and values are both strings. Keys must be ≤ 40 characters; values must be ≤ 500 characters.
 	Metadata *Metadata `json:"metadata,omitempty"`
 
@@ -2834,7 +2844,7 @@ type CreateSwapQuoteResponse struct {
 	} `json:"issues"`
 
 	// LiquidityAvailable Whether sufficient liquidity is available to settle the swap. All other fields in the response will be empty if this is false.
-	LiquidityAvailable CreateSwapQuoteResponseLiquidityAvailable `json:"liquidityAvailable"`
+	LiquidityAvailable bool `json:"liquidityAvailable"`
 
 	// MinToAmount The minimum amount of the `toToken` that must be received for the swap to succeed, in atomic units of the `toToken`.  For example, `1000000000000000000` when receiving ETH equates to 1 ETH, `1000000` when receiving USDC equates to 1 USDC, etc. This value is influenced by the `slippageBps` parameter.
 	MinToAmount string `json:"minToAmount"`
@@ -2867,9 +2877,6 @@ type CreateSwapQuoteResponse struct {
 	} `json:"transaction"`
 }
 
-// CreateSwapQuoteResponseLiquidityAvailable Whether sufficient liquidity is available to settle the swap. All other fields in the response will be empty if this is false.
-type CreateSwapQuoteResponseLiquidityAvailable bool
-
 // CreateSwapQuoteResponseWrapper A wrapper for the response of a swap quote operation.
 type CreateSwapQuoteResponseWrapper struct {
 	union json.RawMessage
@@ -2882,6 +2889,12 @@ type CreateTransferSource struct {
 
 // CreateVoidRequest A request to create a void for a payment session. A void releases all remaining capturable funds back to the payer, including after partial refunds as long as a capturableAmount remains.
 type CreateVoidRequest struct {
+	// CustomerDisplay Optional customer-facing display data for this void, shown to the payer. Falls back to the session's `orderCode` when `referenceCode` is omitted.
+	CustomerDisplay *OperationCustomerDisplay `json:"customerDisplay,omitempty"`
+
+	// ExternalReferenceId An optional merchant-provided internal identifier for this void, from the merchant's own system—not visible to the payer.
+	ExternalReferenceId *ExternalReferenceId `json:"externalReferenceId,omitempty"`
+
 	// Metadata Optional metadata as key-value pairs. Use this to store additional structured information on a resource, such as customer IDs, order references, or any application-specific data. Up to 10 key/value pairs may be provided. Keys and values are both strings. Keys must be ≤ 40 characters; values must be ≤ 500 characters.
 	Metadata *Metadata `json:"metadata,omitempty"`
 }
@@ -2969,10 +2982,16 @@ type CustomerDisplay struct {
 
 	// MerchantName The merchant name to display on the payment UI. When provided, this overrides the default name derived from the entity's profile. Useful when a merchant operates multiple storefronts or brands under a single entity.
 	MerchantName *string `json:"merchantName,omitempty"`
+
+	// OrderCode A customer-visible code for the overall order. When omitted, CDP generates one and returns it. It must not contain personally identifiable information (PII) or payment credentials.
+	OrderCode *string `json:"orderCode,omitempty"`
 }
 
 // CustomerId The ID of the Customer, which is a UUID prefixed by `customer_`.
 type CustomerId = string
+
+// CustomerReferenceCode A short customer-facing reference for an operation, visible to the payer. It must not contain personally identifiable information (PII) or payment credentials.
+type CustomerReferenceCode = string
 
 // CustomerType The type of the customer. Required on create; accepted but ignored on update.
 type CustomerType string
@@ -3240,6 +3259,9 @@ type Disbursement struct {
 
 	// CreatedAt The UTC ISO 8601 timestamp at which the disbursement was created.
 	CreatedAt time.Time `json:"createdAt"`
+
+	// CustomerDisplay Customer-facing display data for this disbursement, shown to the payer. Always present: if the create request omits `referenceCode`, one is auto-generated, since disbursements have no payment session to fall back to.
+	CustomerDisplay *OperationCustomerDisplay `json:"customerDisplay,omitempty"`
 
 	// DisbursementId The unique identifier of the disbursement.
 	DisbursementId DisbursementId `json:"disbursementId"`
@@ -3799,7 +3821,7 @@ type EvmTypedStringCondition struct {
 	Path string `json:"path"`
 }
 
-// EvmUserOperation defines model for EvmUserOperation.
+// EvmUserOperation A smart account operation response.
 type EvmUserOperation struct {
 	// Calls The list of calls in the user operation.
 	Calls []EvmCall `json:"calls"`
@@ -3828,6 +3850,9 @@ type EvmUserOperationStatus string
 
 // EvmUserOperationNetwork The network the user operation is for.
 type EvmUserOperationNetwork string
+
+// ExternalReferenceId A merchant-provided internal identifier for a resource from the merchant's own system—not visible to the payer. It must not contain personally identifiable information (PII) or payment credentials.
+type ExternalReferenceId = string
 
 // FedwireDepositSource The originating Fedwire deposit details for the transfer source. Present when funds were deposited via Fedwire into a deposit destination.
 type FedwireDepositSource struct {
@@ -3958,7 +3983,7 @@ type GetSwapPriceResponse struct {
 	} `json:"issues"`
 
 	// LiquidityAvailable Whether sufficient liquidity is available to settle the swap. All other fields in the response will be empty if this is false.
-	LiquidityAvailable GetSwapPriceResponseLiquidityAvailable `json:"liquidityAvailable"`
+	LiquidityAvailable bool `json:"liquidityAvailable"`
 
 	// MinToAmount The minimum amount of the `toToken` that must be received for the swap to succeed, in atomic units of the `toToken`.  For example, `1000000000000000000` when receiving ETH equates to 1 ETH, `1000000` when receiving USDC equates to 1 USDC, etc. This value is influenced by the `slippageBps` parameter.
 	MinToAmount string `json:"minToAmount"`
@@ -3969,9 +3994,6 @@ type GetSwapPriceResponse struct {
 	// ToToken The 0x-prefixed contract address of the token that will be received.
 	ToToken string `json:"toToken"`
 }
-
-// GetSwapPriceResponseLiquidityAvailable Whether sufficient liquidity is available to settle the swap. All other fields in the response will be empty if this is false.
-type GetSwapPriceResponseLiquidityAvailable bool
 
 // GetSwapPriceResponseWrapper A wrapper for the response of a swap price operation.
 type GetSwapPriceResponseWrapper struct {
@@ -4766,6 +4788,12 @@ type OnrampVerificationInitiation struct {
 	VerificationId OnrampVerificationId `json:"verificationId"`
 }
 
+// OperationCustomerDisplay Customer-facing display data for a payment operation, shown to the payer.
+type OperationCustomerDisplay struct {
+	// ReferenceCode A short reference code for this payment operation, visible to the payer.
+	ReferenceCode *CustomerReferenceCode `json:"referenceCode,omitempty"`
+}
+
 // Owner The Owner ID of the Account.
 //
 // Owner IDs are UUIDs prefixed with the Owner Type as follows:
@@ -5134,8 +5162,14 @@ type Refund struct {
 	// CreatedAt The UTC ISO 8601 timestamp at which the refund was created.
 	CreatedAt *time.Time `json:"createdAt,omitempty"`
 
+	// CustomerDisplay Customer-facing display data for this refund, shown to the payer. Present when supplied on the create refund request or when the session's `orderCode` fallback applies; otherwise omitted.
+	CustomerDisplay *OperationCustomerDisplay `json:"customerDisplay,omitempty"`
+
 	// Error An error that occurred during a payment operation.
 	Error *PaymentError `json:"error,omitempty"`
+
+	// ExternalReferenceId A merchant-provided internal identifier for this refund, from the merchant's own system—not visible to the payer. Present only when supplied on the create refund request.
+	ExternalReferenceId *ExternalReferenceId `json:"externalReferenceId,omitempty"`
 
 	// Metadata Optional metadata as key-value pairs. Use this to store additional structured information on a resource, such as customer IDs, order references, or any application-specific data. Up to 10 key/value pairs may be provided. Keys and values are both strings. Keys must be ≤ 40 characters; values must be ≤ 500 characters.
 	Metadata *Metadata `json:"metadata,omitempty"`
@@ -6178,11 +6212,8 @@ type SwapPermit2Approval struct {
 // SwapUnavailableResponse defines model for SwapUnavailableResponse.
 type SwapUnavailableResponse struct {
 	// LiquidityAvailable Whether sufficient liquidity is available to settle the swap. All other fields in the response will be empty if this is false.
-	LiquidityAvailable SwapUnavailableResponseLiquidityAvailable `json:"liquidityAvailable"`
+	LiquidityAvailable bool `json:"liquidityAvailable"`
 }
-
-// SwapUnavailableResponseLiquidityAvailable Whether sufficient liquidity is available to settle the swap. All other fields in the response will be empty if this is false.
-type SwapUnavailableResponseLiquidityAvailable bool
 
 // SwiftDetails Details specific to SWIFT (international wire) payment methods.
 type SwiftDetails struct {
@@ -6783,8 +6814,14 @@ type Void struct {
 	// CreatedAt The UTC ISO 8601 timestamp at which the void was created.
 	CreatedAt *time.Time `json:"createdAt,omitempty"`
 
+	// CustomerDisplay Customer-facing display data for this void, shown to the payer. Present when supplied on the create void request or when the session's `orderCode` fallback applies; otherwise omitted.
+	CustomerDisplay *OperationCustomerDisplay `json:"customerDisplay,omitempty"`
+
 	// Error An error that occurred during a payment operation.
 	Error *PaymentError `json:"error,omitempty"`
+
+	// ExternalReferenceId A merchant-provided internal identifier for this void, from the merchant's own system—not visible to the payer. Present only when supplied on the create void request.
+	ExternalReferenceId *ExternalReferenceId `json:"externalReferenceId,omitempty"`
 
 	// Metadata Optional metadata as key-value pairs. Use this to store additional structured information on a resource, such as customer IDs, order references, or any application-specific data. Up to 10 key/value pairs may be provided. Keys and values are both strings. Keys must be ≤ 40 characters; values must be ≤ 500 characters.
 	Metadata *Metadata `json:"metadata,omitempty"`
@@ -6855,6 +6892,12 @@ type WalletAuthorizationOptionsResponse struct {
 
 // WalletAuthorizationRequest A request to authorize a payment session using a wallet. The payer selects one of the options returned by the wallet authorization options endpoint and submits the signed payloads.
 type WalletAuthorizationRequest struct {
+	// CustomerDisplay Optional customer-facing display data for this authorization, shown to the payer. Falls back to the session's `orderCode` when `referenceCode` is omitted.
+	CustomerDisplay *OperationCustomerDisplay `json:"customerDisplay,omitempty"`
+
+	// ExternalReferenceId An optional merchant-provided internal identifier for this wallet authorization, from the merchant's own system—not visible to the payer.
+	ExternalReferenceId *ExternalReferenceId `json:"externalReferenceId,omitempty"`
+
 	// Metadata Optional metadata as key-value pairs. Use this to store additional structured information on a resource, such as customer IDs, order references, or any application-specific data. Up to 10 key/value pairs may be provided. Keys and values are both strings. Keys must be ≤ 40 characters; values must be ≤ 500 characters.
 	Metadata *Metadata `json:"metadata,omitempty"`
 
@@ -9631,6 +9674,12 @@ type GetWalletAuthorizationOptionsParams struct {
 type AuthorizeX402PaymentSessionParams struct {
 	// PAYMENTSIGNATURE Optional. Base64-encoded (RFC 4648) x402-compliant payment payload.
 	PAYMENTSIGNATURE *string `json:"PAYMENT-SIGNATURE,omitempty"`
+
+	// XExternalReferenceId An optional merchant-provided internal identifier for this x402 authorization, from the merchant's own system—not visible to the payer.
+	XExternalReferenceId *ExternalReferenceId `json:"X-External-Reference-Id,omitempty"`
+
+	// XCustomerDisplayReferenceCode A short customer-facing reference code for this x402 authorization, visible to the payer. Equivalent to `customerDisplay.referenceCode` on JSON authorization requests. Falls back to the session's `orderCode` when omitted.
+	XCustomerDisplayReferenceCode *CustomerReferenceCode `json:"X-Customer-Display-Reference-Code,omitempty"`
 
 	// XIdempotencyKey An optional string request header for making requests safely retryable.
 	// When included, duplicate requests with the same key will return identical responses.
@@ -26046,15 +26095,37 @@ func NewAuthorizeX402PaymentSessionRequest(server string, paymentSessionId Payme
 			req.Header.Set("PAYMENT-SIGNATURE", headerParam0)
 		}
 
-		if params.XIdempotencyKey != nil {
+		if params.XExternalReferenceId != nil {
 			var headerParam1 string
 
-			headerParam1, err = runtime.StyleParamWithLocation("simple", false, "X-Idempotency-Key", runtime.ParamLocationHeader, *params.XIdempotencyKey)
+			headerParam1, err = runtime.StyleParamWithLocation("simple", false, "X-External-Reference-Id", runtime.ParamLocationHeader, *params.XExternalReferenceId)
 			if err != nil {
 				return nil, err
 			}
 
-			req.Header.Set("X-Idempotency-Key", headerParam1)
+			req.Header.Set("X-External-Reference-Id", headerParam1)
+		}
+
+		if params.XCustomerDisplayReferenceCode != nil {
+			var headerParam2 string
+
+			headerParam2, err = runtime.StyleParamWithLocation("simple", false, "X-Customer-Display-Reference-Code", runtime.ParamLocationHeader, *params.XCustomerDisplayReferenceCode)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Customer-Display-Reference-Code", headerParam2)
+		}
+
+		if params.XIdempotencyKey != nil {
+			var headerParam3 string
+
+			headerParam3, err = runtime.StyleParamWithLocation("simple", false, "X-Idempotency-Key", runtime.ParamLocationHeader, *params.XIdempotencyKey)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Idempotency-Key", headerParam3)
 		}
 
 	}

--- a/java/src/main/java/com/coinbase/cdp/openapi/api/PaymentSessionsApi.java
+++ b/java/src/main/java/com/coinbase/cdp/openapi/api/PaymentSessionsApi.java
@@ -311,12 +311,14 @@ public class PaymentSessionsApi {
    * Authorizes a payment session using x402. The session must be in &#x60;created&#x60; status.  The client sends no request body. You may supply the base64-encoded x402-compliant payment payload in the optional **&#x60;PAYMENT-SIGNATURE&#x60;** header.  On authorization, a hold is placed on the payer&#39;s funds. The authorization is returned in &#x60;pending&#x60; status and transitions asynchronously to &#x60;succeeded&#x60; or &#x60;failed&#x60;.  **402 Payment Required** may be returned when payment must be supplied before authorization can proceed. The **402** response uses the standard CDP **&#x60;Error&#x60;** JSON body and may include a **&#x60;PAYMENT-REQUIRED&#x60;** header (see the **402** response) describing accepted networks, assets, and amounts.  If &#x60;autoCapture&#x60; is enabled on the session, a capture is automatically created after a successful authorization.
    * @param paymentSessionId The unique identifier of the payment session to authorize with x402. (required)
    * @param PAYMENT_SIGNATURE Optional. Base64-encoded (RFC 4648) x402-compliant payment payload. (optional)
+   * @param xExternalReferenceId An optional merchant-provided internal identifier for this x402 authorization, from the merchant&#39;s own system—not visible to the payer. (optional)
+   * @param xCustomerDisplayReferenceCode A short customer-facing reference code for this x402 authorization, visible to the payer. Equivalent to &#x60;customerDisplay.referenceCode&#x60; on JSON authorization requests. Falls back to the session&#39;s &#x60;orderCode&#x60; when omitted. (optional)
    * @param xIdempotencyKey An optional string request header for making requests safely retryable. When included, duplicate requests with the same key will return identical responses. Refer to our [Idempotency docs](https://docs.cdp.coinbase.com/api-reference/v2/idempotency) for more information on using idempotency keys.  (optional)
    * @return Authorization
    * @throws ApiException if fails to make API call
    */
-  public Authorization authorizeX402PaymentSession(String paymentSessionId, String PAYMENT_SIGNATURE, String xIdempotencyKey) throws ApiException {
-    ApiResponse<Authorization> localVarResponse = authorizeX402PaymentSessionWithHttpInfo(paymentSessionId, PAYMENT_SIGNATURE, xIdempotencyKey);
+  public Authorization authorizeX402PaymentSession(String paymentSessionId, String PAYMENT_SIGNATURE, String xExternalReferenceId, String xCustomerDisplayReferenceCode, String xIdempotencyKey) throws ApiException {
+    ApiResponse<Authorization> localVarResponse = authorizeX402PaymentSessionWithHttpInfo(paymentSessionId, PAYMENT_SIGNATURE, xExternalReferenceId, xCustomerDisplayReferenceCode, xIdempotencyKey);
     return localVarResponse.getData();
   }
 
@@ -325,12 +327,14 @@ public class PaymentSessionsApi {
    * Authorizes a payment session using x402. The session must be in &#x60;created&#x60; status.  The client sends no request body. You may supply the base64-encoded x402-compliant payment payload in the optional **&#x60;PAYMENT-SIGNATURE&#x60;** header.  On authorization, a hold is placed on the payer&#39;s funds. The authorization is returned in &#x60;pending&#x60; status and transitions asynchronously to &#x60;succeeded&#x60; or &#x60;failed&#x60;.  **402 Payment Required** may be returned when payment must be supplied before authorization can proceed. The **402** response uses the standard CDP **&#x60;Error&#x60;** JSON body and may include a **&#x60;PAYMENT-REQUIRED&#x60;** header (see the **402** response) describing accepted networks, assets, and amounts.  If &#x60;autoCapture&#x60; is enabled on the session, a capture is automatically created after a successful authorization.
    * @param paymentSessionId The unique identifier of the payment session to authorize with x402. (required)
    * @param PAYMENT_SIGNATURE Optional. Base64-encoded (RFC 4648) x402-compliant payment payload. (optional)
+   * @param xExternalReferenceId An optional merchant-provided internal identifier for this x402 authorization, from the merchant&#39;s own system—not visible to the payer. (optional)
+   * @param xCustomerDisplayReferenceCode A short customer-facing reference code for this x402 authorization, visible to the payer. Equivalent to &#x60;customerDisplay.referenceCode&#x60; on JSON authorization requests. Falls back to the session&#39;s &#x60;orderCode&#x60; when omitted. (optional)
    * @param xIdempotencyKey An optional string request header for making requests safely retryable. When included, duplicate requests with the same key will return identical responses. Refer to our [Idempotency docs](https://docs.cdp.coinbase.com/api-reference/v2/idempotency) for more information on using idempotency keys.  (optional)
    * @return ApiResponse&lt;Authorization&gt;
    * @throws ApiException if fails to make API call
    */
-  public ApiResponse<Authorization> authorizeX402PaymentSessionWithHttpInfo(String paymentSessionId, String PAYMENT_SIGNATURE, String xIdempotencyKey) throws ApiException {
-    HttpRequest.Builder localVarRequestBuilder = authorizeX402PaymentSessionRequestBuilder(paymentSessionId, PAYMENT_SIGNATURE, xIdempotencyKey);
+  public ApiResponse<Authorization> authorizeX402PaymentSessionWithHttpInfo(String paymentSessionId, String PAYMENT_SIGNATURE, String xExternalReferenceId, String xCustomerDisplayReferenceCode, String xIdempotencyKey) throws ApiException {
+    HttpRequest.Builder localVarRequestBuilder = authorizeX402PaymentSessionRequestBuilder(paymentSessionId, PAYMENT_SIGNATURE, xExternalReferenceId, xCustomerDisplayReferenceCode, xIdempotencyKey);
     try {
       HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
@@ -369,7 +373,7 @@ public class PaymentSessionsApi {
     }
   }
 
-  private HttpRequest.Builder authorizeX402PaymentSessionRequestBuilder(String paymentSessionId, String PAYMENT_SIGNATURE, String xIdempotencyKey) throws ApiException {
+  private HttpRequest.Builder authorizeX402PaymentSessionRequestBuilder(String paymentSessionId, String PAYMENT_SIGNATURE, String xExternalReferenceId, String xCustomerDisplayReferenceCode, String xIdempotencyKey) throws ApiException {
     // verify the required parameter 'paymentSessionId' is set
     if (paymentSessionId == null) {
       throw new ApiException(400, "Missing the required parameter 'paymentSessionId' when calling authorizeX402PaymentSession");
@@ -384,6 +388,12 @@ public class PaymentSessionsApi {
 
     if (PAYMENT_SIGNATURE != null) {
       localVarRequestBuilder.header("PAYMENT-SIGNATURE", PAYMENT_SIGNATURE.toString());
+    }
+    if (xExternalReferenceId != null) {
+      localVarRequestBuilder.header("X-External-Reference-Id", xExternalReferenceId.toString());
+    }
+    if (xCustomerDisplayReferenceCode != null) {
+      localVarRequestBuilder.header("X-Customer-Display-Reference-Code", xCustomerDisplayReferenceCode.toString());
     }
     if (xIdempotencyKey != null) {
       localVarRequestBuilder.header("X-Idempotency-Key", xIdempotencyKey.toString());

--- a/java/src/main/java/com/coinbase/cdp/openapi/model/Authorization.java
+++ b/java/src/main/java/com/coinbase/cdp/openapi/model/Authorization.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.HashMap;
 import com.coinbase.cdp.openapi.model.Metadata;
 import com.coinbase.cdp.openapi.model.OnchainTransaction;
+import com.coinbase.cdp.openapi.model.OperationCustomerDisplay;
 import com.coinbase.cdp.openapi.model.PaymentActionStatus;
 import com.coinbase.cdp.openapi.model.PaymentError;
 import com.coinbase.cdp.openapi.model.PaymentSessionSource;
@@ -48,6 +49,8 @@ import com.coinbase.cdp.openapi.ApiClient;
   Authorization.JSON_PROPERTY_ERROR,
   Authorization.JSON_PROPERTY_MESSAGE,
   Authorization.JSON_PROPERTY_METADATA,
+  Authorization.JSON_PROPERTY_EXTERNAL_REFERENCE_ID,
+  Authorization.JSON_PROPERTY_CUSTOMER_DISPLAY,
   Authorization.JSON_PROPERTY_SOURCE,
   Authorization.JSON_PROPERTY_ONCHAIN_TRANSACTIONS,
   Authorization.JSON_PROPERTY_CREATED_AT,
@@ -82,6 +85,14 @@ public class Authorization {
   public static final String JSON_PROPERTY_METADATA = "metadata";
   @jakarta.annotation.Nullable
   private Metadata metadata = new Metadata();
+
+  public static final String JSON_PROPERTY_EXTERNAL_REFERENCE_ID = "externalReferenceId";
+  @jakarta.annotation.Nullable
+  private String externalReferenceId;
+
+  public static final String JSON_PROPERTY_CUSTOMER_DISPLAY = "customerDisplay";
+  @jakarta.annotation.Nullable
+  private OperationCustomerDisplay customerDisplay;
 
   public static final String JSON_PROPERTY_SOURCE = "source";
   @jakarta.annotation.Nullable
@@ -270,6 +281,54 @@ public class Authorization {
   }
 
 
+  public Authorization externalReferenceId(@jakarta.annotation.Nullable String externalReferenceId) {
+    this.externalReferenceId = externalReferenceId;
+    return this;
+  }
+
+  /**
+   * A merchant-provided internal identifier for this authorization, from the merchant&#39;s own system—not visible to the payer. Present only when supplied on the authorization request.
+   * @return externalReferenceId
+   */
+  @jakarta.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_EXTERNAL_REFERENCE_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public String getExternalReferenceId() {
+    return externalReferenceId;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_EXTERNAL_REFERENCE_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setExternalReferenceId(@jakarta.annotation.Nullable String externalReferenceId) {
+    this.externalReferenceId = externalReferenceId;
+  }
+
+
+  public Authorization customerDisplay(@jakarta.annotation.Nullable OperationCustomerDisplay customerDisplay) {
+    this.customerDisplay = customerDisplay;
+    return this;
+  }
+
+  /**
+   * Customer-facing display data for this authorization, shown to the payer. Present when supplied on the authorization request or when the session&#39;s &#x60;orderCode&#x60; fallback applies; otherwise omitted.
+   * @return customerDisplay
+   */
+  @jakarta.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_CUSTOMER_DISPLAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public OperationCustomerDisplay getCustomerDisplay() {
+    return customerDisplay;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_CUSTOMER_DISPLAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setCustomerDisplay(@jakarta.annotation.Nullable OperationCustomerDisplay customerDisplay) {
+    this.customerDisplay = customerDisplay;
+  }
+
+
   public Authorization source(@jakarta.annotation.Nullable PaymentSessionSource source) {
     this.source = source;
     return this;
@@ -393,6 +452,8 @@ public class Authorization {
         Objects.equals(this.error, authorization.error) &&
         Objects.equals(this.message, authorization.message) &&
         Objects.equals(this.metadata, authorization.metadata) &&
+        Objects.equals(this.externalReferenceId, authorization.externalReferenceId) &&
+        Objects.equals(this.customerDisplay, authorization.customerDisplay) &&
         Objects.equals(this.source, authorization.source) &&
         Objects.equals(this.onchainTransactions, authorization.onchainTransactions) &&
         Objects.equals(this.createdAt, authorization.createdAt) &&
@@ -401,7 +462,7 @@ public class Authorization {
 
   @Override
   public int hashCode() {
-    return Objects.hash(authorizationId, paymentSessionId, status, amount, error, message, metadata, source, onchainTransactions, createdAt, updatedAt);
+    return Objects.hash(authorizationId, paymentSessionId, status, amount, error, message, metadata, externalReferenceId, customerDisplay, source, onchainTransactions, createdAt, updatedAt);
   }
 
   @Override
@@ -415,6 +476,8 @@ public class Authorization {
     sb.append("    error: ").append(toIndentedString(error)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    metadata: ").append(toIndentedString(metadata)).append("\n");
+    sb.append("    externalReferenceId: ").append(toIndentedString(externalReferenceId)).append("\n");
+    sb.append("    customerDisplay: ").append(toIndentedString(customerDisplay)).append("\n");
     sb.append("    source: ").append(toIndentedString(source)).append("\n");
     sb.append("    onchainTransactions: ").append(toIndentedString(onchainTransactions)).append("\n");
     sb.append("    createdAt: ").append(toIndentedString(createdAt)).append("\n");
@@ -501,6 +564,16 @@ public class Authorization {
       joiner.add(String.format("%smetadata%s=%s", prefix, suffix, URLEncoder.encode(ApiClient.valueToString(getMetadata()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
     }
 
+    // add `externalReferenceId` to the URL query string
+    if (getExternalReferenceId() != null) {
+      joiner.add(String.format("%sexternalReferenceId%s=%s", prefix, suffix, URLEncoder.encode(ApiClient.valueToString(getExternalReferenceId()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
+    }
+
+    // add `customerDisplay` to the URL query string
+    if (getCustomerDisplay() != null) {
+      joiner.add(getCustomerDisplay().toUrlQueryString(prefix + "customerDisplay" + suffix));
+    }
+
     // add `source` to the URL query string
     if (getSource() != null) {
       joiner.add(getSource().toUrlQueryString(prefix + "source" + suffix));
@@ -569,6 +642,14 @@ public class Authorization {
       this.instance.metadata = metadata;
       return this;
     }
+    public Authorization.Builder externalReferenceId(String externalReferenceId) {
+      this.instance.externalReferenceId = externalReferenceId;
+      return this;
+    }
+    public Authorization.Builder customerDisplay(OperationCustomerDisplay customerDisplay) {
+      this.instance.customerDisplay = customerDisplay;
+      return this;
+    }
     public Authorization.Builder source(PaymentSessionSource source) {
       this.instance.source = source;
       return this;
@@ -626,6 +707,8 @@ public class Authorization {
       .error(getError())
       .message(getMessage())
       .metadata(getMetadata())
+      .externalReferenceId(getExternalReferenceId())
+      .customerDisplay(getCustomerDisplay())
       .source(getSource())
       .onchainTransactions(getOnchainTransactions())
       .createdAt(getCreatedAt())

--- a/java/src/main/java/com/coinbase/cdp/openapi/model/Capture.java
+++ b/java/src/main/java/com/coinbase/cdp/openapi/model/Capture.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.HashMap;
 import com.coinbase.cdp.openapi.model.Metadata;
 import com.coinbase.cdp.openapi.model.OnchainTransaction;
+import com.coinbase.cdp.openapi.model.OperationCustomerDisplay;
 import com.coinbase.cdp.openapi.model.PaymentActionStatus;
 import com.coinbase.cdp.openapi.model.PaymentError;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -47,6 +48,8 @@ import com.coinbase.cdp.openapi.ApiClient;
   Capture.JSON_PROPERTY_FINAL_CAPTURE,
   Capture.JSON_PROPERTY_ERROR,
   Capture.JSON_PROPERTY_METADATA,
+  Capture.JSON_PROPERTY_EXTERNAL_REFERENCE_ID,
+  Capture.JSON_PROPERTY_CUSTOMER_DISPLAY,
   Capture.JSON_PROPERTY_ONCHAIN_TRANSACTIONS,
   Capture.JSON_PROPERTY_CREATED_AT,
   Capture.JSON_PROPERTY_UPDATED_AT
@@ -80,6 +83,14 @@ public class Capture {
   public static final String JSON_PROPERTY_METADATA = "metadata";
   @jakarta.annotation.Nullable
   private Metadata metadata = new Metadata();
+
+  public static final String JSON_PROPERTY_EXTERNAL_REFERENCE_ID = "externalReferenceId";
+  @jakarta.annotation.Nullable
+  private String externalReferenceId;
+
+  public static final String JSON_PROPERTY_CUSTOMER_DISPLAY = "customerDisplay";
+  @jakarta.annotation.Nullable
+  private OperationCustomerDisplay customerDisplay;
 
   public static final String JSON_PROPERTY_ONCHAIN_TRANSACTIONS = "onchainTransactions";
   @jakarta.annotation.Nullable
@@ -264,6 +275,54 @@ public class Capture {
   }
 
 
+  public Capture externalReferenceId(@jakarta.annotation.Nullable String externalReferenceId) {
+    this.externalReferenceId = externalReferenceId;
+    return this;
+  }
+
+  /**
+   * A merchant-provided internal identifier for this capture, from the merchant&#39;s own system—not visible to the payer. A manual capture uses the caller-provided value; an auto-capture reuses the authorization&#39;s value and omits it when the authorization omitted it. It never falls back to &#x60;PaymentSession.externalReferenceId&#x60;.
+   * @return externalReferenceId
+   */
+  @jakarta.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_EXTERNAL_REFERENCE_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public String getExternalReferenceId() {
+    return externalReferenceId;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_EXTERNAL_REFERENCE_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setExternalReferenceId(@jakarta.annotation.Nullable String externalReferenceId) {
+    this.externalReferenceId = externalReferenceId;
+  }
+
+
+  public Capture customerDisplay(@jakarta.annotation.Nullable OperationCustomerDisplay customerDisplay) {
+    this.customerDisplay = customerDisplay;
+    return this;
+  }
+
+  /**
+   * Customer-facing display data for this capture, shown to the payer. A manual capture falls back to the session&#39;s &#x60;orderCode&#x60; when &#x60;referenceCode&#x60; is omitted; an auto-capture reuses the authorization&#39;s &#x60;referenceCode&#x60;.
+   * @return customerDisplay
+   */
+  @jakarta.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_CUSTOMER_DISPLAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public OperationCustomerDisplay getCustomerDisplay() {
+    return customerDisplay;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_CUSTOMER_DISPLAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setCustomerDisplay(@jakarta.annotation.Nullable OperationCustomerDisplay customerDisplay) {
+    this.customerDisplay = customerDisplay;
+  }
+
+
   public Capture onchainTransactions(@jakarta.annotation.Nullable List<OnchainTransaction> onchainTransactions) {
     this.onchainTransactions = onchainTransactions;
     return this;
@@ -363,6 +422,8 @@ public class Capture {
         Objects.equals(this.finalCapture, capture.finalCapture) &&
         Objects.equals(this.error, capture.error) &&
         Objects.equals(this.metadata, capture.metadata) &&
+        Objects.equals(this.externalReferenceId, capture.externalReferenceId) &&
+        Objects.equals(this.customerDisplay, capture.customerDisplay) &&
         Objects.equals(this.onchainTransactions, capture.onchainTransactions) &&
         Objects.equals(this.createdAt, capture.createdAt) &&
         Objects.equals(this.updatedAt, capture.updatedAt);
@@ -370,7 +431,7 @@ public class Capture {
 
   @Override
   public int hashCode() {
-    return Objects.hash(captureId, paymentSessionId, status, amount, finalCapture, error, metadata, onchainTransactions, createdAt, updatedAt);
+    return Objects.hash(captureId, paymentSessionId, status, amount, finalCapture, error, metadata, externalReferenceId, customerDisplay, onchainTransactions, createdAt, updatedAt);
   }
 
   @Override
@@ -384,6 +445,8 @@ public class Capture {
     sb.append("    finalCapture: ").append(toIndentedString(finalCapture)).append("\n");
     sb.append("    error: ").append(toIndentedString(error)).append("\n");
     sb.append("    metadata: ").append(toIndentedString(metadata)).append("\n");
+    sb.append("    externalReferenceId: ").append(toIndentedString(externalReferenceId)).append("\n");
+    sb.append("    customerDisplay: ").append(toIndentedString(customerDisplay)).append("\n");
     sb.append("    onchainTransactions: ").append(toIndentedString(onchainTransactions)).append("\n");
     sb.append("    createdAt: ").append(toIndentedString(createdAt)).append("\n");
     sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
@@ -469,6 +532,16 @@ public class Capture {
       joiner.add(String.format("%smetadata%s=%s", prefix, suffix, URLEncoder.encode(ApiClient.valueToString(getMetadata()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
     }
 
+    // add `externalReferenceId` to the URL query string
+    if (getExternalReferenceId() != null) {
+      joiner.add(String.format("%sexternalReferenceId%s=%s", prefix, suffix, URLEncoder.encode(ApiClient.valueToString(getExternalReferenceId()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
+    }
+
+    // add `customerDisplay` to the URL query string
+    if (getCustomerDisplay() != null) {
+      joiner.add(getCustomerDisplay().toUrlQueryString(prefix + "customerDisplay" + suffix));
+    }
+
     // add `onchainTransactions` to the URL query string
     if (getOnchainTransactions() != null) {
       for (int i = 0; i < getOnchainTransactions().size(); i++) {
@@ -532,6 +605,14 @@ public class Capture {
       this.instance.metadata = metadata;
       return this;
     }
+    public Capture.Builder externalReferenceId(String externalReferenceId) {
+      this.instance.externalReferenceId = externalReferenceId;
+      return this;
+    }
+    public Capture.Builder customerDisplay(OperationCustomerDisplay customerDisplay) {
+      this.instance.customerDisplay = customerDisplay;
+      return this;
+    }
     public Capture.Builder onchainTransactions(List<OnchainTransaction> onchainTransactions) {
       this.instance.onchainTransactions = onchainTransactions;
       return this;
@@ -585,6 +666,8 @@ public class Capture {
       .finalCapture(getFinalCapture())
       .error(getError())
       .metadata(getMetadata())
+      .externalReferenceId(getExternalReferenceId())
+      .customerDisplay(getCustomerDisplay())
       .onchainTransactions(getOnchainTransactions())
       .createdAt(getCreatedAt())
       .updatedAt(getUpdatedAt());

--- a/java/src/main/java/com/coinbase/cdp/openapi/model/CoinbaseAuthorizationRequest.java
+++ b/java/src/main/java/com/coinbase/cdp/openapi/model/CoinbaseAuthorizationRequest.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 import java.util.Map;
 import java.util.HashMap;
 import com.coinbase.cdp.openapi.model.Metadata;
+import com.coinbase.cdp.openapi.model.OperationCustomerDisplay;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -34,13 +35,23 @@ import com.coinbase.cdp.openapi.ApiClient;
  * A request to authorize a payment session using the payer&#39;s Coinbase account authenticated via OAuth.
  */
 @JsonPropertyOrder({
-  CoinbaseAuthorizationRequest.JSON_PROPERTY_METADATA
+  CoinbaseAuthorizationRequest.JSON_PROPERTY_METADATA,
+  CoinbaseAuthorizationRequest.JSON_PROPERTY_CUSTOMER_DISPLAY,
+  CoinbaseAuthorizationRequest.JSON_PROPERTY_EXTERNAL_REFERENCE_ID
 })
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.11.0")
 public class CoinbaseAuthorizationRequest {
   public static final String JSON_PROPERTY_METADATA = "metadata";
   @jakarta.annotation.Nullable
   private Metadata metadata = new Metadata();
+
+  public static final String JSON_PROPERTY_CUSTOMER_DISPLAY = "customerDisplay";
+  @jakarta.annotation.Nullable
+  private OperationCustomerDisplay customerDisplay;
+
+  public static final String JSON_PROPERTY_EXTERNAL_REFERENCE_ID = "externalReferenceId";
+  @jakarta.annotation.Nullable
+  private String externalReferenceId;
 
   public CoinbaseAuthorizationRequest() { 
   }
@@ -69,6 +80,54 @@ public class CoinbaseAuthorizationRequest {
   }
 
 
+  public CoinbaseAuthorizationRequest customerDisplay(@jakarta.annotation.Nullable OperationCustomerDisplay customerDisplay) {
+    this.customerDisplay = customerDisplay;
+    return this;
+  }
+
+  /**
+   * Optional customer-facing display data for this authorization, shown to the payer. Falls back to the session&#39;s &#x60;orderCode&#x60; when &#x60;referenceCode&#x60; is omitted.
+   * @return customerDisplay
+   */
+  @jakarta.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_CUSTOMER_DISPLAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public OperationCustomerDisplay getCustomerDisplay() {
+    return customerDisplay;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_CUSTOMER_DISPLAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setCustomerDisplay(@jakarta.annotation.Nullable OperationCustomerDisplay customerDisplay) {
+    this.customerDisplay = customerDisplay;
+  }
+
+
+  public CoinbaseAuthorizationRequest externalReferenceId(@jakarta.annotation.Nullable String externalReferenceId) {
+    this.externalReferenceId = externalReferenceId;
+    return this;
+  }
+
+  /**
+   * An optional merchant-provided internal identifier for this Coinbase authorization, from the merchant&#39;s own system—not visible to the payer.
+   * @return externalReferenceId
+   */
+  @jakarta.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_EXTERNAL_REFERENCE_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public String getExternalReferenceId() {
+    return externalReferenceId;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_EXTERNAL_REFERENCE_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setExternalReferenceId(@jakarta.annotation.Nullable String externalReferenceId) {
+    this.externalReferenceId = externalReferenceId;
+  }
+
+
   /**
    * Return true if this CoinbaseAuthorizationRequest object is equal to o.
    */
@@ -81,12 +140,14 @@ public class CoinbaseAuthorizationRequest {
       return false;
     }
     CoinbaseAuthorizationRequest coinbaseAuthorizationRequest = (CoinbaseAuthorizationRequest) o;
-    return Objects.equals(this.metadata, coinbaseAuthorizationRequest.metadata);
+    return Objects.equals(this.metadata, coinbaseAuthorizationRequest.metadata) &&
+        Objects.equals(this.customerDisplay, coinbaseAuthorizationRequest.customerDisplay) &&
+        Objects.equals(this.externalReferenceId, coinbaseAuthorizationRequest.externalReferenceId);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(metadata);
+    return Objects.hash(metadata, customerDisplay, externalReferenceId);
   }
 
   @Override
@@ -94,6 +155,8 @@ public class CoinbaseAuthorizationRequest {
     StringBuilder sb = new StringBuilder();
     sb.append("class CoinbaseAuthorizationRequest {\n");
     sb.append("    metadata: ").append(toIndentedString(metadata)).append("\n");
+    sb.append("    customerDisplay: ").append(toIndentedString(customerDisplay)).append("\n");
+    sb.append("    externalReferenceId: ").append(toIndentedString(externalReferenceId)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -146,6 +209,16 @@ public class CoinbaseAuthorizationRequest {
       joiner.add(String.format("%smetadata%s=%s", prefix, suffix, URLEncoder.encode(ApiClient.valueToString(getMetadata()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
     }
 
+    // add `customerDisplay` to the URL query string
+    if (getCustomerDisplay() != null) {
+      joiner.add(getCustomerDisplay().toUrlQueryString(prefix + "customerDisplay" + suffix));
+    }
+
+    // add `externalReferenceId` to the URL query string
+    if (getExternalReferenceId() != null) {
+      joiner.add(String.format("%sexternalReferenceId%s=%s", prefix, suffix, URLEncoder.encode(ApiClient.valueToString(getExternalReferenceId()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
+    }
+
     return joiner.toString();
   }
 
@@ -163,6 +236,14 @@ public class CoinbaseAuthorizationRequest {
 
     public CoinbaseAuthorizationRequest.Builder metadata(Metadata metadata) {
       this.instance.metadata = metadata;
+      return this;
+    }
+    public CoinbaseAuthorizationRequest.Builder customerDisplay(OperationCustomerDisplay customerDisplay) {
+      this.instance.customerDisplay = customerDisplay;
+      return this;
+    }
+    public CoinbaseAuthorizationRequest.Builder externalReferenceId(String externalReferenceId) {
+      this.instance.externalReferenceId = externalReferenceId;
       return this;
     }
 
@@ -199,7 +280,9 @@ public class CoinbaseAuthorizationRequest {
   */
   public CoinbaseAuthorizationRequest.Builder toBuilder() {
     return new CoinbaseAuthorizationRequest.Builder()
-      .metadata(getMetadata());
+      .metadata(getMetadata())
+      .customerDisplay(getCustomerDisplay())
+      .externalReferenceId(getExternalReferenceId());
   }
 
 }

--- a/java/src/main/java/com/coinbase/cdp/openapi/model/CommonSwapResponse.java
+++ b/java/src/main/java/com/coinbase/cdp/openapi/model/CommonSwapResponse.java
@@ -67,42 +67,9 @@ public class CommonSwapResponse {
   @jakarta.annotation.Nonnull
   private CommonSwapResponseIssues issues;
 
-  /**
-   * Whether sufficient liquidity is available to settle the swap. All other fields in the response will be empty if this is false.
-   */
-  public enum LiquidityAvailableEnum {
-    TRUE(Boolean.valueOf("true"));
-
-    private Boolean value;
-
-    LiquidityAvailableEnum(Boolean value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public Boolean getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static LiquidityAvailableEnum fromValue(Boolean value) {
-      for (LiquidityAvailableEnum b : LiquidityAvailableEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
   public static final String JSON_PROPERTY_LIQUIDITY_AVAILABLE = "liquidityAvailable";
   @jakarta.annotation.Nonnull
-  private LiquidityAvailableEnum liquidityAvailable;
+  private Boolean liquidityAvailable;
 
   public static final String JSON_PROPERTY_MIN_TO_AMOUNT = "minToAmount";
   @jakarta.annotation.Nonnull
@@ -239,7 +206,7 @@ public class CommonSwapResponse {
   }
 
 
-  public CommonSwapResponse liquidityAvailable(@jakarta.annotation.Nonnull LiquidityAvailableEnum liquidityAvailable) {
+  public CommonSwapResponse liquidityAvailable(@jakarta.annotation.Nonnull Boolean liquidityAvailable) {
     this.liquidityAvailable = liquidityAvailable;
     return this;
   }
@@ -251,14 +218,14 @@ public class CommonSwapResponse {
   @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_LIQUIDITY_AVAILABLE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
-  public LiquidityAvailableEnum getLiquidityAvailable() {
+  public Boolean getLiquidityAvailable() {
     return liquidityAvailable;
   }
 
 
   @JsonProperty(JSON_PROPERTY_LIQUIDITY_AVAILABLE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
-  public void setLiquidityAvailable(@jakarta.annotation.Nonnull LiquidityAvailableEnum liquidityAvailable) {
+  public void setLiquidityAvailable(@jakarta.annotation.Nonnull Boolean liquidityAvailable) {
     this.liquidityAvailable = liquidityAvailable;
   }
 
@@ -503,7 +470,7 @@ public class CommonSwapResponse {
       this.instance.issues = issues;
       return this;
     }
-    public CommonSwapResponse.Builder liquidityAvailable(LiquidityAvailableEnum liquidityAvailable) {
+    public CommonSwapResponse.Builder liquidityAvailable(Boolean liquidityAvailable) {
       this.instance.liquidityAvailable = liquidityAvailable;
       return this;
     }

--- a/java/src/main/java/com/coinbase/cdp/openapi/model/CommonSwapResponseNot.java
+++ b/java/src/main/java/com/coinbase/cdp/openapi/model/CommonSwapResponseNot.java
@@ -30,46 +30,79 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import com.coinbase.cdp.openapi.ApiClient;
 /**
- * SwapUnavailableResponse
+ * CommonSwapResponseNot
  */
 @JsonPropertyOrder({
-  SwapUnavailableResponse.JSON_PROPERTY_LIQUIDITY_AVAILABLE
+  CommonSwapResponseNot.JSON_PROPERTY_LIQUIDITY_AVAILABLE
 })
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.11.0")
-public class SwapUnavailableResponse {
-  public static final String JSON_PROPERTY_LIQUIDITY_AVAILABLE = "liquidityAvailable";
-  @jakarta.annotation.Nonnull
-  private Boolean liquidityAvailable;
+public class CommonSwapResponseNot {
+  /**
+   * Gets or Sets liquidityAvailable
+   */
+  public enum LiquidityAvailableEnum {
+    FALSE(Boolean.valueOf("false"));
 
-  public SwapUnavailableResponse() { 
+    private Boolean value;
+
+    LiquidityAvailableEnum(Boolean value) {
+      this.value = value;
+    }
+
+    @JsonValue
+    public Boolean getValue() {
+      return value;
+    }
+
+    @Override
+    public String toString() {
+      return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static LiquidityAvailableEnum fromValue(Boolean value) {
+      for (LiquidityAvailableEnum b : LiquidityAvailableEnum.values()) {
+        if (b.value.equals(value)) {
+          return b;
+        }
+      }
+      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
   }
 
-  public SwapUnavailableResponse liquidityAvailable(@jakarta.annotation.Nonnull Boolean liquidityAvailable) {
+  public static final String JSON_PROPERTY_LIQUIDITY_AVAILABLE = "liquidityAvailable";
+  @jakarta.annotation.Nullable
+  private LiquidityAvailableEnum liquidityAvailable;
+
+  public CommonSwapResponseNot() { 
+  }
+
+  public CommonSwapResponseNot liquidityAvailable(@jakarta.annotation.Nullable LiquidityAvailableEnum liquidityAvailable) {
     this.liquidityAvailable = liquidityAvailable;
     return this;
   }
 
   /**
-   * Whether sufficient liquidity is available to settle the swap. All other fields in the response will be empty if this is false.
+   * Get liquidityAvailable
    * @return liquidityAvailable
    */
-  @jakarta.annotation.Nonnull
+  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LIQUIDITY_AVAILABLE)
-  @JsonInclude(value = JsonInclude.Include.ALWAYS)
-  public Boolean getLiquidityAvailable() {
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public LiquidityAvailableEnum getLiquidityAvailable() {
     return liquidityAvailable;
   }
 
 
   @JsonProperty(JSON_PROPERTY_LIQUIDITY_AVAILABLE)
-  @JsonInclude(value = JsonInclude.Include.ALWAYS)
-  public void setLiquidityAvailable(@jakarta.annotation.Nonnull Boolean liquidityAvailable) {
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setLiquidityAvailable(@jakarta.annotation.Nullable LiquidityAvailableEnum liquidityAvailable) {
     this.liquidityAvailable = liquidityAvailable;
   }
 
 
   /**
-   * Return true if this SwapUnavailableResponse object is equal to o.
+   * Return true if this CommonSwapResponse_not object is equal to o.
    */
   @Override
   public boolean equals(Object o) {
@@ -79,8 +112,8 @@ public class SwapUnavailableResponse {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    SwapUnavailableResponse swapUnavailableResponse = (SwapUnavailableResponse) o;
-    return Objects.equals(this.liquidityAvailable, swapUnavailableResponse.liquidityAvailable);
+    CommonSwapResponseNot commonSwapResponseNot = (CommonSwapResponseNot) o;
+    return Objects.equals(this.liquidityAvailable, commonSwapResponseNot.liquidityAvailable);
   }
 
   @Override
@@ -91,7 +124,7 @@ public class SwapUnavailableResponse {
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
-    sb.append("class SwapUnavailableResponse {\n");
+    sb.append("class CommonSwapResponseNot {\n");
     sb.append("    liquidityAvailable: ").append(toIndentedString(liquidityAvailable)).append("\n");
     sb.append("}");
     return sb.toString();
@@ -150,28 +183,28 @@ public class SwapUnavailableResponse {
 
     public static class Builder {
 
-    private SwapUnavailableResponse instance;
+    private CommonSwapResponseNot instance;
 
     public Builder() {
-      this(new SwapUnavailableResponse());
+      this(new CommonSwapResponseNot());
     }
 
-    protected Builder(SwapUnavailableResponse instance) {
+    protected Builder(CommonSwapResponseNot instance) {
       this.instance = instance;
     }
 
-    public SwapUnavailableResponse.Builder liquidityAvailable(Boolean liquidityAvailable) {
+    public CommonSwapResponseNot.Builder liquidityAvailable(LiquidityAvailableEnum liquidityAvailable) {
       this.instance.liquidityAvailable = liquidityAvailable;
       return this;
     }
 
 
     /**
-    * returns a built SwapUnavailableResponse instance.
+    * returns a built CommonSwapResponseNot instance.
     *
     * The builder is not reusable.
     */
-    public SwapUnavailableResponse build() {
+    public CommonSwapResponseNot build() {
       try {
         return this.instance;
       } finally {
@@ -189,15 +222,15 @@ public class SwapUnavailableResponse {
   /**
   * Create a builder with no initialized field.
   */
-  public static SwapUnavailableResponse.Builder builder() {
-    return new SwapUnavailableResponse.Builder();
+  public static CommonSwapResponseNot.Builder builder() {
+    return new CommonSwapResponseNot.Builder();
   }
 
   /**
   * Create a builder with a shallow copy of this instance.
   */
-  public SwapUnavailableResponse.Builder toBuilder() {
-    return new SwapUnavailableResponse.Builder()
+  public CommonSwapResponseNot.Builder toBuilder() {
+    return new CommonSwapResponseNot.Builder()
       .liquidityAvailable(getLiquidityAvailable());
   }
 

--- a/java/src/main/java/com/coinbase/cdp/openapi/model/CreateCaptureRequest.java
+++ b/java/src/main/java/com/coinbase/cdp/openapi/model/CreateCaptureRequest.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 import java.util.Map;
 import java.util.HashMap;
 import com.coinbase.cdp.openapi.model.Metadata;
+import com.coinbase.cdp.openapi.model.OperationCustomerDisplay;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -36,7 +37,9 @@ import com.coinbase.cdp.openapi.ApiClient;
 @JsonPropertyOrder({
   CreateCaptureRequest.JSON_PROPERTY_AMOUNT,
   CreateCaptureRequest.JSON_PROPERTY_FINAL_CAPTURE,
-  CreateCaptureRequest.JSON_PROPERTY_METADATA
+  CreateCaptureRequest.JSON_PROPERTY_METADATA,
+  CreateCaptureRequest.JSON_PROPERTY_EXTERNAL_REFERENCE_ID,
+  CreateCaptureRequest.JSON_PROPERTY_CUSTOMER_DISPLAY
 })
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.11.0")
 public class CreateCaptureRequest {
@@ -51,6 +54,14 @@ public class CreateCaptureRequest {
   public static final String JSON_PROPERTY_METADATA = "metadata";
   @jakarta.annotation.Nullable
   private Metadata metadata = new Metadata();
+
+  public static final String JSON_PROPERTY_EXTERNAL_REFERENCE_ID = "externalReferenceId";
+  @jakarta.annotation.Nullable
+  private String externalReferenceId;
+
+  public static final String JSON_PROPERTY_CUSTOMER_DISPLAY = "customerDisplay";
+  @jakarta.annotation.Nullable
+  private OperationCustomerDisplay customerDisplay;
 
   public CreateCaptureRequest() { 
   }
@@ -127,6 +138,54 @@ public class CreateCaptureRequest {
   }
 
 
+  public CreateCaptureRequest externalReferenceId(@jakarta.annotation.Nullable String externalReferenceId) {
+    this.externalReferenceId = externalReferenceId;
+    return this;
+  }
+
+  /**
+   * An optional merchant-provided internal identifier for this manual capture, from the merchant&#39;s own system—not visible to the payer.
+   * @return externalReferenceId
+   */
+  @jakarta.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_EXTERNAL_REFERENCE_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public String getExternalReferenceId() {
+    return externalReferenceId;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_EXTERNAL_REFERENCE_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setExternalReferenceId(@jakarta.annotation.Nullable String externalReferenceId) {
+    this.externalReferenceId = externalReferenceId;
+  }
+
+
+  public CreateCaptureRequest customerDisplay(@jakarta.annotation.Nullable OperationCustomerDisplay customerDisplay) {
+    this.customerDisplay = customerDisplay;
+    return this;
+  }
+
+  /**
+   * Optional customer-facing display data for this manual capture, shown to the payer. Falls back to the session&#39;s &#x60;orderCode&#x60; when &#x60;referenceCode&#x60; is omitted.
+   * @return customerDisplay
+   */
+  @jakarta.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_CUSTOMER_DISPLAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public OperationCustomerDisplay getCustomerDisplay() {
+    return customerDisplay;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_CUSTOMER_DISPLAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setCustomerDisplay(@jakarta.annotation.Nullable OperationCustomerDisplay customerDisplay) {
+    this.customerDisplay = customerDisplay;
+  }
+
+
   /**
    * Return true if this CreateCaptureRequest object is equal to o.
    */
@@ -141,12 +200,14 @@ public class CreateCaptureRequest {
     CreateCaptureRequest createCaptureRequest = (CreateCaptureRequest) o;
     return Objects.equals(this.amount, createCaptureRequest.amount) &&
         Objects.equals(this.finalCapture, createCaptureRequest.finalCapture) &&
-        Objects.equals(this.metadata, createCaptureRequest.metadata);
+        Objects.equals(this.metadata, createCaptureRequest.metadata) &&
+        Objects.equals(this.externalReferenceId, createCaptureRequest.externalReferenceId) &&
+        Objects.equals(this.customerDisplay, createCaptureRequest.customerDisplay);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(amount, finalCapture, metadata);
+    return Objects.hash(amount, finalCapture, metadata, externalReferenceId, customerDisplay);
   }
 
   @Override
@@ -156,6 +217,8 @@ public class CreateCaptureRequest {
     sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
     sb.append("    finalCapture: ").append(toIndentedString(finalCapture)).append("\n");
     sb.append("    metadata: ").append(toIndentedString(metadata)).append("\n");
+    sb.append("    externalReferenceId: ").append(toIndentedString(externalReferenceId)).append("\n");
+    sb.append("    customerDisplay: ").append(toIndentedString(customerDisplay)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -218,6 +281,16 @@ public class CreateCaptureRequest {
       joiner.add(String.format("%smetadata%s=%s", prefix, suffix, URLEncoder.encode(ApiClient.valueToString(getMetadata()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
     }
 
+    // add `externalReferenceId` to the URL query string
+    if (getExternalReferenceId() != null) {
+      joiner.add(String.format("%sexternalReferenceId%s=%s", prefix, suffix, URLEncoder.encode(ApiClient.valueToString(getExternalReferenceId()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
+    }
+
+    // add `customerDisplay` to the URL query string
+    if (getCustomerDisplay() != null) {
+      joiner.add(getCustomerDisplay().toUrlQueryString(prefix + "customerDisplay" + suffix));
+    }
+
     return joiner.toString();
   }
 
@@ -243,6 +316,14 @@ public class CreateCaptureRequest {
     }
     public CreateCaptureRequest.Builder metadata(Metadata metadata) {
       this.instance.metadata = metadata;
+      return this;
+    }
+    public CreateCaptureRequest.Builder externalReferenceId(String externalReferenceId) {
+      this.instance.externalReferenceId = externalReferenceId;
+      return this;
+    }
+    public CreateCaptureRequest.Builder customerDisplay(OperationCustomerDisplay customerDisplay) {
+      this.instance.customerDisplay = customerDisplay;
       return this;
     }
 
@@ -281,7 +362,9 @@ public class CreateCaptureRequest {
     return new CreateCaptureRequest.Builder()
       .amount(getAmount())
       .finalCapture(getFinalCapture())
-      .metadata(getMetadata());
+      .metadata(getMetadata())
+      .externalReferenceId(getExternalReferenceId())
+      .customerDisplay(getCustomerDisplay());
   }
 
 }

--- a/java/src/main/java/com/coinbase/cdp/openapi/model/CreateDisbursementRequest.java
+++ b/java/src/main/java/com/coinbase/cdp/openapi/model/CreateDisbursementRequest.java
@@ -23,6 +23,7 @@ import com.coinbase.cdp.openapi.model.DisbursementCompliance;
 import com.coinbase.cdp.openapi.model.DisbursementSource;
 import com.coinbase.cdp.openapi.model.DisbursementTarget;
 import com.coinbase.cdp.openapi.model.Metadata;
+import com.coinbase.cdp.openapi.model.OperationCustomerDisplay;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -43,6 +44,7 @@ import com.coinbase.cdp.openapi.ApiClient;
   CreateDisbursementRequest.JSON_PROPERTY_ASSET,
   CreateDisbursementRequest.JSON_PROPERTY_REASON,
   CreateDisbursementRequest.JSON_PROPERTY_EXTERNAL_REFERENCE_ID,
+  CreateDisbursementRequest.JSON_PROPERTY_CUSTOMER_DISPLAY,
   CreateDisbursementRequest.JSON_PROPERTY_METADATA,
   CreateDisbursementRequest.JSON_PROPERTY_COMPLIANCE
 })
@@ -71,6 +73,10 @@ public class CreateDisbursementRequest {
   public static final String JSON_PROPERTY_EXTERNAL_REFERENCE_ID = "externalReferenceId";
   @jakarta.annotation.Nullable
   private String externalReferenceId;
+
+  public static final String JSON_PROPERTY_CUSTOMER_DISPLAY = "customerDisplay";
+  @jakarta.annotation.Nullable
+  private OperationCustomerDisplay customerDisplay;
 
   public static final String JSON_PROPERTY_METADATA = "metadata";
   @jakarta.annotation.Nullable
@@ -227,6 +233,30 @@ public class CreateDisbursementRequest {
   }
 
 
+  public CreateDisbursementRequest customerDisplay(@jakarta.annotation.Nullable OperationCustomerDisplay customerDisplay) {
+    this.customerDisplay = customerDisplay;
+    return this;
+  }
+
+  /**
+   * Optional customer-facing display data for this disbursement, shown to the payer. If &#x60;referenceCode&#x60; is omitted, one is auto-generated — disbursements have no payment session to fall back to, unlike every other action type.
+   * @return customerDisplay
+   */
+  @jakarta.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_CUSTOMER_DISPLAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public OperationCustomerDisplay getCustomerDisplay() {
+    return customerDisplay;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_CUSTOMER_DISPLAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setCustomerDisplay(@jakarta.annotation.Nullable OperationCustomerDisplay customerDisplay) {
+    this.customerDisplay = customerDisplay;
+  }
+
+
   public CreateDisbursementRequest metadata(@jakarta.annotation.Nullable Metadata metadata) {
     this.metadata = metadata;
     return this;
@@ -293,13 +323,14 @@ public class CreateDisbursementRequest {
         Objects.equals(this.asset, createDisbursementRequest.asset) &&
         Objects.equals(this.reason, createDisbursementRequest.reason) &&
         Objects.equals(this.externalReferenceId, createDisbursementRequest.externalReferenceId) &&
+        Objects.equals(this.customerDisplay, createDisbursementRequest.customerDisplay) &&
         Objects.equals(this.metadata, createDisbursementRequest.metadata) &&
         Objects.equals(this.compliance, createDisbursementRequest.compliance);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(source, target, amount, asset, reason, externalReferenceId, metadata, compliance);
+    return Objects.hash(source, target, amount, asset, reason, externalReferenceId, customerDisplay, metadata, compliance);
   }
 
   @Override
@@ -312,6 +343,7 @@ public class CreateDisbursementRequest {
     sb.append("    asset: ").append(toIndentedString(asset)).append("\n");
     sb.append("    reason: ").append(toIndentedString(reason)).append("\n");
     sb.append("    externalReferenceId: ").append(toIndentedString(externalReferenceId)).append("\n");
+    sb.append("    customerDisplay: ").append(toIndentedString(customerDisplay)).append("\n");
     sb.append("    metadata: ").append(toIndentedString(metadata)).append("\n");
     sb.append("    compliance: ").append(toIndentedString(compliance)).append("\n");
     sb.append("}");
@@ -391,6 +423,11 @@ public class CreateDisbursementRequest {
       joiner.add(String.format("%sexternalReferenceId%s=%s", prefix, suffix, URLEncoder.encode(ApiClient.valueToString(getExternalReferenceId()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
     }
 
+    // add `customerDisplay` to the URL query string
+    if (getCustomerDisplay() != null) {
+      joiner.add(getCustomerDisplay().toUrlQueryString(prefix + "customerDisplay" + suffix));
+    }
+
     // add `metadata` to the URL query string
     if (getMetadata() != null) {
       joiner.add(String.format("%smetadata%s=%s", prefix, suffix, URLEncoder.encode(ApiClient.valueToString(getMetadata()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
@@ -438,6 +475,10 @@ public class CreateDisbursementRequest {
     }
     public CreateDisbursementRequest.Builder externalReferenceId(String externalReferenceId) {
       this.instance.externalReferenceId = externalReferenceId;
+      return this;
+    }
+    public CreateDisbursementRequest.Builder customerDisplay(OperationCustomerDisplay customerDisplay) {
+      this.instance.customerDisplay = customerDisplay;
       return this;
     }
     public CreateDisbursementRequest.Builder metadata(Metadata metadata) {
@@ -488,6 +529,7 @@ public class CreateDisbursementRequest {
       .asset(getAsset())
       .reason(getReason())
       .externalReferenceId(getExternalReferenceId())
+      .customerDisplay(getCustomerDisplay())
       .metadata(getMetadata())
       .compliance(getCompliance());
   }

--- a/java/src/main/java/com/coinbase/cdp/openapi/model/CreateRefundRequest.java
+++ b/java/src/main/java/com/coinbase/cdp/openapi/model/CreateRefundRequest.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 import java.util.Map;
 import java.util.HashMap;
 import com.coinbase.cdp.openapi.model.Metadata;
+import com.coinbase.cdp.openapi.model.OperationCustomerDisplay;
 import com.coinbase.cdp.openapi.model.RefundSource;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -38,7 +39,9 @@ import com.coinbase.cdp.openapi.ApiClient;
   CreateRefundRequest.JSON_PROPERTY_SOURCE,
   CreateRefundRequest.JSON_PROPERTY_AMOUNT,
   CreateRefundRequest.JSON_PROPERTY_REASON,
-  CreateRefundRequest.JSON_PROPERTY_METADATA
+  CreateRefundRequest.JSON_PROPERTY_METADATA,
+  CreateRefundRequest.JSON_PROPERTY_EXTERNAL_REFERENCE_ID,
+  CreateRefundRequest.JSON_PROPERTY_CUSTOMER_DISPLAY
 })
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.11.0")
 public class CreateRefundRequest {
@@ -57,6 +60,14 @@ public class CreateRefundRequest {
   public static final String JSON_PROPERTY_METADATA = "metadata";
   @jakarta.annotation.Nullable
   private Metadata metadata = new Metadata();
+
+  public static final String JSON_PROPERTY_EXTERNAL_REFERENCE_ID = "externalReferenceId";
+  @jakarta.annotation.Nullable
+  private String externalReferenceId;
+
+  public static final String JSON_PROPERTY_CUSTOMER_DISPLAY = "customerDisplay";
+  @jakarta.annotation.Nullable
+  private OperationCustomerDisplay customerDisplay;
 
   public CreateRefundRequest() { 
   }
@@ -157,6 +168,54 @@ public class CreateRefundRequest {
   }
 
 
+  public CreateRefundRequest externalReferenceId(@jakarta.annotation.Nullable String externalReferenceId) {
+    this.externalReferenceId = externalReferenceId;
+    return this;
+  }
+
+  /**
+   * An optional merchant-provided internal identifier for this refund, from the merchant&#39;s own system—not visible to the payer.
+   * @return externalReferenceId
+   */
+  @jakarta.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_EXTERNAL_REFERENCE_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public String getExternalReferenceId() {
+    return externalReferenceId;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_EXTERNAL_REFERENCE_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setExternalReferenceId(@jakarta.annotation.Nullable String externalReferenceId) {
+    this.externalReferenceId = externalReferenceId;
+  }
+
+
+  public CreateRefundRequest customerDisplay(@jakarta.annotation.Nullable OperationCustomerDisplay customerDisplay) {
+    this.customerDisplay = customerDisplay;
+    return this;
+  }
+
+  /**
+   * Optional customer-facing display data for this refund, shown to the payer. Falls back to the session&#39;s &#x60;orderCode&#x60; when &#x60;referenceCode&#x60; is omitted.
+   * @return customerDisplay
+   */
+  @jakarta.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_CUSTOMER_DISPLAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public OperationCustomerDisplay getCustomerDisplay() {
+    return customerDisplay;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_CUSTOMER_DISPLAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setCustomerDisplay(@jakarta.annotation.Nullable OperationCustomerDisplay customerDisplay) {
+    this.customerDisplay = customerDisplay;
+  }
+
+
   /**
    * Return true if this CreateRefundRequest object is equal to o.
    */
@@ -172,12 +231,14 @@ public class CreateRefundRequest {
     return Objects.equals(this.source, createRefundRequest.source) &&
         Objects.equals(this.amount, createRefundRequest.amount) &&
         Objects.equals(this.reason, createRefundRequest.reason) &&
-        Objects.equals(this.metadata, createRefundRequest.metadata);
+        Objects.equals(this.metadata, createRefundRequest.metadata) &&
+        Objects.equals(this.externalReferenceId, createRefundRequest.externalReferenceId) &&
+        Objects.equals(this.customerDisplay, createRefundRequest.customerDisplay);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(source, amount, reason, metadata);
+    return Objects.hash(source, amount, reason, metadata, externalReferenceId, customerDisplay);
   }
 
   @Override
@@ -188,6 +249,8 @@ public class CreateRefundRequest {
     sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
     sb.append("    reason: ").append(toIndentedString(reason)).append("\n");
     sb.append("    metadata: ").append(toIndentedString(metadata)).append("\n");
+    sb.append("    externalReferenceId: ").append(toIndentedString(externalReferenceId)).append("\n");
+    sb.append("    customerDisplay: ").append(toIndentedString(customerDisplay)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -255,6 +318,16 @@ public class CreateRefundRequest {
       joiner.add(String.format("%smetadata%s=%s", prefix, suffix, URLEncoder.encode(ApiClient.valueToString(getMetadata()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
     }
 
+    // add `externalReferenceId` to the URL query string
+    if (getExternalReferenceId() != null) {
+      joiner.add(String.format("%sexternalReferenceId%s=%s", prefix, suffix, URLEncoder.encode(ApiClient.valueToString(getExternalReferenceId()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
+    }
+
+    // add `customerDisplay` to the URL query string
+    if (getCustomerDisplay() != null) {
+      joiner.add(getCustomerDisplay().toUrlQueryString(prefix + "customerDisplay" + suffix));
+    }
+
     return joiner.toString();
   }
 
@@ -284,6 +357,14 @@ public class CreateRefundRequest {
     }
     public CreateRefundRequest.Builder metadata(Metadata metadata) {
       this.instance.metadata = metadata;
+      return this;
+    }
+    public CreateRefundRequest.Builder externalReferenceId(String externalReferenceId) {
+      this.instance.externalReferenceId = externalReferenceId;
+      return this;
+    }
+    public CreateRefundRequest.Builder customerDisplay(OperationCustomerDisplay customerDisplay) {
+      this.instance.customerDisplay = customerDisplay;
       return this;
     }
 
@@ -323,7 +404,9 @@ public class CreateRefundRequest {
       .source(getSource())
       .amount(getAmount())
       .reason(getReason())
-      .metadata(getMetadata());
+      .metadata(getMetadata())
+      .externalReferenceId(getExternalReferenceId())
+      .customerDisplay(getCustomerDisplay());
   }
 
 }

--- a/java/src/main/java/com/coinbase/cdp/openapi/model/CreateSwapQuoteResponse.java
+++ b/java/src/main/java/com/coinbase/cdp/openapi/model/CreateSwapQuoteResponse.java
@@ -71,42 +71,9 @@ public class CreateSwapQuoteResponse {
   @jakarta.annotation.Nonnull
   private CommonSwapResponseIssues issues;
 
-  /**
-   * Whether sufficient liquidity is available to settle the swap. All other fields in the response will be empty if this is false.
-   */
-  public enum LiquidityAvailableEnum {
-    TRUE(Boolean.valueOf("true"));
-
-    private Boolean value;
-
-    LiquidityAvailableEnum(Boolean value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public Boolean getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static LiquidityAvailableEnum fromValue(Boolean value) {
-      for (LiquidityAvailableEnum b : LiquidityAvailableEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
   public static final String JSON_PROPERTY_LIQUIDITY_AVAILABLE = "liquidityAvailable";
   @jakarta.annotation.Nonnull
-  private LiquidityAvailableEnum liquidityAvailable;
+  private Boolean liquidityAvailable;
 
   public static final String JSON_PROPERTY_MIN_TO_AMOUNT = "minToAmount";
   @jakarta.annotation.Nonnull
@@ -251,7 +218,7 @@ public class CreateSwapQuoteResponse {
   }
 
 
-  public CreateSwapQuoteResponse liquidityAvailable(@jakarta.annotation.Nonnull LiquidityAvailableEnum liquidityAvailable) {
+  public CreateSwapQuoteResponse liquidityAvailable(@jakarta.annotation.Nonnull Boolean liquidityAvailable) {
     this.liquidityAvailable = liquidityAvailable;
     return this;
   }
@@ -263,14 +230,14 @@ public class CreateSwapQuoteResponse {
   @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_LIQUIDITY_AVAILABLE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
-  public LiquidityAvailableEnum getLiquidityAvailable() {
+  public Boolean getLiquidityAvailable() {
     return liquidityAvailable;
   }
 
 
   @JsonProperty(JSON_PROPERTY_LIQUIDITY_AVAILABLE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
-  public void setLiquidityAvailable(@jakarta.annotation.Nonnull LiquidityAvailableEnum liquidityAvailable) {
+  public void setLiquidityAvailable(@jakarta.annotation.Nonnull Boolean liquidityAvailable) {
     this.liquidityAvailable = liquidityAvailable;
   }
 
@@ -577,7 +544,7 @@ public class CreateSwapQuoteResponse {
       this.instance.issues = issues;
       return this;
     }
-    public CreateSwapQuoteResponse.Builder liquidityAvailable(LiquidityAvailableEnum liquidityAvailable) {
+    public CreateSwapQuoteResponse.Builder liquidityAvailable(Boolean liquidityAvailable) {
       this.instance.liquidityAvailable = liquidityAvailable;
       return this;
     }

--- a/java/src/main/java/com/coinbase/cdp/openapi/model/CreateVoidRequest.java
+++ b/java/src/main/java/com/coinbase/cdp/openapi/model/CreateVoidRequest.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 import java.util.Map;
 import java.util.HashMap;
 import com.coinbase.cdp.openapi.model.Metadata;
+import com.coinbase.cdp.openapi.model.OperationCustomerDisplay;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -34,13 +35,23 @@ import com.coinbase.cdp.openapi.ApiClient;
  * A request to create a void for a payment session. A void releases all remaining capturable funds back to the payer, including after partial refunds as long as a capturableAmount remains.
  */
 @JsonPropertyOrder({
-  CreateVoidRequest.JSON_PROPERTY_METADATA
+  CreateVoidRequest.JSON_PROPERTY_METADATA,
+  CreateVoidRequest.JSON_PROPERTY_EXTERNAL_REFERENCE_ID,
+  CreateVoidRequest.JSON_PROPERTY_CUSTOMER_DISPLAY
 })
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.11.0")
 public class CreateVoidRequest {
   public static final String JSON_PROPERTY_METADATA = "metadata";
   @jakarta.annotation.Nullable
   private Metadata metadata = new Metadata();
+
+  public static final String JSON_PROPERTY_EXTERNAL_REFERENCE_ID = "externalReferenceId";
+  @jakarta.annotation.Nullable
+  private String externalReferenceId;
+
+  public static final String JSON_PROPERTY_CUSTOMER_DISPLAY = "customerDisplay";
+  @jakarta.annotation.Nullable
+  private OperationCustomerDisplay customerDisplay;
 
   public CreateVoidRequest() { 
   }
@@ -69,6 +80,54 @@ public class CreateVoidRequest {
   }
 
 
+  public CreateVoidRequest externalReferenceId(@jakarta.annotation.Nullable String externalReferenceId) {
+    this.externalReferenceId = externalReferenceId;
+    return this;
+  }
+
+  /**
+   * An optional merchant-provided internal identifier for this void, from the merchant&#39;s own system—not visible to the payer.
+   * @return externalReferenceId
+   */
+  @jakarta.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_EXTERNAL_REFERENCE_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public String getExternalReferenceId() {
+    return externalReferenceId;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_EXTERNAL_REFERENCE_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setExternalReferenceId(@jakarta.annotation.Nullable String externalReferenceId) {
+    this.externalReferenceId = externalReferenceId;
+  }
+
+
+  public CreateVoidRequest customerDisplay(@jakarta.annotation.Nullable OperationCustomerDisplay customerDisplay) {
+    this.customerDisplay = customerDisplay;
+    return this;
+  }
+
+  /**
+   * Optional customer-facing display data for this void, shown to the payer. Falls back to the session&#39;s &#x60;orderCode&#x60; when &#x60;referenceCode&#x60; is omitted.
+   * @return customerDisplay
+   */
+  @jakarta.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_CUSTOMER_DISPLAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public OperationCustomerDisplay getCustomerDisplay() {
+    return customerDisplay;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_CUSTOMER_DISPLAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setCustomerDisplay(@jakarta.annotation.Nullable OperationCustomerDisplay customerDisplay) {
+    this.customerDisplay = customerDisplay;
+  }
+
+
   /**
    * Return true if this CreateVoidRequest object is equal to o.
    */
@@ -81,12 +140,14 @@ public class CreateVoidRequest {
       return false;
     }
     CreateVoidRequest createVoidRequest = (CreateVoidRequest) o;
-    return Objects.equals(this.metadata, createVoidRequest.metadata);
+    return Objects.equals(this.metadata, createVoidRequest.metadata) &&
+        Objects.equals(this.externalReferenceId, createVoidRequest.externalReferenceId) &&
+        Objects.equals(this.customerDisplay, createVoidRequest.customerDisplay);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(metadata);
+    return Objects.hash(metadata, externalReferenceId, customerDisplay);
   }
 
   @Override
@@ -94,6 +155,8 @@ public class CreateVoidRequest {
     StringBuilder sb = new StringBuilder();
     sb.append("class CreateVoidRequest {\n");
     sb.append("    metadata: ").append(toIndentedString(metadata)).append("\n");
+    sb.append("    externalReferenceId: ").append(toIndentedString(externalReferenceId)).append("\n");
+    sb.append("    customerDisplay: ").append(toIndentedString(customerDisplay)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -146,6 +209,16 @@ public class CreateVoidRequest {
       joiner.add(String.format("%smetadata%s=%s", prefix, suffix, URLEncoder.encode(ApiClient.valueToString(getMetadata()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
     }
 
+    // add `externalReferenceId` to the URL query string
+    if (getExternalReferenceId() != null) {
+      joiner.add(String.format("%sexternalReferenceId%s=%s", prefix, suffix, URLEncoder.encode(ApiClient.valueToString(getExternalReferenceId()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
+    }
+
+    // add `customerDisplay` to the URL query string
+    if (getCustomerDisplay() != null) {
+      joiner.add(getCustomerDisplay().toUrlQueryString(prefix + "customerDisplay" + suffix));
+    }
+
     return joiner.toString();
   }
 
@@ -163,6 +236,14 @@ public class CreateVoidRequest {
 
     public CreateVoidRequest.Builder metadata(Metadata metadata) {
       this.instance.metadata = metadata;
+      return this;
+    }
+    public CreateVoidRequest.Builder externalReferenceId(String externalReferenceId) {
+      this.instance.externalReferenceId = externalReferenceId;
+      return this;
+    }
+    public CreateVoidRequest.Builder customerDisplay(OperationCustomerDisplay customerDisplay) {
+      this.instance.customerDisplay = customerDisplay;
       return this;
     }
 
@@ -199,7 +280,9 @@ public class CreateVoidRequest {
   */
   public CreateVoidRequest.Builder toBuilder() {
     return new CreateVoidRequest.Builder()
-      .metadata(getMetadata());
+      .metadata(getMetadata())
+      .externalReferenceId(getExternalReferenceId())
+      .customerDisplay(getCustomerDisplay());
   }
 
 }

--- a/java/src/main/java/com/coinbase/cdp/openapi/model/CustomerDisplay.java
+++ b/java/src/main/java/com/coinbase/cdp/openapi/model/CustomerDisplay.java
@@ -35,7 +35,8 @@ import com.coinbase.cdp.openapi.ApiClient;
  */
 @JsonPropertyOrder({
   CustomerDisplay.JSON_PROPERTY_MERCHANT_NAME,
-  CustomerDisplay.JSON_PROPERTY_DISPLAY_AMOUNT
+  CustomerDisplay.JSON_PROPERTY_DISPLAY_AMOUNT,
+  CustomerDisplay.JSON_PROPERTY_ORDER_CODE
 })
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.11.0")
 public class CustomerDisplay {
@@ -46,6 +47,10 @@ public class CustomerDisplay {
   public static final String JSON_PROPERTY_DISPLAY_AMOUNT = "displayAmount";
   @jakarta.annotation.Nullable
   private CustomerDisplayDisplayAmount displayAmount;
+
+  public static final String JSON_PROPERTY_ORDER_CODE = "orderCode";
+  @jakarta.annotation.Nullable
+  private String orderCode;
 
   public CustomerDisplay() { 
   }
@@ -98,6 +103,30 @@ public class CustomerDisplay {
   }
 
 
+  public CustomerDisplay orderCode(@jakarta.annotation.Nullable String orderCode) {
+    this.orderCode = orderCode;
+    return this;
+  }
+
+  /**
+   * A customer-visible code for the overall order. When omitted, CDP generates one and returns it. It must not contain personally identifiable information (PII) or payment credentials.
+   * @return orderCode
+   */
+  @jakarta.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_ORDER_CODE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public String getOrderCode() {
+    return orderCode;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_ORDER_CODE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setOrderCode(@jakarta.annotation.Nullable String orderCode) {
+    this.orderCode = orderCode;
+  }
+
+
   /**
    * Return true if this CustomerDisplay object is equal to o.
    */
@@ -111,12 +140,13 @@ public class CustomerDisplay {
     }
     CustomerDisplay customerDisplay = (CustomerDisplay) o;
     return Objects.equals(this.merchantName, customerDisplay.merchantName) &&
-        Objects.equals(this.displayAmount, customerDisplay.displayAmount);
+        Objects.equals(this.displayAmount, customerDisplay.displayAmount) &&
+        Objects.equals(this.orderCode, customerDisplay.orderCode);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(merchantName, displayAmount);
+    return Objects.hash(merchantName, displayAmount, orderCode);
   }
 
   @Override
@@ -125,6 +155,7 @@ public class CustomerDisplay {
     sb.append("class CustomerDisplay {\n");
     sb.append("    merchantName: ").append(toIndentedString(merchantName)).append("\n");
     sb.append("    displayAmount: ").append(toIndentedString(displayAmount)).append("\n");
+    sb.append("    orderCode: ").append(toIndentedString(orderCode)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -182,6 +213,11 @@ public class CustomerDisplay {
       joiner.add(getDisplayAmount().toUrlQueryString(prefix + "displayAmount" + suffix));
     }
 
+    // add `orderCode` to the URL query string
+    if (getOrderCode() != null) {
+      joiner.add(String.format("%sorderCode%s=%s", prefix, suffix, URLEncoder.encode(ApiClient.valueToString(getOrderCode()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
+    }
+
     return joiner.toString();
   }
 
@@ -203,6 +239,10 @@ public class CustomerDisplay {
     }
     public CustomerDisplay.Builder displayAmount(CustomerDisplayDisplayAmount displayAmount) {
       this.instance.displayAmount = displayAmount;
+      return this;
+    }
+    public CustomerDisplay.Builder orderCode(String orderCode) {
+      this.instance.orderCode = orderCode;
       return this;
     }
 
@@ -240,7 +280,8 @@ public class CustomerDisplay {
   public CustomerDisplay.Builder toBuilder() {
     return new CustomerDisplay.Builder()
       .merchantName(getMerchantName())
-      .displayAmount(getDisplayAmount());
+      .displayAmount(getDisplayAmount())
+      .orderCode(getOrderCode());
   }
 
 }

--- a/java/src/main/java/com/coinbase/cdp/openapi/model/Disbursement.java
+++ b/java/src/main/java/com/coinbase/cdp/openapi/model/Disbursement.java
@@ -23,6 +23,7 @@ import com.coinbase.cdp.openapi.model.DisbursementSource;
 import com.coinbase.cdp.openapi.model.DisbursementTarget;
 import com.coinbase.cdp.openapi.model.Metadata;
 import com.coinbase.cdp.openapi.model.OnchainTransaction;
+import com.coinbase.cdp.openapi.model.OperationCustomerDisplay;
 import com.coinbase.cdp.openapi.model.PaymentActionStatus;
 import com.coinbase.cdp.openapi.model.PaymentError;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -50,6 +51,7 @@ import com.coinbase.cdp.openapi.ApiClient;
   Disbursement.JSON_PROPERTY_STATUS,
   Disbursement.JSON_PROPERTY_REASON,
   Disbursement.JSON_PROPERTY_EXTERNAL_REFERENCE_ID,
+  Disbursement.JSON_PROPERTY_CUSTOMER_DISPLAY,
   Disbursement.JSON_PROPERTY_METADATA,
   Disbursement.JSON_PROPERTY_ERROR,
   Disbursement.JSON_PROPERTY_ONCHAIN_TRANSACTIONS,
@@ -89,6 +91,10 @@ public class Disbursement {
   public static final String JSON_PROPERTY_EXTERNAL_REFERENCE_ID = "externalReferenceId";
   @jakarta.annotation.Nullable
   private String externalReferenceId;
+
+  public static final String JSON_PROPERTY_CUSTOMER_DISPLAY = "customerDisplay";
+  @jakarta.annotation.Nullable
+  private OperationCustomerDisplay customerDisplay;
 
   public static final String JSON_PROPERTY_METADATA = "metadata";
   @jakarta.annotation.Nullable
@@ -305,6 +311,30 @@ public class Disbursement {
   }
 
 
+  public Disbursement customerDisplay(@jakarta.annotation.Nullable OperationCustomerDisplay customerDisplay) {
+    this.customerDisplay = customerDisplay;
+    return this;
+  }
+
+  /**
+   * Customer-facing display data for this disbursement, shown to the payer. Always present: if the create request omits &#x60;referenceCode&#x60;, one is auto-generated, since disbursements have no payment session to fall back to.
+   * @return customerDisplay
+   */
+  @jakarta.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_CUSTOMER_DISPLAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public OperationCustomerDisplay getCustomerDisplay() {
+    return customerDisplay;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_CUSTOMER_DISPLAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setCustomerDisplay(@jakarta.annotation.Nullable OperationCustomerDisplay customerDisplay) {
+    this.customerDisplay = customerDisplay;
+  }
+
+
   public Disbursement metadata(@jakarta.annotation.Nullable Metadata metadata) {
     this.metadata = metadata;
     return this;
@@ -453,6 +483,7 @@ public class Disbursement {
         Objects.equals(this.status, disbursement.status) &&
         Objects.equals(this.reason, disbursement.reason) &&
         Objects.equals(this.externalReferenceId, disbursement.externalReferenceId) &&
+        Objects.equals(this.customerDisplay, disbursement.customerDisplay) &&
         Objects.equals(this.metadata, disbursement.metadata) &&
         Objects.equals(this.error, disbursement.error) &&
         Objects.equals(this.onchainTransactions, disbursement.onchainTransactions) &&
@@ -462,7 +493,7 @@ public class Disbursement {
 
   @Override
   public int hashCode() {
-    return Objects.hash(disbursementId, source, target, amount, asset, status, reason, externalReferenceId, metadata, error, onchainTransactions, createdAt, updatedAt);
+    return Objects.hash(disbursementId, source, target, amount, asset, status, reason, externalReferenceId, customerDisplay, metadata, error, onchainTransactions, createdAt, updatedAt);
   }
 
   @Override
@@ -477,6 +508,7 @@ public class Disbursement {
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
     sb.append("    reason: ").append(toIndentedString(reason)).append("\n");
     sb.append("    externalReferenceId: ").append(toIndentedString(externalReferenceId)).append("\n");
+    sb.append("    customerDisplay: ").append(toIndentedString(customerDisplay)).append("\n");
     sb.append("    metadata: ").append(toIndentedString(metadata)).append("\n");
     sb.append("    error: ").append(toIndentedString(error)).append("\n");
     sb.append("    onchainTransactions: ").append(toIndentedString(onchainTransactions)).append("\n");
@@ -569,6 +601,11 @@ public class Disbursement {
       joiner.add(String.format("%sexternalReferenceId%s=%s", prefix, suffix, URLEncoder.encode(ApiClient.valueToString(getExternalReferenceId()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
     }
 
+    // add `customerDisplay` to the URL query string
+    if (getCustomerDisplay() != null) {
+      joiner.add(getCustomerDisplay().toUrlQueryString(prefix + "customerDisplay" + suffix));
+    }
+
     // add `metadata` to the URL query string
     if (getMetadata() != null) {
       joiner.add(String.format("%smetadata%s=%s", prefix, suffix, URLEncoder.encode(ApiClient.valueToString(getMetadata()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
@@ -646,6 +683,10 @@ public class Disbursement {
       this.instance.externalReferenceId = externalReferenceId;
       return this;
     }
+    public Disbursement.Builder customerDisplay(OperationCustomerDisplay customerDisplay) {
+      this.instance.customerDisplay = customerDisplay;
+      return this;
+    }
     public Disbursement.Builder metadata(Metadata metadata) {
       this.instance.metadata = metadata;
       return this;
@@ -708,6 +749,7 @@ public class Disbursement {
       .status(getStatus())
       .reason(getReason())
       .externalReferenceId(getExternalReferenceId())
+      .customerDisplay(getCustomerDisplay())
       .metadata(getMetadata())
       .error(getError())
       .onchainTransactions(getOnchainTransactions())

--- a/java/src/main/java/com/coinbase/cdp/openapi/model/EvmUserOperation.java
+++ b/java/src/main/java/com/coinbase/cdp/openapi/model/EvmUserOperation.java
@@ -36,7 +36,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import com.coinbase.cdp.openapi.ApiClient;
 /**
- * EvmUserOperation
+ * A smart account operation response.
  */
 @JsonPropertyOrder({
   EvmUserOperation.JSON_PROPERTY_NETWORK,

--- a/java/src/main/java/com/coinbase/cdp/openapi/model/GetSwapPriceResponse.java
+++ b/java/src/main/java/com/coinbase/cdp/openapi/model/GetSwapPriceResponse.java
@@ -69,42 +69,9 @@ public class GetSwapPriceResponse {
   @jakarta.annotation.Nonnull
   private CommonSwapResponseIssues issues;
 
-  /**
-   * Whether sufficient liquidity is available to settle the swap. All other fields in the response will be empty if this is false.
-   */
-  public enum LiquidityAvailableEnum {
-    TRUE(Boolean.valueOf("true"));
-
-    private Boolean value;
-
-    LiquidityAvailableEnum(Boolean value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public Boolean getValue() {
-      return value;
-    }
-
-    @Override
-    public String toString() {
-      return String.valueOf(value);
-    }
-
-    @JsonCreator
-    public static LiquidityAvailableEnum fromValue(Boolean value) {
-      for (LiquidityAvailableEnum b : LiquidityAvailableEnum.values()) {
-        if (b.value.equals(value)) {
-          return b;
-        }
-      }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
-    }
-  }
-
   public static final String JSON_PROPERTY_LIQUIDITY_AVAILABLE = "liquidityAvailable";
   @jakarta.annotation.Nonnull
-  private LiquidityAvailableEnum liquidityAvailable;
+  private Boolean liquidityAvailable;
 
   public static final String JSON_PROPERTY_MIN_TO_AMOUNT = "minToAmount";
   @jakarta.annotation.Nonnull
@@ -249,7 +216,7 @@ public class GetSwapPriceResponse {
   }
 
 
-  public GetSwapPriceResponse liquidityAvailable(@jakarta.annotation.Nonnull LiquidityAvailableEnum liquidityAvailable) {
+  public GetSwapPriceResponse liquidityAvailable(@jakarta.annotation.Nonnull Boolean liquidityAvailable) {
     this.liquidityAvailable = liquidityAvailable;
     return this;
   }
@@ -261,14 +228,14 @@ public class GetSwapPriceResponse {
   @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_LIQUIDITY_AVAILABLE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
-  public LiquidityAvailableEnum getLiquidityAvailable() {
+  public Boolean getLiquidityAvailable() {
     return liquidityAvailable;
   }
 
 
   @JsonProperty(JSON_PROPERTY_LIQUIDITY_AVAILABLE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
-  public void setLiquidityAvailable(@jakarta.annotation.Nonnull LiquidityAvailableEnum liquidityAvailable) {
+  public void setLiquidityAvailable(@jakarta.annotation.Nonnull Boolean liquidityAvailable) {
     this.liquidityAvailable = liquidityAvailable;
   }
 
@@ -575,7 +542,7 @@ public class GetSwapPriceResponse {
       this.instance.issues = issues;
       return this;
     }
-    public GetSwapPriceResponse.Builder liquidityAvailable(LiquidityAvailableEnum liquidityAvailable) {
+    public GetSwapPriceResponse.Builder liquidityAvailable(Boolean liquidityAvailable) {
       this.instance.liquidityAvailable = liquidityAvailable;
       return this;
     }

--- a/java/src/main/java/com/coinbase/cdp/openapi/model/ModelVoid.java
+++ b/java/src/main/java/com/coinbase/cdp/openapi/model/ModelVoid.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.HashMap;
 import com.coinbase.cdp.openapi.model.Metadata;
 import com.coinbase.cdp.openapi.model.OnchainTransaction;
+import com.coinbase.cdp.openapi.model.OperationCustomerDisplay;
 import com.coinbase.cdp.openapi.model.PaymentActionStatus;
 import com.coinbase.cdp.openapi.model.PaymentError;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -46,6 +47,8 @@ import com.coinbase.cdp.openapi.ApiClient;
   ModelVoid.JSON_PROPERTY_AMOUNT,
   ModelVoid.JSON_PROPERTY_ERROR,
   ModelVoid.JSON_PROPERTY_METADATA,
+  ModelVoid.JSON_PROPERTY_EXTERNAL_REFERENCE_ID,
+  ModelVoid.JSON_PROPERTY_CUSTOMER_DISPLAY,
   ModelVoid.JSON_PROPERTY_ONCHAIN_TRANSACTIONS,
   ModelVoid.JSON_PROPERTY_CREATED_AT,
   ModelVoid.JSON_PROPERTY_UPDATED_AT
@@ -75,6 +78,14 @@ public class ModelVoid {
   public static final String JSON_PROPERTY_METADATA = "metadata";
   @jakarta.annotation.Nullable
   private Metadata metadata = new Metadata();
+
+  public static final String JSON_PROPERTY_EXTERNAL_REFERENCE_ID = "externalReferenceId";
+  @jakarta.annotation.Nullable
+  private String externalReferenceId;
+
+  public static final String JSON_PROPERTY_CUSTOMER_DISPLAY = "customerDisplay";
+  @jakarta.annotation.Nullable
+  private OperationCustomerDisplay customerDisplay;
 
   public static final String JSON_PROPERTY_ONCHAIN_TRANSACTIONS = "onchainTransactions";
   @jakarta.annotation.Nullable
@@ -235,6 +246,54 @@ public class ModelVoid {
   }
 
 
+  public ModelVoid externalReferenceId(@jakarta.annotation.Nullable String externalReferenceId) {
+    this.externalReferenceId = externalReferenceId;
+    return this;
+  }
+
+  /**
+   * A merchant-provided internal identifier for this void, from the merchant&#39;s own system—not visible to the payer. Present only when supplied on the create void request.
+   * @return externalReferenceId
+   */
+  @jakarta.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_EXTERNAL_REFERENCE_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public String getExternalReferenceId() {
+    return externalReferenceId;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_EXTERNAL_REFERENCE_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setExternalReferenceId(@jakarta.annotation.Nullable String externalReferenceId) {
+    this.externalReferenceId = externalReferenceId;
+  }
+
+
+  public ModelVoid customerDisplay(@jakarta.annotation.Nullable OperationCustomerDisplay customerDisplay) {
+    this.customerDisplay = customerDisplay;
+    return this;
+  }
+
+  /**
+   * Customer-facing display data for this void, shown to the payer. Present when supplied on the create void request or when the session&#39;s &#x60;orderCode&#x60; fallback applies; otherwise omitted.
+   * @return customerDisplay
+   */
+  @jakarta.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_CUSTOMER_DISPLAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public OperationCustomerDisplay getCustomerDisplay() {
+    return customerDisplay;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_CUSTOMER_DISPLAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setCustomerDisplay(@jakarta.annotation.Nullable OperationCustomerDisplay customerDisplay) {
+    this.customerDisplay = customerDisplay;
+  }
+
+
   public ModelVoid onchainTransactions(@jakarta.annotation.Nullable List<OnchainTransaction> onchainTransactions) {
     this.onchainTransactions = onchainTransactions;
     return this;
@@ -333,6 +392,8 @@ public class ModelVoid {
         Objects.equals(this.amount, _void.amount) &&
         Objects.equals(this.error, _void.error) &&
         Objects.equals(this.metadata, _void.metadata) &&
+        Objects.equals(this.externalReferenceId, _void.externalReferenceId) &&
+        Objects.equals(this.customerDisplay, _void.customerDisplay) &&
         Objects.equals(this.onchainTransactions, _void.onchainTransactions) &&
         Objects.equals(this.createdAt, _void.createdAt) &&
         Objects.equals(this.updatedAt, _void.updatedAt);
@@ -340,7 +401,7 @@ public class ModelVoid {
 
   @Override
   public int hashCode() {
-    return Objects.hash(voidId, paymentSessionId, status, amount, error, metadata, onchainTransactions, createdAt, updatedAt);
+    return Objects.hash(voidId, paymentSessionId, status, amount, error, metadata, externalReferenceId, customerDisplay, onchainTransactions, createdAt, updatedAt);
   }
 
   @Override
@@ -353,6 +414,8 @@ public class ModelVoid {
     sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
     sb.append("    error: ").append(toIndentedString(error)).append("\n");
     sb.append("    metadata: ").append(toIndentedString(metadata)).append("\n");
+    sb.append("    externalReferenceId: ").append(toIndentedString(externalReferenceId)).append("\n");
+    sb.append("    customerDisplay: ").append(toIndentedString(customerDisplay)).append("\n");
     sb.append("    onchainTransactions: ").append(toIndentedString(onchainTransactions)).append("\n");
     sb.append("    createdAt: ").append(toIndentedString(createdAt)).append("\n");
     sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
@@ -433,6 +496,16 @@ public class ModelVoid {
       joiner.add(String.format("%smetadata%s=%s", prefix, suffix, URLEncoder.encode(ApiClient.valueToString(getMetadata()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
     }
 
+    // add `externalReferenceId` to the URL query string
+    if (getExternalReferenceId() != null) {
+      joiner.add(String.format("%sexternalReferenceId%s=%s", prefix, suffix, URLEncoder.encode(ApiClient.valueToString(getExternalReferenceId()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
+    }
+
+    // add `customerDisplay` to the URL query string
+    if (getCustomerDisplay() != null) {
+      joiner.add(getCustomerDisplay().toUrlQueryString(prefix + "customerDisplay" + suffix));
+    }
+
     // add `onchainTransactions` to the URL query string
     if (getOnchainTransactions() != null) {
       for (int i = 0; i < getOnchainTransactions().size(); i++) {
@@ -492,6 +565,14 @@ public class ModelVoid {
       this.instance.metadata = metadata;
       return this;
     }
+    public ModelVoid.Builder externalReferenceId(String externalReferenceId) {
+      this.instance.externalReferenceId = externalReferenceId;
+      return this;
+    }
+    public ModelVoid.Builder customerDisplay(OperationCustomerDisplay customerDisplay) {
+      this.instance.customerDisplay = customerDisplay;
+      return this;
+    }
     public ModelVoid.Builder onchainTransactions(List<OnchainTransaction> onchainTransactions) {
       this.instance.onchainTransactions = onchainTransactions;
       return this;
@@ -544,6 +625,8 @@ public class ModelVoid {
       .amount(getAmount())
       .error(getError())
       .metadata(getMetadata())
+      .externalReferenceId(getExternalReferenceId())
+      .customerDisplay(getCustomerDisplay())
       .onchainTransactions(getOnchainTransactions())
       .createdAt(getCreatedAt())
       .updatedAt(getUpdatedAt());

--- a/java/src/main/java/com/coinbase/cdp/openapi/model/OperationCustomerDisplay.java
+++ b/java/src/main/java/com/coinbase/cdp/openapi/model/OperationCustomerDisplay.java
@@ -30,46 +30,46 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import com.coinbase.cdp.openapi.ApiClient;
 /**
- * SwapUnavailableResponse
+ * Customer-facing display data for a payment operation, shown to the payer.
  */
 @JsonPropertyOrder({
-  SwapUnavailableResponse.JSON_PROPERTY_LIQUIDITY_AVAILABLE
+  OperationCustomerDisplay.JSON_PROPERTY_REFERENCE_CODE
 })
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.11.0")
-public class SwapUnavailableResponse {
-  public static final String JSON_PROPERTY_LIQUIDITY_AVAILABLE = "liquidityAvailable";
-  @jakarta.annotation.Nonnull
-  private Boolean liquidityAvailable;
+public class OperationCustomerDisplay {
+  public static final String JSON_PROPERTY_REFERENCE_CODE = "referenceCode";
+  @jakarta.annotation.Nullable
+  private String referenceCode;
 
-  public SwapUnavailableResponse() { 
+  public OperationCustomerDisplay() { 
   }
 
-  public SwapUnavailableResponse liquidityAvailable(@jakarta.annotation.Nonnull Boolean liquidityAvailable) {
-    this.liquidityAvailable = liquidityAvailable;
+  public OperationCustomerDisplay referenceCode(@jakarta.annotation.Nullable String referenceCode) {
+    this.referenceCode = referenceCode;
     return this;
   }
 
   /**
-   * Whether sufficient liquidity is available to settle the swap. All other fields in the response will be empty if this is false.
-   * @return liquidityAvailable
+   * A short reference code for this payment operation, visible to the payer.
+   * @return referenceCode
    */
-  @jakarta.annotation.Nonnull
-  @JsonProperty(JSON_PROPERTY_LIQUIDITY_AVAILABLE)
-  @JsonInclude(value = JsonInclude.Include.ALWAYS)
-  public Boolean getLiquidityAvailable() {
-    return liquidityAvailable;
+  @jakarta.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_REFERENCE_CODE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public String getReferenceCode() {
+    return referenceCode;
   }
 
 
-  @JsonProperty(JSON_PROPERTY_LIQUIDITY_AVAILABLE)
-  @JsonInclude(value = JsonInclude.Include.ALWAYS)
-  public void setLiquidityAvailable(@jakarta.annotation.Nonnull Boolean liquidityAvailable) {
-    this.liquidityAvailable = liquidityAvailable;
+  @JsonProperty(JSON_PROPERTY_REFERENCE_CODE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setReferenceCode(@jakarta.annotation.Nullable String referenceCode) {
+    this.referenceCode = referenceCode;
   }
 
 
   /**
-   * Return true if this SwapUnavailableResponse object is equal to o.
+   * Return true if this OperationCustomerDisplay object is equal to o.
    */
   @Override
   public boolean equals(Object o) {
@@ -79,20 +79,20 @@ public class SwapUnavailableResponse {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    SwapUnavailableResponse swapUnavailableResponse = (SwapUnavailableResponse) o;
-    return Objects.equals(this.liquidityAvailable, swapUnavailableResponse.liquidityAvailable);
+    OperationCustomerDisplay operationCustomerDisplay = (OperationCustomerDisplay) o;
+    return Objects.equals(this.referenceCode, operationCustomerDisplay.referenceCode);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(liquidityAvailable);
+    return Objects.hash(referenceCode);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
-    sb.append("class SwapUnavailableResponse {\n");
-    sb.append("    liquidityAvailable: ").append(toIndentedString(liquidityAvailable)).append("\n");
+    sb.append("class OperationCustomerDisplay {\n");
+    sb.append("    referenceCode: ").append(toIndentedString(referenceCode)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -140,9 +140,9 @@ public class SwapUnavailableResponse {
 
     StringJoiner joiner = new StringJoiner("&");
 
-    // add `liquidityAvailable` to the URL query string
-    if (getLiquidityAvailable() != null) {
-      joiner.add(String.format("%sliquidityAvailable%s=%s", prefix, suffix, URLEncoder.encode(ApiClient.valueToString(getLiquidityAvailable()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
+    // add `referenceCode` to the URL query string
+    if (getReferenceCode() != null) {
+      joiner.add(String.format("%sreferenceCode%s=%s", prefix, suffix, URLEncoder.encode(ApiClient.valueToString(getReferenceCode()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
     }
 
     return joiner.toString();
@@ -150,28 +150,28 @@ public class SwapUnavailableResponse {
 
     public static class Builder {
 
-    private SwapUnavailableResponse instance;
+    private OperationCustomerDisplay instance;
 
     public Builder() {
-      this(new SwapUnavailableResponse());
+      this(new OperationCustomerDisplay());
     }
 
-    protected Builder(SwapUnavailableResponse instance) {
+    protected Builder(OperationCustomerDisplay instance) {
       this.instance = instance;
     }
 
-    public SwapUnavailableResponse.Builder liquidityAvailable(Boolean liquidityAvailable) {
-      this.instance.liquidityAvailable = liquidityAvailable;
+    public OperationCustomerDisplay.Builder referenceCode(String referenceCode) {
+      this.instance.referenceCode = referenceCode;
       return this;
     }
 
 
     /**
-    * returns a built SwapUnavailableResponse instance.
+    * returns a built OperationCustomerDisplay instance.
     *
     * The builder is not reusable.
     */
-    public SwapUnavailableResponse build() {
+    public OperationCustomerDisplay build() {
       try {
         return this.instance;
       } finally {
@@ -189,16 +189,16 @@ public class SwapUnavailableResponse {
   /**
   * Create a builder with no initialized field.
   */
-  public static SwapUnavailableResponse.Builder builder() {
-    return new SwapUnavailableResponse.Builder();
+  public static OperationCustomerDisplay.Builder builder() {
+    return new OperationCustomerDisplay.Builder();
   }
 
   /**
   * Create a builder with a shallow copy of this instance.
   */
-  public SwapUnavailableResponse.Builder toBuilder() {
-    return new SwapUnavailableResponse.Builder()
-      .liquidityAvailable(getLiquidityAvailable());
+  public OperationCustomerDisplay.Builder toBuilder() {
+    return new OperationCustomerDisplay.Builder()
+      .referenceCode(getReferenceCode());
   }
 
 }

--- a/java/src/main/java/com/coinbase/cdp/openapi/model/PaymentSessionEventDataAuthorization.java
+++ b/java/src/main/java/com/coinbase/cdp/openapi/model/PaymentSessionEventDataAuthorization.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.HashMap;
 import com.coinbase.cdp.openapi.model.Metadata;
 import com.coinbase.cdp.openapi.model.OnchainTransaction;
+import com.coinbase.cdp.openapi.model.OperationCustomerDisplay;
 import com.coinbase.cdp.openapi.model.PaymentActionStatus;
 import com.coinbase.cdp.openapi.model.PaymentError;
 import com.coinbase.cdp.openapi.model.PaymentSessionSource;
@@ -44,6 +45,8 @@ import com.coinbase.cdp.openapi.ApiClient;
   PaymentSessionEventDataAuthorization.JSON_PROPERTY_AUTHORIZATION_ID,
   PaymentSessionEventDataAuthorization.JSON_PROPERTY_STATUS,
   PaymentSessionEventDataAuthorization.JSON_PROPERTY_AMOUNT,
+  PaymentSessionEventDataAuthorization.JSON_PROPERTY_EXTERNAL_REFERENCE_ID,
+  PaymentSessionEventDataAuthorization.JSON_PROPERTY_CUSTOMER_DISPLAY,
   PaymentSessionEventDataAuthorization.JSON_PROPERTY_ERROR,
   PaymentSessionEventDataAuthorization.JSON_PROPERTY_ONCHAIN_TRANSACTIONS,
   PaymentSessionEventDataAuthorization.JSON_PROPERTY_METADATA,
@@ -64,6 +67,14 @@ public class PaymentSessionEventDataAuthorization {
   public static final String JSON_PROPERTY_AMOUNT = "amount";
   @jakarta.annotation.Nonnull
   private String amount;
+
+  public static final String JSON_PROPERTY_EXTERNAL_REFERENCE_ID = "externalReferenceId";
+  @jakarta.annotation.Nullable
+  private String externalReferenceId;
+
+  public static final String JSON_PROPERTY_CUSTOMER_DISPLAY = "customerDisplay";
+  @jakarta.annotation.Nullable
+  private OperationCustomerDisplay customerDisplay;
 
   public static final String JSON_PROPERTY_ERROR = "error";
   @jakarta.annotation.Nullable
@@ -161,6 +172,54 @@ public class PaymentSessionEventDataAuthorization {
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setAmount(@jakarta.annotation.Nonnull String amount) {
     this.amount = amount;
+  }
+
+
+  public PaymentSessionEventDataAuthorization externalReferenceId(@jakarta.annotation.Nullable String externalReferenceId) {
+    this.externalReferenceId = externalReferenceId;
+    return this;
+  }
+
+  /**
+   * An optional merchant-provided internal identifier for this authorization, from the merchant&#39;s own system—not visible to the payer. Present only when supplied on the authorization request.
+   * @return externalReferenceId
+   */
+  @jakarta.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_EXTERNAL_REFERENCE_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public String getExternalReferenceId() {
+    return externalReferenceId;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_EXTERNAL_REFERENCE_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setExternalReferenceId(@jakarta.annotation.Nullable String externalReferenceId) {
+    this.externalReferenceId = externalReferenceId;
+  }
+
+
+  public PaymentSessionEventDataAuthorization customerDisplay(@jakarta.annotation.Nullable OperationCustomerDisplay customerDisplay) {
+    this.customerDisplay = customerDisplay;
+    return this;
+  }
+
+  /**
+   * Customer-facing display data for this authorization, shown to the payer. Present when supplied on the authorization request or when the session&#39;s &#x60;orderCode&#x60; fallback applies; otherwise omitted.
+   * @return customerDisplay
+   */
+  @jakarta.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_CUSTOMER_DISPLAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public OperationCustomerDisplay getCustomerDisplay() {
+    return customerDisplay;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_CUSTOMER_DISPLAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setCustomerDisplay(@jakarta.annotation.Nullable OperationCustomerDisplay customerDisplay) {
+    this.customerDisplay = customerDisplay;
   }
 
 
@@ -331,6 +390,8 @@ public class PaymentSessionEventDataAuthorization {
     return Objects.equals(this.authorizationId, paymentSessionEventDataAuthorization.authorizationId) &&
         Objects.equals(this.status, paymentSessionEventDataAuthorization.status) &&
         Objects.equals(this.amount, paymentSessionEventDataAuthorization.amount) &&
+        Objects.equals(this.externalReferenceId, paymentSessionEventDataAuthorization.externalReferenceId) &&
+        Objects.equals(this.customerDisplay, paymentSessionEventDataAuthorization.customerDisplay) &&
         Objects.equals(this.error, paymentSessionEventDataAuthorization.error) &&
         Objects.equals(this.onchainTransactions, paymentSessionEventDataAuthorization.onchainTransactions) &&
         Objects.equals(this.metadata, paymentSessionEventDataAuthorization.metadata) &&
@@ -341,7 +402,7 @@ public class PaymentSessionEventDataAuthorization {
 
   @Override
   public int hashCode() {
-    return Objects.hash(authorizationId, status, amount, error, onchainTransactions, metadata, source, createdAt, updatedAt);
+    return Objects.hash(authorizationId, status, amount, externalReferenceId, customerDisplay, error, onchainTransactions, metadata, source, createdAt, updatedAt);
   }
 
   @Override
@@ -351,6 +412,8 @@ public class PaymentSessionEventDataAuthorization {
     sb.append("    authorizationId: ").append(toIndentedString(authorizationId)).append("\n");
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
     sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
+    sb.append("    externalReferenceId: ").append(toIndentedString(externalReferenceId)).append("\n");
+    sb.append("    customerDisplay: ").append(toIndentedString(customerDisplay)).append("\n");
     sb.append("    error: ").append(toIndentedString(error)).append("\n");
     sb.append("    onchainTransactions: ").append(toIndentedString(onchainTransactions)).append("\n");
     sb.append("    metadata: ").append(toIndentedString(metadata)).append("\n");
@@ -419,6 +482,16 @@ public class PaymentSessionEventDataAuthorization {
       joiner.add(String.format("%samount%s=%s", prefix, suffix, URLEncoder.encode(ApiClient.valueToString(getAmount()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
     }
 
+    // add `externalReferenceId` to the URL query string
+    if (getExternalReferenceId() != null) {
+      joiner.add(String.format("%sexternalReferenceId%s=%s", prefix, suffix, URLEncoder.encode(ApiClient.valueToString(getExternalReferenceId()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
+    }
+
+    // add `customerDisplay` to the URL query string
+    if (getCustomerDisplay() != null) {
+      joiner.add(getCustomerDisplay().toUrlQueryString(prefix + "customerDisplay" + suffix));
+    }
+
     // add `error` to the URL query string
     if (getError() != null) {
       joiner.add(getError().toUrlQueryString(prefix + "error" + suffix));
@@ -479,6 +552,14 @@ public class PaymentSessionEventDataAuthorization {
     }
     public PaymentSessionEventDataAuthorization.Builder amount(String amount) {
       this.instance.amount = amount;
+      return this;
+    }
+    public PaymentSessionEventDataAuthorization.Builder externalReferenceId(String externalReferenceId) {
+      this.instance.externalReferenceId = externalReferenceId;
+      return this;
+    }
+    public PaymentSessionEventDataAuthorization.Builder customerDisplay(OperationCustomerDisplay customerDisplay) {
+      this.instance.customerDisplay = customerDisplay;
       return this;
     }
     public PaymentSessionEventDataAuthorization.Builder error(PaymentError error) {
@@ -542,6 +623,8 @@ public class PaymentSessionEventDataAuthorization {
       .authorizationId(getAuthorizationId())
       .status(getStatus())
       .amount(getAmount())
+      .externalReferenceId(getExternalReferenceId())
+      .customerDisplay(getCustomerDisplay())
       .error(getError())
       .onchainTransactions(getOnchainTransactions())
       .metadata(getMetadata())

--- a/java/src/main/java/com/coinbase/cdp/openapi/model/PaymentSessionEventDataCapture.java
+++ b/java/src/main/java/com/coinbase/cdp/openapi/model/PaymentSessionEventDataCapture.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.HashMap;
 import com.coinbase.cdp.openapi.model.Metadata;
 import com.coinbase.cdp.openapi.model.OnchainTransaction;
+import com.coinbase.cdp.openapi.model.OperationCustomerDisplay;
 import com.coinbase.cdp.openapi.model.PaymentActionStatus;
 import com.coinbase.cdp.openapi.model.PaymentError;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -43,6 +44,8 @@ import com.coinbase.cdp.openapi.ApiClient;
   PaymentSessionEventDataCapture.JSON_PROPERTY_CAPTURE_ID,
   PaymentSessionEventDataCapture.JSON_PROPERTY_STATUS,
   PaymentSessionEventDataCapture.JSON_PROPERTY_AMOUNT,
+  PaymentSessionEventDataCapture.JSON_PROPERTY_EXTERNAL_REFERENCE_ID,
+  PaymentSessionEventDataCapture.JSON_PROPERTY_CUSTOMER_DISPLAY,
   PaymentSessionEventDataCapture.JSON_PROPERTY_FINAL_CAPTURE,
   PaymentSessionEventDataCapture.JSON_PROPERTY_ERROR,
   PaymentSessionEventDataCapture.JSON_PROPERTY_ONCHAIN_TRANSACTIONS,
@@ -63,6 +66,14 @@ public class PaymentSessionEventDataCapture {
   public static final String JSON_PROPERTY_AMOUNT = "amount";
   @jakarta.annotation.Nonnull
   private String amount;
+
+  public static final String JSON_PROPERTY_EXTERNAL_REFERENCE_ID = "externalReferenceId";
+  @jakarta.annotation.Nullable
+  private String externalReferenceId;
+
+  public static final String JSON_PROPERTY_CUSTOMER_DISPLAY = "customerDisplay";
+  @jakarta.annotation.Nullable
+  private OperationCustomerDisplay customerDisplay;
 
   public static final String JSON_PROPERTY_FINAL_CAPTURE = "finalCapture";
   @jakarta.annotation.Nonnull
@@ -160,6 +171,54 @@ public class PaymentSessionEventDataCapture {
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setAmount(@jakarta.annotation.Nonnull String amount) {
     this.amount = amount;
+  }
+
+
+  public PaymentSessionEventDataCapture externalReferenceId(@jakarta.annotation.Nullable String externalReferenceId) {
+    this.externalReferenceId = externalReferenceId;
+    return this;
+  }
+
+  /**
+   * An optional merchant-provided internal identifier for this capture, from the merchant&#39;s own system—not visible to the payer. For an auto-capture, it is copied from the authorization.
+   * @return externalReferenceId
+   */
+  @jakarta.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_EXTERNAL_REFERENCE_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public String getExternalReferenceId() {
+    return externalReferenceId;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_EXTERNAL_REFERENCE_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setExternalReferenceId(@jakarta.annotation.Nullable String externalReferenceId) {
+    this.externalReferenceId = externalReferenceId;
+  }
+
+
+  public PaymentSessionEventDataCapture customerDisplay(@jakarta.annotation.Nullable OperationCustomerDisplay customerDisplay) {
+    this.customerDisplay = customerDisplay;
+    return this;
+  }
+
+  /**
+   * Customer-facing display data for this capture, shown to the payer. An auto-capture reuses the authorization&#39;s &#x60;referenceCode&#x60;.
+   * @return customerDisplay
+   */
+  @jakarta.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_CUSTOMER_DISPLAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public OperationCustomerDisplay getCustomerDisplay() {
+    return customerDisplay;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_CUSTOMER_DISPLAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setCustomerDisplay(@jakarta.annotation.Nullable OperationCustomerDisplay customerDisplay) {
+    this.customerDisplay = customerDisplay;
   }
 
 
@@ -330,6 +389,8 @@ public class PaymentSessionEventDataCapture {
     return Objects.equals(this.captureId, paymentSessionEventDataCapture.captureId) &&
         Objects.equals(this.status, paymentSessionEventDataCapture.status) &&
         Objects.equals(this.amount, paymentSessionEventDataCapture.amount) &&
+        Objects.equals(this.externalReferenceId, paymentSessionEventDataCapture.externalReferenceId) &&
+        Objects.equals(this.customerDisplay, paymentSessionEventDataCapture.customerDisplay) &&
         Objects.equals(this.finalCapture, paymentSessionEventDataCapture.finalCapture) &&
         Objects.equals(this.error, paymentSessionEventDataCapture.error) &&
         Objects.equals(this.onchainTransactions, paymentSessionEventDataCapture.onchainTransactions) &&
@@ -340,7 +401,7 @@ public class PaymentSessionEventDataCapture {
 
   @Override
   public int hashCode() {
-    return Objects.hash(captureId, status, amount, finalCapture, error, onchainTransactions, metadata, createdAt, updatedAt);
+    return Objects.hash(captureId, status, amount, externalReferenceId, customerDisplay, finalCapture, error, onchainTransactions, metadata, createdAt, updatedAt);
   }
 
   @Override
@@ -350,6 +411,8 @@ public class PaymentSessionEventDataCapture {
     sb.append("    captureId: ").append(toIndentedString(captureId)).append("\n");
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
     sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
+    sb.append("    externalReferenceId: ").append(toIndentedString(externalReferenceId)).append("\n");
+    sb.append("    customerDisplay: ").append(toIndentedString(customerDisplay)).append("\n");
     sb.append("    finalCapture: ").append(toIndentedString(finalCapture)).append("\n");
     sb.append("    error: ").append(toIndentedString(error)).append("\n");
     sb.append("    onchainTransactions: ").append(toIndentedString(onchainTransactions)).append("\n");
@@ -418,6 +481,16 @@ public class PaymentSessionEventDataCapture {
       joiner.add(String.format("%samount%s=%s", prefix, suffix, URLEncoder.encode(ApiClient.valueToString(getAmount()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
     }
 
+    // add `externalReferenceId` to the URL query string
+    if (getExternalReferenceId() != null) {
+      joiner.add(String.format("%sexternalReferenceId%s=%s", prefix, suffix, URLEncoder.encode(ApiClient.valueToString(getExternalReferenceId()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
+    }
+
+    // add `customerDisplay` to the URL query string
+    if (getCustomerDisplay() != null) {
+      joiner.add(getCustomerDisplay().toUrlQueryString(prefix + "customerDisplay" + suffix));
+    }
+
     // add `finalCapture` to the URL query string
     if (getFinalCapture() != null) {
       joiner.add(String.format("%sfinalCapture%s=%s", prefix, suffix, URLEncoder.encode(ApiClient.valueToString(getFinalCapture()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
@@ -478,6 +551,14 @@ public class PaymentSessionEventDataCapture {
     }
     public PaymentSessionEventDataCapture.Builder amount(String amount) {
       this.instance.amount = amount;
+      return this;
+    }
+    public PaymentSessionEventDataCapture.Builder externalReferenceId(String externalReferenceId) {
+      this.instance.externalReferenceId = externalReferenceId;
+      return this;
+    }
+    public PaymentSessionEventDataCapture.Builder customerDisplay(OperationCustomerDisplay customerDisplay) {
+      this.instance.customerDisplay = customerDisplay;
       return this;
     }
     public PaymentSessionEventDataCapture.Builder finalCapture(Boolean finalCapture) {
@@ -541,6 +622,8 @@ public class PaymentSessionEventDataCapture {
       .captureId(getCaptureId())
       .status(getStatus())
       .amount(getAmount())
+      .externalReferenceId(getExternalReferenceId())
+      .customerDisplay(getCustomerDisplay())
       .finalCapture(getFinalCapture())
       .error(getError())
       .onchainTransactions(getOnchainTransactions())

--- a/java/src/main/java/com/coinbase/cdp/openapi/model/PaymentSessionEventDataRefund.java
+++ b/java/src/main/java/com/coinbase/cdp/openapi/model/PaymentSessionEventDataRefund.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.HashMap;
 import com.coinbase.cdp.openapi.model.Metadata;
 import com.coinbase.cdp.openapi.model.OnchainTransaction;
+import com.coinbase.cdp.openapi.model.OperationCustomerDisplay;
 import com.coinbase.cdp.openapi.model.PaymentActionStatus;
 import com.coinbase.cdp.openapi.model.PaymentError;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -43,6 +44,8 @@ import com.coinbase.cdp.openapi.ApiClient;
   PaymentSessionEventDataRefund.JSON_PROPERTY_REFUND_ID,
   PaymentSessionEventDataRefund.JSON_PROPERTY_STATUS,
   PaymentSessionEventDataRefund.JSON_PROPERTY_AMOUNT,
+  PaymentSessionEventDataRefund.JSON_PROPERTY_EXTERNAL_REFERENCE_ID,
+  PaymentSessionEventDataRefund.JSON_PROPERTY_CUSTOMER_DISPLAY,
   PaymentSessionEventDataRefund.JSON_PROPERTY_REASON,
   PaymentSessionEventDataRefund.JSON_PROPERTY_ERROR,
   PaymentSessionEventDataRefund.JSON_PROPERTY_ONCHAIN_TRANSACTIONS,
@@ -63,6 +66,14 @@ public class PaymentSessionEventDataRefund {
   public static final String JSON_PROPERTY_AMOUNT = "amount";
   @jakarta.annotation.Nonnull
   private String amount;
+
+  public static final String JSON_PROPERTY_EXTERNAL_REFERENCE_ID = "externalReferenceId";
+  @jakarta.annotation.Nullable
+  private String externalReferenceId;
+
+  public static final String JSON_PROPERTY_CUSTOMER_DISPLAY = "customerDisplay";
+  @jakarta.annotation.Nullable
+  private OperationCustomerDisplay customerDisplay;
 
   public static final String JSON_PROPERTY_REASON = "reason";
   @jakarta.annotation.Nullable
@@ -160,6 +171,54 @@ public class PaymentSessionEventDataRefund {
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setAmount(@jakarta.annotation.Nonnull String amount) {
     this.amount = amount;
+  }
+
+
+  public PaymentSessionEventDataRefund externalReferenceId(@jakarta.annotation.Nullable String externalReferenceId) {
+    this.externalReferenceId = externalReferenceId;
+    return this;
+  }
+
+  /**
+   * An optional merchant-provided internal identifier for this refund, from the merchant&#39;s own system—not visible to the payer. Present only when supplied on the create refund request.
+   * @return externalReferenceId
+   */
+  @jakarta.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_EXTERNAL_REFERENCE_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public String getExternalReferenceId() {
+    return externalReferenceId;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_EXTERNAL_REFERENCE_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setExternalReferenceId(@jakarta.annotation.Nullable String externalReferenceId) {
+    this.externalReferenceId = externalReferenceId;
+  }
+
+
+  public PaymentSessionEventDataRefund customerDisplay(@jakarta.annotation.Nullable OperationCustomerDisplay customerDisplay) {
+    this.customerDisplay = customerDisplay;
+    return this;
+  }
+
+  /**
+   * Customer-facing display data for this refund, shown to the payer. Present when supplied on the create refund request or when the session&#39;s &#x60;orderCode&#x60; fallback applies; otherwise omitted.
+   * @return customerDisplay
+   */
+  @jakarta.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_CUSTOMER_DISPLAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public OperationCustomerDisplay getCustomerDisplay() {
+    return customerDisplay;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_CUSTOMER_DISPLAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setCustomerDisplay(@jakarta.annotation.Nullable OperationCustomerDisplay customerDisplay) {
+    this.customerDisplay = customerDisplay;
   }
 
 
@@ -330,6 +389,8 @@ public class PaymentSessionEventDataRefund {
     return Objects.equals(this.refundId, paymentSessionEventDataRefund.refundId) &&
         Objects.equals(this.status, paymentSessionEventDataRefund.status) &&
         Objects.equals(this.amount, paymentSessionEventDataRefund.amount) &&
+        Objects.equals(this.externalReferenceId, paymentSessionEventDataRefund.externalReferenceId) &&
+        Objects.equals(this.customerDisplay, paymentSessionEventDataRefund.customerDisplay) &&
         Objects.equals(this.reason, paymentSessionEventDataRefund.reason) &&
         Objects.equals(this.error, paymentSessionEventDataRefund.error) &&
         Objects.equals(this.onchainTransactions, paymentSessionEventDataRefund.onchainTransactions) &&
@@ -340,7 +401,7 @@ public class PaymentSessionEventDataRefund {
 
   @Override
   public int hashCode() {
-    return Objects.hash(refundId, status, amount, reason, error, onchainTransactions, metadata, createdAt, updatedAt);
+    return Objects.hash(refundId, status, amount, externalReferenceId, customerDisplay, reason, error, onchainTransactions, metadata, createdAt, updatedAt);
   }
 
   @Override
@@ -350,6 +411,8 @@ public class PaymentSessionEventDataRefund {
     sb.append("    refundId: ").append(toIndentedString(refundId)).append("\n");
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
     sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
+    sb.append("    externalReferenceId: ").append(toIndentedString(externalReferenceId)).append("\n");
+    sb.append("    customerDisplay: ").append(toIndentedString(customerDisplay)).append("\n");
     sb.append("    reason: ").append(toIndentedString(reason)).append("\n");
     sb.append("    error: ").append(toIndentedString(error)).append("\n");
     sb.append("    onchainTransactions: ").append(toIndentedString(onchainTransactions)).append("\n");
@@ -418,6 +481,16 @@ public class PaymentSessionEventDataRefund {
       joiner.add(String.format("%samount%s=%s", prefix, suffix, URLEncoder.encode(ApiClient.valueToString(getAmount()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
     }
 
+    // add `externalReferenceId` to the URL query string
+    if (getExternalReferenceId() != null) {
+      joiner.add(String.format("%sexternalReferenceId%s=%s", prefix, suffix, URLEncoder.encode(ApiClient.valueToString(getExternalReferenceId()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
+    }
+
+    // add `customerDisplay` to the URL query string
+    if (getCustomerDisplay() != null) {
+      joiner.add(getCustomerDisplay().toUrlQueryString(prefix + "customerDisplay" + suffix));
+    }
+
     // add `reason` to the URL query string
     if (getReason() != null) {
       joiner.add(String.format("%sreason%s=%s", prefix, suffix, URLEncoder.encode(ApiClient.valueToString(getReason()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
@@ -478,6 +551,14 @@ public class PaymentSessionEventDataRefund {
     }
     public PaymentSessionEventDataRefund.Builder amount(String amount) {
       this.instance.amount = amount;
+      return this;
+    }
+    public PaymentSessionEventDataRefund.Builder externalReferenceId(String externalReferenceId) {
+      this.instance.externalReferenceId = externalReferenceId;
+      return this;
+    }
+    public PaymentSessionEventDataRefund.Builder customerDisplay(OperationCustomerDisplay customerDisplay) {
+      this.instance.customerDisplay = customerDisplay;
       return this;
     }
     public PaymentSessionEventDataRefund.Builder reason(String reason) {
@@ -541,6 +622,8 @@ public class PaymentSessionEventDataRefund {
       .refundId(getRefundId())
       .status(getStatus())
       .amount(getAmount())
+      .externalReferenceId(getExternalReferenceId())
+      .customerDisplay(getCustomerDisplay())
       .reason(getReason())
       .error(getError())
       .onchainTransactions(getOnchainTransactions())

--- a/java/src/main/java/com/coinbase/cdp/openapi/model/PaymentSessionEventDataVoid.java
+++ b/java/src/main/java/com/coinbase/cdp/openapi/model/PaymentSessionEventDataVoid.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.HashMap;
 import com.coinbase.cdp.openapi.model.Metadata;
 import com.coinbase.cdp.openapi.model.OnchainTransaction;
+import com.coinbase.cdp.openapi.model.OperationCustomerDisplay;
 import com.coinbase.cdp.openapi.model.PaymentActionStatus;
 import com.coinbase.cdp.openapi.model.PaymentError;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -43,6 +44,8 @@ import com.coinbase.cdp.openapi.ApiClient;
   PaymentSessionEventDataVoid.JSON_PROPERTY_VOID_ID,
   PaymentSessionEventDataVoid.JSON_PROPERTY_STATUS,
   PaymentSessionEventDataVoid.JSON_PROPERTY_AMOUNT,
+  PaymentSessionEventDataVoid.JSON_PROPERTY_EXTERNAL_REFERENCE_ID,
+  PaymentSessionEventDataVoid.JSON_PROPERTY_CUSTOMER_DISPLAY,
   PaymentSessionEventDataVoid.JSON_PROPERTY_ERROR,
   PaymentSessionEventDataVoid.JSON_PROPERTY_ONCHAIN_TRANSACTIONS,
   PaymentSessionEventDataVoid.JSON_PROPERTY_METADATA,
@@ -62,6 +65,14 @@ public class PaymentSessionEventDataVoid {
   public static final String JSON_PROPERTY_AMOUNT = "amount";
   @jakarta.annotation.Nonnull
   private String amount;
+
+  public static final String JSON_PROPERTY_EXTERNAL_REFERENCE_ID = "externalReferenceId";
+  @jakarta.annotation.Nullable
+  private String externalReferenceId;
+
+  public static final String JSON_PROPERTY_CUSTOMER_DISPLAY = "customerDisplay";
+  @jakarta.annotation.Nullable
+  private OperationCustomerDisplay customerDisplay;
 
   public static final String JSON_PROPERTY_ERROR = "error";
   @jakarta.annotation.Nullable
@@ -155,6 +166,54 @@ public class PaymentSessionEventDataVoid {
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setAmount(@jakarta.annotation.Nonnull String amount) {
     this.amount = amount;
+  }
+
+
+  public PaymentSessionEventDataVoid externalReferenceId(@jakarta.annotation.Nullable String externalReferenceId) {
+    this.externalReferenceId = externalReferenceId;
+    return this;
+  }
+
+  /**
+   * An optional merchant-provided internal identifier for this void, from the merchant&#39;s own system—not visible to the payer. Present only when supplied on the create void request.
+   * @return externalReferenceId
+   */
+  @jakarta.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_EXTERNAL_REFERENCE_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public String getExternalReferenceId() {
+    return externalReferenceId;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_EXTERNAL_REFERENCE_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setExternalReferenceId(@jakarta.annotation.Nullable String externalReferenceId) {
+    this.externalReferenceId = externalReferenceId;
+  }
+
+
+  public PaymentSessionEventDataVoid customerDisplay(@jakarta.annotation.Nullable OperationCustomerDisplay customerDisplay) {
+    this.customerDisplay = customerDisplay;
+    return this;
+  }
+
+  /**
+   * Customer-facing display data for this void, shown to the payer. Present when supplied on the create void request or when the session&#39;s &#x60;orderCode&#x60; fallback applies; otherwise omitted.
+   * @return customerDisplay
+   */
+  @jakarta.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_CUSTOMER_DISPLAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public OperationCustomerDisplay getCustomerDisplay() {
+    return customerDisplay;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_CUSTOMER_DISPLAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setCustomerDisplay(@jakarta.annotation.Nullable OperationCustomerDisplay customerDisplay) {
+    this.customerDisplay = customerDisplay;
   }
 
 
@@ -301,6 +360,8 @@ public class PaymentSessionEventDataVoid {
     return Objects.equals(this.voidId, paymentSessionEventDataVoid.voidId) &&
         Objects.equals(this.status, paymentSessionEventDataVoid.status) &&
         Objects.equals(this.amount, paymentSessionEventDataVoid.amount) &&
+        Objects.equals(this.externalReferenceId, paymentSessionEventDataVoid.externalReferenceId) &&
+        Objects.equals(this.customerDisplay, paymentSessionEventDataVoid.customerDisplay) &&
         Objects.equals(this.error, paymentSessionEventDataVoid.error) &&
         Objects.equals(this.onchainTransactions, paymentSessionEventDataVoid.onchainTransactions) &&
         Objects.equals(this.metadata, paymentSessionEventDataVoid.metadata) &&
@@ -310,7 +371,7 @@ public class PaymentSessionEventDataVoid {
 
   @Override
   public int hashCode() {
-    return Objects.hash(voidId, status, amount, error, onchainTransactions, metadata, createdAt, updatedAt);
+    return Objects.hash(voidId, status, amount, externalReferenceId, customerDisplay, error, onchainTransactions, metadata, createdAt, updatedAt);
   }
 
   @Override
@@ -320,6 +381,8 @@ public class PaymentSessionEventDataVoid {
     sb.append("    voidId: ").append(toIndentedString(voidId)).append("\n");
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
     sb.append("    amount: ").append(toIndentedString(amount)).append("\n");
+    sb.append("    externalReferenceId: ").append(toIndentedString(externalReferenceId)).append("\n");
+    sb.append("    customerDisplay: ").append(toIndentedString(customerDisplay)).append("\n");
     sb.append("    error: ").append(toIndentedString(error)).append("\n");
     sb.append("    onchainTransactions: ").append(toIndentedString(onchainTransactions)).append("\n");
     sb.append("    metadata: ").append(toIndentedString(metadata)).append("\n");
@@ -387,6 +450,16 @@ public class PaymentSessionEventDataVoid {
       joiner.add(String.format("%samount%s=%s", prefix, suffix, URLEncoder.encode(ApiClient.valueToString(getAmount()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
     }
 
+    // add `externalReferenceId` to the URL query string
+    if (getExternalReferenceId() != null) {
+      joiner.add(String.format("%sexternalReferenceId%s=%s", prefix, suffix, URLEncoder.encode(ApiClient.valueToString(getExternalReferenceId()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
+    }
+
+    // add `customerDisplay` to the URL query string
+    if (getCustomerDisplay() != null) {
+      joiner.add(getCustomerDisplay().toUrlQueryString(prefix + "customerDisplay" + suffix));
+    }
+
     // add `error` to the URL query string
     if (getError() != null) {
       joiner.add(getError().toUrlQueryString(prefix + "error" + suffix));
@@ -442,6 +515,14 @@ public class PaymentSessionEventDataVoid {
     }
     public PaymentSessionEventDataVoid.Builder amount(String amount) {
       this.instance.amount = amount;
+      return this;
+    }
+    public PaymentSessionEventDataVoid.Builder externalReferenceId(String externalReferenceId) {
+      this.instance.externalReferenceId = externalReferenceId;
+      return this;
+    }
+    public PaymentSessionEventDataVoid.Builder customerDisplay(OperationCustomerDisplay customerDisplay) {
+      this.instance.customerDisplay = customerDisplay;
       return this;
     }
     public PaymentSessionEventDataVoid.Builder error(PaymentError error) {
@@ -501,6 +582,8 @@ public class PaymentSessionEventDataVoid {
       .voidId(getVoidId())
       .status(getStatus())
       .amount(getAmount())
+      .externalReferenceId(getExternalReferenceId())
+      .customerDisplay(getCustomerDisplay())
       .error(getError())
       .onchainTransactions(getOnchainTransactions())
       .metadata(getMetadata())

--- a/java/src/main/java/com/coinbase/cdp/openapi/model/Refund.java
+++ b/java/src/main/java/com/coinbase/cdp/openapi/model/Refund.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.HashMap;
 import com.coinbase.cdp.openapi.model.Metadata;
 import com.coinbase.cdp.openapi.model.OnchainTransaction;
+import com.coinbase.cdp.openapi.model.OperationCustomerDisplay;
 import com.coinbase.cdp.openapi.model.PaymentActionStatus;
 import com.coinbase.cdp.openapi.model.PaymentError;
 import com.coinbase.cdp.openapi.model.RefundSource;
@@ -49,6 +50,8 @@ import com.coinbase.cdp.openapi.ApiClient;
   Refund.JSON_PROPERTY_REASON,
   Refund.JSON_PROPERTY_ERROR,
   Refund.JSON_PROPERTY_METADATA,
+  Refund.JSON_PROPERTY_EXTERNAL_REFERENCE_ID,
+  Refund.JSON_PROPERTY_CUSTOMER_DISPLAY,
   Refund.JSON_PROPERTY_ONCHAIN_TRANSACTIONS,
   Refund.JSON_PROPERTY_CREATED_AT,
   Refund.JSON_PROPERTY_UPDATED_AT
@@ -86,6 +89,14 @@ public class Refund {
   public static final String JSON_PROPERTY_METADATA = "metadata";
   @jakarta.annotation.Nullable
   private Metadata metadata = new Metadata();
+
+  public static final String JSON_PROPERTY_EXTERNAL_REFERENCE_ID = "externalReferenceId";
+  @jakarta.annotation.Nullable
+  private String externalReferenceId;
+
+  public static final String JSON_PROPERTY_CUSTOMER_DISPLAY = "customerDisplay";
+  @jakarta.annotation.Nullable
+  private OperationCustomerDisplay customerDisplay;
 
   public static final String JSON_PROPERTY_ONCHAIN_TRANSACTIONS = "onchainTransactions";
   @jakarta.annotation.Nullable
@@ -294,6 +305,54 @@ public class Refund {
   }
 
 
+  public Refund externalReferenceId(@jakarta.annotation.Nullable String externalReferenceId) {
+    this.externalReferenceId = externalReferenceId;
+    return this;
+  }
+
+  /**
+   * A merchant-provided internal identifier for this refund, from the merchant&#39;s own system—not visible to the payer. Present only when supplied on the create refund request.
+   * @return externalReferenceId
+   */
+  @jakarta.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_EXTERNAL_REFERENCE_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public String getExternalReferenceId() {
+    return externalReferenceId;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_EXTERNAL_REFERENCE_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setExternalReferenceId(@jakarta.annotation.Nullable String externalReferenceId) {
+    this.externalReferenceId = externalReferenceId;
+  }
+
+
+  public Refund customerDisplay(@jakarta.annotation.Nullable OperationCustomerDisplay customerDisplay) {
+    this.customerDisplay = customerDisplay;
+    return this;
+  }
+
+  /**
+   * Customer-facing display data for this refund, shown to the payer. Present when supplied on the create refund request or when the session&#39;s &#x60;orderCode&#x60; fallback applies; otherwise omitted.
+   * @return customerDisplay
+   */
+  @jakarta.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_CUSTOMER_DISPLAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public OperationCustomerDisplay getCustomerDisplay() {
+    return customerDisplay;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_CUSTOMER_DISPLAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setCustomerDisplay(@jakarta.annotation.Nullable OperationCustomerDisplay customerDisplay) {
+    this.customerDisplay = customerDisplay;
+  }
+
+
   public Refund onchainTransactions(@jakarta.annotation.Nullable List<OnchainTransaction> onchainTransactions) {
     this.onchainTransactions = onchainTransactions;
     return this;
@@ -394,6 +453,8 @@ public class Refund {
         Objects.equals(this.reason, refund.reason) &&
         Objects.equals(this.error, refund.error) &&
         Objects.equals(this.metadata, refund.metadata) &&
+        Objects.equals(this.externalReferenceId, refund.externalReferenceId) &&
+        Objects.equals(this.customerDisplay, refund.customerDisplay) &&
         Objects.equals(this.onchainTransactions, refund.onchainTransactions) &&
         Objects.equals(this.createdAt, refund.createdAt) &&
         Objects.equals(this.updatedAt, refund.updatedAt);
@@ -401,7 +462,7 @@ public class Refund {
 
   @Override
   public int hashCode() {
-    return Objects.hash(refundId, paymentSessionId, source, status, amount, reason, error, metadata, onchainTransactions, createdAt, updatedAt);
+    return Objects.hash(refundId, paymentSessionId, source, status, amount, reason, error, metadata, externalReferenceId, customerDisplay, onchainTransactions, createdAt, updatedAt);
   }
 
   @Override
@@ -416,6 +477,8 @@ public class Refund {
     sb.append("    reason: ").append(toIndentedString(reason)).append("\n");
     sb.append("    error: ").append(toIndentedString(error)).append("\n");
     sb.append("    metadata: ").append(toIndentedString(metadata)).append("\n");
+    sb.append("    externalReferenceId: ").append(toIndentedString(externalReferenceId)).append("\n");
+    sb.append("    customerDisplay: ").append(toIndentedString(customerDisplay)).append("\n");
     sb.append("    onchainTransactions: ").append(toIndentedString(onchainTransactions)).append("\n");
     sb.append("    createdAt: ").append(toIndentedString(createdAt)).append("\n");
     sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
@@ -506,6 +569,16 @@ public class Refund {
       joiner.add(String.format("%smetadata%s=%s", prefix, suffix, URLEncoder.encode(ApiClient.valueToString(getMetadata()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
     }
 
+    // add `externalReferenceId` to the URL query string
+    if (getExternalReferenceId() != null) {
+      joiner.add(String.format("%sexternalReferenceId%s=%s", prefix, suffix, URLEncoder.encode(ApiClient.valueToString(getExternalReferenceId()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
+    }
+
+    // add `customerDisplay` to the URL query string
+    if (getCustomerDisplay() != null) {
+      joiner.add(getCustomerDisplay().toUrlQueryString(prefix + "customerDisplay" + suffix));
+    }
+
     // add `onchainTransactions` to the URL query string
     if (getOnchainTransactions() != null) {
       for (int i = 0; i < getOnchainTransactions().size(); i++) {
@@ -573,6 +646,14 @@ public class Refund {
       this.instance.metadata = metadata;
       return this;
     }
+    public Refund.Builder externalReferenceId(String externalReferenceId) {
+      this.instance.externalReferenceId = externalReferenceId;
+      return this;
+    }
+    public Refund.Builder customerDisplay(OperationCustomerDisplay customerDisplay) {
+      this.instance.customerDisplay = customerDisplay;
+      return this;
+    }
     public Refund.Builder onchainTransactions(List<OnchainTransaction> onchainTransactions) {
       this.instance.onchainTransactions = onchainTransactions;
       return this;
@@ -627,6 +708,8 @@ public class Refund {
       .reason(getReason())
       .error(getError())
       .metadata(getMetadata())
+      .externalReferenceId(getExternalReferenceId())
+      .customerDisplay(getCustomerDisplay())
       .onchainTransactions(getOnchainTransactions())
       .createdAt(getCreatedAt())
       .updatedAt(getUpdatedAt());

--- a/java/src/main/java/com/coinbase/cdp/openapi/model/SwapUnavailableResponse1.java
+++ b/java/src/main/java/com/coinbase/cdp/openapi/model/SwapUnavailableResponse1.java
@@ -30,46 +30,79 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import com.coinbase.cdp.openapi.ApiClient;
 /**
- * SwapUnavailableResponse
+ * SwapUnavailableResponse1
  */
 @JsonPropertyOrder({
-  SwapUnavailableResponse.JSON_PROPERTY_LIQUIDITY_AVAILABLE
+  SwapUnavailableResponse1.JSON_PROPERTY_LIQUIDITY_AVAILABLE
 })
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.11.0")
-public class SwapUnavailableResponse {
-  public static final String JSON_PROPERTY_LIQUIDITY_AVAILABLE = "liquidityAvailable";
-  @jakarta.annotation.Nonnull
-  private Boolean liquidityAvailable;
+public class SwapUnavailableResponse1 {
+  /**
+   * Gets or Sets liquidityAvailable
+   */
+  public enum LiquidityAvailableEnum {
+    TRUE(Boolean.valueOf("true"));
 
-  public SwapUnavailableResponse() { 
+    private Boolean value;
+
+    LiquidityAvailableEnum(Boolean value) {
+      this.value = value;
+    }
+
+    @JsonValue
+    public Boolean getValue() {
+      return value;
+    }
+
+    @Override
+    public String toString() {
+      return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static LiquidityAvailableEnum fromValue(Boolean value) {
+      for (LiquidityAvailableEnum b : LiquidityAvailableEnum.values()) {
+        if (b.value.equals(value)) {
+          return b;
+        }
+      }
+      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
   }
 
-  public SwapUnavailableResponse liquidityAvailable(@jakarta.annotation.Nonnull Boolean liquidityAvailable) {
+  public static final String JSON_PROPERTY_LIQUIDITY_AVAILABLE = "liquidityAvailable";
+  @jakarta.annotation.Nullable
+  private LiquidityAvailableEnum liquidityAvailable;
+
+  public SwapUnavailableResponse1() { 
+  }
+
+  public SwapUnavailableResponse1 liquidityAvailable(@jakarta.annotation.Nullable LiquidityAvailableEnum liquidityAvailable) {
     this.liquidityAvailable = liquidityAvailable;
     return this;
   }
 
   /**
-   * Whether sufficient liquidity is available to settle the swap. All other fields in the response will be empty if this is false.
+   * Get liquidityAvailable
    * @return liquidityAvailable
    */
-  @jakarta.annotation.Nonnull
+  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LIQUIDITY_AVAILABLE)
-  @JsonInclude(value = JsonInclude.Include.ALWAYS)
-  public Boolean getLiquidityAvailable() {
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public LiquidityAvailableEnum getLiquidityAvailable() {
     return liquidityAvailable;
   }
 
 
   @JsonProperty(JSON_PROPERTY_LIQUIDITY_AVAILABLE)
-  @JsonInclude(value = JsonInclude.Include.ALWAYS)
-  public void setLiquidityAvailable(@jakarta.annotation.Nonnull Boolean liquidityAvailable) {
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setLiquidityAvailable(@jakarta.annotation.Nullable LiquidityAvailableEnum liquidityAvailable) {
     this.liquidityAvailable = liquidityAvailable;
   }
 
 
   /**
-   * Return true if this SwapUnavailableResponse object is equal to o.
+   * Return true if this SwapUnavailableResponse_1 object is equal to o.
    */
   @Override
   public boolean equals(Object o) {
@@ -79,8 +112,8 @@ public class SwapUnavailableResponse {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    SwapUnavailableResponse swapUnavailableResponse = (SwapUnavailableResponse) o;
-    return Objects.equals(this.liquidityAvailable, swapUnavailableResponse.liquidityAvailable);
+    SwapUnavailableResponse1 swapUnavailableResponse1 = (SwapUnavailableResponse1) o;
+    return Objects.equals(this.liquidityAvailable, swapUnavailableResponse1.liquidityAvailable);
   }
 
   @Override
@@ -91,7 +124,7 @@ public class SwapUnavailableResponse {
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
-    sb.append("class SwapUnavailableResponse {\n");
+    sb.append("class SwapUnavailableResponse1 {\n");
     sb.append("    liquidityAvailable: ").append(toIndentedString(liquidityAvailable)).append("\n");
     sb.append("}");
     return sb.toString();
@@ -150,28 +183,28 @@ public class SwapUnavailableResponse {
 
     public static class Builder {
 
-    private SwapUnavailableResponse instance;
+    private SwapUnavailableResponse1 instance;
 
     public Builder() {
-      this(new SwapUnavailableResponse());
+      this(new SwapUnavailableResponse1());
     }
 
-    protected Builder(SwapUnavailableResponse instance) {
+    protected Builder(SwapUnavailableResponse1 instance) {
       this.instance = instance;
     }
 
-    public SwapUnavailableResponse.Builder liquidityAvailable(Boolean liquidityAvailable) {
+    public SwapUnavailableResponse1.Builder liquidityAvailable(LiquidityAvailableEnum liquidityAvailable) {
       this.instance.liquidityAvailable = liquidityAvailable;
       return this;
     }
 
 
     /**
-    * returns a built SwapUnavailableResponse instance.
+    * returns a built SwapUnavailableResponse1 instance.
     *
     * The builder is not reusable.
     */
-    public SwapUnavailableResponse build() {
+    public SwapUnavailableResponse1 build() {
       try {
         return this.instance;
       } finally {
@@ -189,15 +222,15 @@ public class SwapUnavailableResponse {
   /**
   * Create a builder with no initialized field.
   */
-  public static SwapUnavailableResponse.Builder builder() {
-    return new SwapUnavailableResponse.Builder();
+  public static SwapUnavailableResponse1.Builder builder() {
+    return new SwapUnavailableResponse1.Builder();
   }
 
   /**
   * Create a builder with a shallow copy of this instance.
   */
-  public SwapUnavailableResponse.Builder toBuilder() {
-    return new SwapUnavailableResponse.Builder()
+  public SwapUnavailableResponse1.Builder toBuilder() {
+    return new SwapUnavailableResponse1.Builder()
       .liquidityAvailable(getLiquidityAvailable());
   }
 

--- a/java/src/main/java/com/coinbase/cdp/openapi/model/WalletAuthorizationRequest.java
+++ b/java/src/main/java/com/coinbase/cdp/openapi/model/WalletAuthorizationRequest.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.HashMap;
 import com.coinbase.cdp.openapi.model.Metadata;
 import com.coinbase.cdp.openapi.model.OnchainSignedPayload;
+import com.coinbase.cdp.openapi.model.OperationCustomerDisplay;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -39,7 +40,9 @@ import com.coinbase.cdp.openapi.ApiClient;
 @JsonPropertyOrder({
   WalletAuthorizationRequest.JSON_PROPERTY_OPTION_ID,
   WalletAuthorizationRequest.JSON_PROPERTY_SIGNED_PAYLOADS,
-  WalletAuthorizationRequest.JSON_PROPERTY_METADATA
+  WalletAuthorizationRequest.JSON_PROPERTY_METADATA,
+  WalletAuthorizationRequest.JSON_PROPERTY_CUSTOMER_DISPLAY,
+  WalletAuthorizationRequest.JSON_PROPERTY_EXTERNAL_REFERENCE_ID
 })
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.11.0")
 public class WalletAuthorizationRequest {
@@ -54,6 +57,14 @@ public class WalletAuthorizationRequest {
   public static final String JSON_PROPERTY_METADATA = "metadata";
   @jakarta.annotation.Nullable
   private Metadata metadata = new Metadata();
+
+  public static final String JSON_PROPERTY_CUSTOMER_DISPLAY = "customerDisplay";
+  @jakarta.annotation.Nullable
+  private OperationCustomerDisplay customerDisplay;
+
+  public static final String JSON_PROPERTY_EXTERNAL_REFERENCE_ID = "externalReferenceId";
+  @jakarta.annotation.Nullable
+  private String externalReferenceId;
 
   public WalletAuthorizationRequest() { 
   }
@@ -138,6 +149,54 @@ public class WalletAuthorizationRequest {
   }
 
 
+  public WalletAuthorizationRequest customerDisplay(@jakarta.annotation.Nullable OperationCustomerDisplay customerDisplay) {
+    this.customerDisplay = customerDisplay;
+    return this;
+  }
+
+  /**
+   * Optional customer-facing display data for this authorization, shown to the payer. Falls back to the session&#39;s &#x60;orderCode&#x60; when &#x60;referenceCode&#x60; is omitted.
+   * @return customerDisplay
+   */
+  @jakarta.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_CUSTOMER_DISPLAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public OperationCustomerDisplay getCustomerDisplay() {
+    return customerDisplay;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_CUSTOMER_DISPLAY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setCustomerDisplay(@jakarta.annotation.Nullable OperationCustomerDisplay customerDisplay) {
+    this.customerDisplay = customerDisplay;
+  }
+
+
+  public WalletAuthorizationRequest externalReferenceId(@jakarta.annotation.Nullable String externalReferenceId) {
+    this.externalReferenceId = externalReferenceId;
+    return this;
+  }
+
+  /**
+   * An optional merchant-provided internal identifier for this wallet authorization, from the merchant&#39;s own system—not visible to the payer.
+   * @return externalReferenceId
+   */
+  @jakarta.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_EXTERNAL_REFERENCE_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public String getExternalReferenceId() {
+    return externalReferenceId;
+  }
+
+
+  @JsonProperty(JSON_PROPERTY_EXTERNAL_REFERENCE_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setExternalReferenceId(@jakarta.annotation.Nullable String externalReferenceId) {
+    this.externalReferenceId = externalReferenceId;
+  }
+
+
   /**
    * Return true if this WalletAuthorizationRequest object is equal to o.
    */
@@ -152,12 +211,14 @@ public class WalletAuthorizationRequest {
     WalletAuthorizationRequest walletAuthorizationRequest = (WalletAuthorizationRequest) o;
     return Objects.equals(this.optionId, walletAuthorizationRequest.optionId) &&
         Objects.equals(this.signedPayloads, walletAuthorizationRequest.signedPayloads) &&
-        Objects.equals(this.metadata, walletAuthorizationRequest.metadata);
+        Objects.equals(this.metadata, walletAuthorizationRequest.metadata) &&
+        Objects.equals(this.customerDisplay, walletAuthorizationRequest.customerDisplay) &&
+        Objects.equals(this.externalReferenceId, walletAuthorizationRequest.externalReferenceId);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(optionId, signedPayloads, metadata);
+    return Objects.hash(optionId, signedPayloads, metadata, customerDisplay, externalReferenceId);
   }
 
   @Override
@@ -167,6 +228,8 @@ public class WalletAuthorizationRequest {
     sb.append("    optionId: ").append(toIndentedString(optionId)).append("\n");
     sb.append("    signedPayloads: ").append(toIndentedString(signedPayloads)).append("\n");
     sb.append("    metadata: ").append(toIndentedString(metadata)).append("\n");
+    sb.append("    customerDisplay: ").append(toIndentedString(customerDisplay)).append("\n");
+    sb.append("    externalReferenceId: ").append(toIndentedString(externalReferenceId)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -234,6 +297,16 @@ public class WalletAuthorizationRequest {
       joiner.add(String.format("%smetadata%s=%s", prefix, suffix, URLEncoder.encode(ApiClient.valueToString(getMetadata()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
     }
 
+    // add `customerDisplay` to the URL query string
+    if (getCustomerDisplay() != null) {
+      joiner.add(getCustomerDisplay().toUrlQueryString(prefix + "customerDisplay" + suffix));
+    }
+
+    // add `externalReferenceId` to the URL query string
+    if (getExternalReferenceId() != null) {
+      joiner.add(String.format("%sexternalReferenceId%s=%s", prefix, suffix, URLEncoder.encode(ApiClient.valueToString(getExternalReferenceId()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
+    }
+
     return joiner.toString();
   }
 
@@ -259,6 +332,14 @@ public class WalletAuthorizationRequest {
     }
     public WalletAuthorizationRequest.Builder metadata(Metadata metadata) {
       this.instance.metadata = metadata;
+      return this;
+    }
+    public WalletAuthorizationRequest.Builder customerDisplay(OperationCustomerDisplay customerDisplay) {
+      this.instance.customerDisplay = customerDisplay;
+      return this;
+    }
+    public WalletAuthorizationRequest.Builder externalReferenceId(String externalReferenceId) {
+      this.instance.externalReferenceId = externalReferenceId;
       return this;
     }
 
@@ -297,7 +378,9 @@ public class WalletAuthorizationRequest {
     return new WalletAuthorizationRequest.Builder()
       .optionId(getOptionId())
       .signedPayloads(getSignedPayloads())
-      .metadata(getMetadata());
+      .metadata(getMetadata())
+      .customerDisplay(getCustomerDisplay())
+      .externalReferenceId(getExternalReferenceId());
   }
 
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4008,6 +4008,22 @@ paths:
           schema:
             type: string
           example: eyJ4NDAyVmVyc2lvbiI6MiwicmVzb3VyY2UiOnsidXJsIjoiaHR0cHM6Ly9hcGkuZXhhbXBsZS5jb20vcHJlbWl1bS1kYXRhIiwiZGVzY3JpcHRpb24iOiJBY2Nlc3MgdG8gcHJlbWl1bSBtYXJrZXQgZGF0YSIsIm1pbWVUeXBlIjoiYXBwbGljYXRpb24vanNvbiJ9LCJhY2NlcHRlZCI6eyJzY2hlbWUiOiJleGFjdCIsIm5ldHdvcmsiOiJlaXAxNTU6ODQ1MzIiLCJhbW91bnQiOiIxMDAwMCIsImFzc2V0IjoiMHgwMzZDYkQ1Mzg0MmM1NDI2NjM0ZTc5Mjk1NDFlQzIzMThmM2RDRjdlIiwicGF5VG8iOiIweDIwOTY5M0JjNmFmYzBDNTMyOGJBMzZGYUYwM0M1MTRFRjMxMjI4N0MiLCJtYXhUaW1lb3V0U2Vjb25kcyI6NjAsImV4dHJhIjp7Im5hbWUiOiJVU0RDIiwidmVyc2lvbiI6IjIifX0sInBheWxvYWQiOnsic2lnbmF0dXJlIjoiMHgyZDZhNzU4OGQ2YWNjYTUwNWNiZjBkOWE0YTIyN2UwYzUyYzZjMzQwMDhjOGU4OTg2YTEyODMyNTk3NjQxNzM2MDhhMmNlNjQ5NjY0MmUzNzdkNmRhOGRiYmY1ODM2ZTliZDE1MDkyZjllY2FiMDVkZWQzZDYyOTNhZjE0OGI1NzFjIiwiYXV0aG9yaXphdGlvbiI6eyJmcm9tIjoiMHg4NTdiMDY1MTlFOTFlM0E1NDUzODc5MWJEYmIwRTIyMzczZTM2YjY2IiwidG8iOiIweDIwOTY5M0JjNmFmYzBDNTMyOGJBMzZGYUYwM0M1MTRFRjMxMjI4N0MiLCJ2YWx1ZSI6IjEwMDAwIiwidmFsaWRBZnRlciI6IjE3NDA2NzIwODkiLCJ2YWxpZEJlZm9yZSI6IjE3NDA2NzIxNTQiLCJub25jZSI6IjB4ZjM3NDY2MTNjMmQ5MjBiNWZkYWJjMDg1NmYyYWViMmQ0Zjg4ZWU2MDM3YjhjYzVkMDRhNzFhNDQ2MmYxMzQ4MCJ9fX0=
+        - name: X-External-Reference-Id
+          in: header
+          required: false
+          description: An optional merchant-provided internal identifier for this x402 authorization, from the merchant's own system—not visible to the payer.
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/ExternalReferenceId'
+          example: merchant-authorization-x402abc
+        - name: X-Customer-Display-Reference-Code
+          in: header
+          required: false
+          description: A short customer-facing reference code for this x402 authorization, visible to the payer. Equivalent to `customerDisplay.referenceCode` on JSON authorization requests. Falls back to the session's `orderCode` when omitted.
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/CustomerReferenceCode'
+          example: REF-ABC123
         - $ref: '#/components/parameters/IdempotencyKey'
       responses:
         '200':
@@ -20018,6 +20034,28 @@ components:
         code: insufficient_funds
         message: The payer does not have sufficient funds.
         occurredAt: '2025-06-15T12:00:00.000Z'
+    ExternalReferenceId:
+      type: string
+      maxLength: 256
+      description: A merchant-provided internal identifier for a resource from the merchant's own system—not visible to the payer. It must not contain personally identifiable information (PII) or payment credentials.
+      example: merchant-reference-abc123
+    CustomerReferenceCode:
+      type: string
+      maxLength: 128
+      description: A short customer-facing reference for an operation, visible to the payer. It must not contain personally identifiable information (PII) or payment credentials.
+      example: REF-ABC123
+    OperationCustomerDisplay:
+      type: object
+      title: Operation Customer Display
+      description: Customer-facing display data for a payment operation, shown to the payer.
+      properties:
+        referenceCode:
+          allOf:
+            - $ref: '#/components/schemas/CustomerReferenceCode'
+          description: A short reference code for this payment operation, visible to the payer.
+          example: REF-ABC123
+      example:
+        referenceCode: REF-ABC123
     OnchainTransaction:
       type: object
       description: An onchain transaction associated with a payment action.
@@ -20065,6 +20103,15 @@ components:
           example: Your payment was successfully submitted
         metadata:
           $ref: '#/components/schemas/Metadata'
+        externalReferenceId:
+          allOf:
+            - $ref: '#/components/schemas/ExternalReferenceId'
+          description: A merchant-provided internal identifier for this authorization, from the merchant's own system—not visible to the payer. Present only when supplied on the authorization request.
+          example: merchant-authorization-abc123
+        customerDisplay:
+          allOf:
+            - $ref: '#/components/schemas/OperationCustomerDisplay'
+          description: Customer-facing display data for this authorization, shown to the payer. Present when supplied on the authorization request or when the session's `orderCode` fallback applies; otherwise omitted.
         source:
           allOf:
             - $ref: '#/components/schemas/PaymentSessionSource'
@@ -20143,6 +20190,15 @@ components:
           $ref: '#/components/schemas/PaymentError'
         metadata:
           $ref: '#/components/schemas/Metadata'
+        externalReferenceId:
+          allOf:
+            - $ref: '#/components/schemas/ExternalReferenceId'
+          description: A merchant-provided internal identifier for this capture, from the merchant's own system—not visible to the payer. A manual capture uses the caller-provided value; an auto-capture reuses the authorization's value and omits it when the authorization omitted it. It never falls back to `PaymentSession.externalReferenceId`.
+          example: merchant-capture-abc123
+        customerDisplay:
+          allOf:
+            - $ref: '#/components/schemas/OperationCustomerDisplay'
+          description: Customer-facing display data for this capture, shown to the payer. A manual capture falls back to the session's `orderCode` when `referenceCode` is omitted; an auto-capture reuses the authorization's `referenceCode`.
         onchainTransactions:
           type: array
           description: The onchain transactions associated with this capture.
@@ -20208,6 +20264,15 @@ components:
           $ref: '#/components/schemas/PaymentError'
         metadata:
           $ref: '#/components/schemas/Metadata'
+        externalReferenceId:
+          allOf:
+            - $ref: '#/components/schemas/ExternalReferenceId'
+          description: A merchant-provided internal identifier for this void, from the merchant's own system—not visible to the payer. Present only when supplied on the create void request.
+          example: merchant-void-abc123
+        customerDisplay:
+          allOf:
+            - $ref: '#/components/schemas/OperationCustomerDisplay'
+          description: Customer-facing display data for this void, shown to the payer. Present when supplied on the create void request or when the session's `orderCode` fallback applies; otherwise omitted.
         onchainTransactions:
           type: array
           description: The onchain transactions associated with this void.
@@ -20298,6 +20363,15 @@ components:
           $ref: '#/components/schemas/PaymentError'
         metadata:
           $ref: '#/components/schemas/Metadata'
+        externalReferenceId:
+          allOf:
+            - $ref: '#/components/schemas/ExternalReferenceId'
+          description: A merchant-provided internal identifier for this refund, from the merchant's own system—not visible to the payer. Present only when supplied on the create refund request.
+          example: merchant-refund-abc123
+        customerDisplay:
+          allOf:
+            - $ref: '#/components/schemas/OperationCustomerDisplay'
+          description: Customer-facing display data for this refund, shown to the payer. Present when supplied on the create refund request or when the session's `orderCode` fallback applies; otherwise omitted.
         onchainTransactions:
           type: array
           description: The onchain transactions associated with this refund.
@@ -20377,6 +20451,11 @@ components:
           example:
             amount: '1.37'
             currency: cad
+        orderCode:
+          type: string
+          maxLength: 128
+          description: A customer-visible code for the overall order. When omitted, CDP generates one and returns it. It must not contain personally identifiable information (PII) or payment credentials.
+          example: ORDER-ABC123
       example:
         merchantName: Acme Store
         displayAmount:
@@ -21481,6 +21560,17 @@ components:
               signature: '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab'
         metadata:
           $ref: '#/components/schemas/Metadata'
+        customerDisplay:
+          allOf:
+            - $ref: '#/components/schemas/OperationCustomerDisplay'
+          description: Optional customer-facing display data for this authorization, shown to the payer. Falls back to the session's `orderCode` when `referenceCode` is omitted.
+          example:
+            referenceCode: REF-ABC123
+        externalReferenceId:
+          allOf:
+            - $ref: '#/components/schemas/ExternalReferenceId'
+          description: An optional merchant-provided internal identifier for this wallet authorization, from the merchant's own system—not visible to the payer.
+          example: merchant-authorization-abc123
       required:
         - optionId
         - signedPayloads
@@ -21495,6 +21585,17 @@ components:
       properties:
         metadata:
           $ref: '#/components/schemas/Metadata'
+        customerDisplay:
+          allOf:
+            - $ref: '#/components/schemas/OperationCustomerDisplay'
+          description: Optional customer-facing display data for this authorization, shown to the payer. Falls back to the session's `orderCode` when `referenceCode` is omitted.
+          example:
+            referenceCode: REF-ABC123
+        externalReferenceId:
+          allOf:
+            - $ref: '#/components/schemas/ExternalReferenceId'
+          description: An optional merchant-provided internal identifier for this Coinbase authorization, from the merchant's own system—not visible to the payer.
+          example: merchant-authorization-abc123
     CreateCaptureRequest:
       type: object
       description: A request to create a capture for a payment session.
@@ -21509,6 +21610,17 @@ components:
           example: true
         metadata:
           $ref: '#/components/schemas/Metadata'
+        externalReferenceId:
+          allOf:
+            - $ref: '#/components/schemas/ExternalReferenceId'
+          description: An optional merchant-provided internal identifier for this manual capture, from the merchant's own system—not visible to the payer.
+          example: merchant-capture-abc123
+        customerDisplay:
+          allOf:
+            - $ref: '#/components/schemas/OperationCustomerDisplay'
+          description: Optional customer-facing display data for this manual capture, shown to the payer. Falls back to the session's `orderCode` when `referenceCode` is omitted.
+          example:
+            referenceCode: REF-ABC123
       required:
         - finalCapture
       example:
@@ -21520,6 +21632,17 @@ components:
       properties:
         metadata:
           $ref: '#/components/schemas/Metadata'
+        externalReferenceId:
+          allOf:
+            - $ref: '#/components/schemas/ExternalReferenceId'
+          description: An optional merchant-provided internal identifier for this void, from the merchant's own system—not visible to the payer.
+          example: merchant-void-abc123
+        customerDisplay:
+          allOf:
+            - $ref: '#/components/schemas/OperationCustomerDisplay'
+          description: Optional customer-facing display data for this void, shown to the payer. Falls back to the session's `orderCode` when `referenceCode` is omitted.
+          example:
+            referenceCode: REF-ABC123
     CreateRefundRequest:
       type: object
       description: A request to create a refund for a payment session.
@@ -21541,6 +21664,17 @@ components:
           example: Customer returned the item.
         metadata:
           $ref: '#/components/schemas/Metadata'
+        externalReferenceId:
+          allOf:
+            - $ref: '#/components/schemas/ExternalReferenceId'
+          description: An optional merchant-provided internal identifier for this refund, from the merchant's own system—not visible to the payer.
+          example: merchant-refund-abc123
+        customerDisplay:
+          allOf:
+            - $ref: '#/components/schemas/OperationCustomerDisplay'
+          description: Optional customer-facing display data for this refund, shown to the payer. Falls back to the session's `orderCode` when `referenceCode` is omitted.
+          example:
+            referenceCode: REF-ABC123
       required:
         - source
       example:
@@ -21665,6 +21799,10 @@ components:
           maxLength: 256
           description: A merchant-provided internal identifier for this disbursement, from the merchant's own system—not visible to the payer. It must not contain personally identifiable information (PII) or payment credentials.
           example: disbursement-2026-04-1234
+        customerDisplay:
+          allOf:
+            - $ref: '#/components/schemas/OperationCustomerDisplay'
+          description: 'Customer-facing display data for this disbursement, shown to the payer. Always present: if the create request omits `referenceCode`, one is auto-generated, since disbursements have no payment session to fall back to.'
         metadata:
           $ref: '#/components/schemas/Metadata'
         error:
@@ -21777,6 +21915,10 @@ components:
           maxLength: 256
           description: A merchant-provided internal identifier for this disbursement, from the merchant's own system—not visible to the payer. It must not contain personally identifiable information (PII) or payment credentials.
           example: disbursement-2026-04-1234
+        customerDisplay:
+          allOf:
+            - $ref: '#/components/schemas/OperationCustomerDisplay'
+          description: Optional customer-facing display data for this disbursement, shown to the payer. If `referenceCode` is omitted, one is auto-generated — disbursements have no payment session to fall back to, unlike every other action type.
         metadata:
           $ref: '#/components/schemas/Metadata'
         compliance:
@@ -22323,6 +22465,7 @@ components:
         gasUsed: '100000'
     EvmUserOperation:
       type: object
+      description: A smart account operation response.
       properties:
         network:
           $ref: '#/components/schemas/EvmUserOperationNetwork'
@@ -23922,8 +24065,6 @@ components:
             simulationIncomplete: false
         liquidityAvailable:
           type: boolean
-          enum:
-            - true
           description: Whether sufficient liquidity is available to settle the swap. All other fields in the response will be empty if this is false.
           example: true
         minToAmount:
@@ -23951,6 +24092,11 @@ components:
         - minToAmount
         - fromAmount
         - fromToken
+      not:
+        properties:
+          liquidityAvailable:
+            enum:
+              - false
       example:
         blockNumber: '17038723'
         toAmount: '1000000000000000000'
@@ -24000,15 +24146,19 @@ components:
     SwapUnavailableResponse:
       type: object
       title: SwapUnavailableResponse
+      additionalProperties: false
       properties:
         liquidityAvailable:
           type: boolean
-          enum:
-            - false
           description: Whether sufficient liquidity is available to settle the swap. All other fields in the response will be empty if this is false.
           example: false
       required:
         - liquidityAvailable
+      not:
+        properties:
+          liquidityAvailable:
+            enum:
+              - true
       example:
         liquidityAvailable: false
     GetSwapPriceResponseWrapper:
@@ -30810,6 +30960,15 @@ components:
               type: string
               description: A decimal representation of the authorized amount, denominated in the session's `asset`.
               example: '1.00'
+            externalReferenceId:
+              allOf:
+                - $ref: '#/components/schemas/ExternalReferenceId'
+              description: An optional merchant-provided internal identifier for this authorization, from the merchant's own system—not visible to the payer. Present only when supplied on the authorization request.
+              example: merchant-authorization-abc123
+            customerDisplay:
+              allOf:
+                - $ref: '#/components/schemas/OperationCustomerDisplay'
+              description: Customer-facing display data for this authorization, shown to the payer. Present when supplied on the authorization request or when the session's `orderCode` fallback applies; otherwise omitted.
             error:
               allOf:
                 - $ref: '#/components/schemas/PaymentError'
@@ -30883,6 +31042,15 @@ components:
               type: string
               description: A decimal representation of the captured amount, denominated in the session's `asset`.
               example: '1.00'
+            externalReferenceId:
+              allOf:
+                - $ref: '#/components/schemas/ExternalReferenceId'
+              description: An optional merchant-provided internal identifier for this capture, from the merchant's own system—not visible to the payer. For an auto-capture, it is copied from the authorization.
+              example: merchant-capture-abc123
+            customerDisplay:
+              allOf:
+                - $ref: '#/components/schemas/OperationCustomerDisplay'
+              description: Customer-facing display data for this capture, shown to the payer. An auto-capture reuses the authorization's `referenceCode`.
             finalCapture:
               type: boolean
               description: When `true`, this capture is treated as the final one for the authorization. Any remaining capturable balance is released back to the payer immediately after the capture settles. When `false`, the remaining capturable balance stays held and is available for subsequent partial captures (subject to `captureExpiresAt`). Has no effect if `amount` equals the full capturable balance, since no remaining balance exists to release.
@@ -30950,6 +31118,15 @@ components:
               type: string
               description: A decimal representation of the voided amount, denominated in the session's `asset`.
               example: '1.00'
+            externalReferenceId:
+              allOf:
+                - $ref: '#/components/schemas/ExternalReferenceId'
+              description: An optional merchant-provided internal identifier for this void, from the merchant's own system—not visible to the payer. Present only when supplied on the create void request.
+              example: merchant-void-abc123
+            customerDisplay:
+              allOf:
+                - $ref: '#/components/schemas/OperationCustomerDisplay'
+              description: Customer-facing display data for this void, shown to the payer. Present when supplied on the create void request or when the session's `orderCode` fallback applies; otherwise omitted.
             error:
               allOf:
                 - $ref: '#/components/schemas/PaymentError'
@@ -31011,6 +31188,15 @@ components:
               type: string
               description: A decimal representation of the refunded amount, denominated in the session's `asset`.
               example: '0.50'
+            externalReferenceId:
+              allOf:
+                - $ref: '#/components/schemas/ExternalReferenceId'
+              description: An optional merchant-provided internal identifier for this refund, from the merchant's own system—not visible to the payer. Present only when supplied on the create refund request.
+              example: merchant-refund-abc123
+            customerDisplay:
+              allOf:
+                - $ref: '#/components/schemas/OperationCustomerDisplay'
+              description: Customer-facing display data for this refund, shown to the payer. Present when supplied on the create refund request or when the session's `orderCode` fallback applies; otherwise omitted.
             reason:
               type: string
               description: The reason for the refund, if provided when the refund was created.

--- a/python/cdp/openapi_client/__init__.py
+++ b/python/cdp/openapi_client/__init__.py
@@ -119,6 +119,7 @@ from cdp.openapi_client.models.common_swap_response_fees import CommonSwapRespon
 from cdp.openapi_client.models.common_swap_response_issues import CommonSwapResponseIssues
 from cdp.openapi_client.models.common_swap_response_issues_allowance import CommonSwapResponseIssuesAllowance
 from cdp.openapi_client.models.common_swap_response_issues_balance import CommonSwapResponseIssuesBalance
+from cdp.openapi_client.models.common_swap_response_not import CommonSwapResponseNot
 from cdp.openapi_client.models.compliance import Compliance
 from cdp.openapi_client.models.create_account_request import CreateAccountRequest
 from cdp.openapi_client.models.create_capture_request import CreateCaptureRequest
@@ -340,6 +341,7 @@ from cdp.openapi_client.models.onramp_user_id_type import OnrampUserIdType
 from cdp.openapi_client.models.onramp_user_limit import OnrampUserLimit
 from cdp.openapi_client.models.onramp_verification_confirmation import OnrampVerificationConfirmation
 from cdp.openapi_client.models.onramp_verification_initiation import OnrampVerificationInitiation
+from cdp.openapi_client.models.operation_customer_display import OperationCustomerDisplay
 from cdp.openapi_client.models.order_fee import OrderFee
 from cdp.openapi_client.models.payment_action_status import PaymentActionStatus
 from cdp.openapi_client.models.payment_error import PaymentError
@@ -486,6 +488,7 @@ from cdp.openapi_client.models.spl_value_criterion import SplValueCriterion
 from cdp.openapi_client.models.submit_onramp_verification_request import SubmitOnrampVerificationRequest
 from cdp.openapi_client.models.swap_permit2_approval import SwapPermit2Approval
 from cdp.openapi_client.models.swap_unavailable_response import SwapUnavailableResponse
+from cdp.openapi_client.models.swap_unavailable_response1 import SwapUnavailableResponse1
 from cdp.openapi_client.models.swift_details import SwiftDetails
 from cdp.openapi_client.models.swift_payment_method import SwiftPaymentMethod
 from cdp.openapi_client.models.tax_attestation import TaxAttestation

--- a/python/cdp/openapi_client/api/payment_sessions_api.py
+++ b/python/cdp/openapi_client/api/payment_sessions_api.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from typing_extensions import Annotated
 
 from pydantic import Field, StrictInt, StrictStr, field_validator
-from typing import List, Optional
+from typing import Any, List, Optional
 from typing_extensions import Annotated
 from cdp.openapi_client.models.authorization import Authorization
 from cdp.openapi_client.models.balances import Balances
@@ -725,6 +725,8 @@ class PaymentSessionsApi:
         self,
         payment_session_id: Annotated[str, Field(strict=True, description="The unique identifier of the payment session to authorize with x402.")],
         payment_signature: Annotated[Optional[StrictStr], Field(description="Optional. Base64-encoded (RFC 4648) x402-compliant payment payload.")] = None,
+        x_external_reference_id: Annotated[Optional[Any], Field(description="An optional merchant-provided internal identifier for this x402 authorization, from the merchant's own system—not visible to the payer.")] = None,
+        x_customer_display_reference_code: Annotated[Optional[Any], Field(description="A short customer-facing reference code for this x402 authorization, visible to the payer. Equivalent to `customerDisplay.referenceCode` on JSON authorization requests. Falls back to the session's `orderCode` when omitted.")] = None,
         x_idempotency_key: Annotated[Optional[Annotated[str, Field(min_length=1, strict=True, max_length=128)]], Field(description="An optional string request header for making requests safely retryable. When included, duplicate requests with the same key will return identical responses. Refer to our [Idempotency docs](https://docs.cdp.coinbase.com/api-reference/v2/idempotency) for more information on using idempotency keys. ")] = None,
         _request_timeout: Union[
             None,
@@ -747,6 +749,10 @@ class PaymentSessionsApi:
         :type payment_session_id: str
         :param payment_signature: Optional. Base64-encoded (RFC 4648) x402-compliant payment payload.
         :type payment_signature: str
+        :param x_external_reference_id: An optional merchant-provided internal identifier for this x402 authorization, from the merchant's own system—not visible to the payer.
+        :type x_external_reference_id: str
+        :param x_customer_display_reference_code: A short customer-facing reference code for this x402 authorization, visible to the payer. Equivalent to `customerDisplay.referenceCode` on JSON authorization requests. Falls back to the session's `orderCode` when omitted.
+        :type x_customer_display_reference_code: str
         :param x_idempotency_key: An optional string request header for making requests safely retryable. When included, duplicate requests with the same key will return identical responses. Refer to our [Idempotency docs](https://docs.cdp.coinbase.com/api-reference/v2/idempotency) for more information on using idempotency keys. 
         :type x_idempotency_key: str
         :param _request_timeout: timeout setting for this request. If one
@@ -774,6 +780,8 @@ class PaymentSessionsApi:
         _param = self._authorize_x402_payment_session_serialize(
             payment_session_id=payment_session_id,
             payment_signature=payment_signature,
+            x_external_reference_id=x_external_reference_id,
+            x_customer_display_reference_code=x_customer_display_reference_code,
             x_idempotency_key=x_idempotency_key,
             _request_auth=_request_auth,
             _content_type=_content_type,
@@ -807,6 +815,8 @@ class PaymentSessionsApi:
         self,
         payment_session_id: Annotated[str, Field(strict=True, description="The unique identifier of the payment session to authorize with x402.")],
         payment_signature: Annotated[Optional[StrictStr], Field(description="Optional. Base64-encoded (RFC 4648) x402-compliant payment payload.")] = None,
+        x_external_reference_id: Annotated[Optional[Any], Field(description="An optional merchant-provided internal identifier for this x402 authorization, from the merchant's own system—not visible to the payer.")] = None,
+        x_customer_display_reference_code: Annotated[Optional[Any], Field(description="A short customer-facing reference code for this x402 authorization, visible to the payer. Equivalent to `customerDisplay.referenceCode` on JSON authorization requests. Falls back to the session's `orderCode` when omitted.")] = None,
         x_idempotency_key: Annotated[Optional[Annotated[str, Field(min_length=1, strict=True, max_length=128)]], Field(description="An optional string request header for making requests safely retryable. When included, duplicate requests with the same key will return identical responses. Refer to our [Idempotency docs](https://docs.cdp.coinbase.com/api-reference/v2/idempotency) for more information on using idempotency keys. ")] = None,
         _request_timeout: Union[
             None,
@@ -829,6 +839,10 @@ class PaymentSessionsApi:
         :type payment_session_id: str
         :param payment_signature: Optional. Base64-encoded (RFC 4648) x402-compliant payment payload.
         :type payment_signature: str
+        :param x_external_reference_id: An optional merchant-provided internal identifier for this x402 authorization, from the merchant's own system—not visible to the payer.
+        :type x_external_reference_id: str
+        :param x_customer_display_reference_code: A short customer-facing reference code for this x402 authorization, visible to the payer. Equivalent to `customerDisplay.referenceCode` on JSON authorization requests. Falls back to the session's `orderCode` when omitted.
+        :type x_customer_display_reference_code: str
         :param x_idempotency_key: An optional string request header for making requests safely retryable. When included, duplicate requests with the same key will return identical responses. Refer to our [Idempotency docs](https://docs.cdp.coinbase.com/api-reference/v2/idempotency) for more information on using idempotency keys. 
         :type x_idempotency_key: str
         :param _request_timeout: timeout setting for this request. If one
@@ -856,6 +870,8 @@ class PaymentSessionsApi:
         _param = self._authorize_x402_payment_session_serialize(
             payment_session_id=payment_session_id,
             payment_signature=payment_signature,
+            x_external_reference_id=x_external_reference_id,
+            x_customer_display_reference_code=x_customer_display_reference_code,
             x_idempotency_key=x_idempotency_key,
             _request_auth=_request_auth,
             _content_type=_content_type,
@@ -889,6 +905,8 @@ class PaymentSessionsApi:
         self,
         payment_session_id: Annotated[str, Field(strict=True, description="The unique identifier of the payment session to authorize with x402.")],
         payment_signature: Annotated[Optional[StrictStr], Field(description="Optional. Base64-encoded (RFC 4648) x402-compliant payment payload.")] = None,
+        x_external_reference_id: Annotated[Optional[Any], Field(description="An optional merchant-provided internal identifier for this x402 authorization, from the merchant's own system—not visible to the payer.")] = None,
+        x_customer_display_reference_code: Annotated[Optional[Any], Field(description="A short customer-facing reference code for this x402 authorization, visible to the payer. Equivalent to `customerDisplay.referenceCode` on JSON authorization requests. Falls back to the session's `orderCode` when omitted.")] = None,
         x_idempotency_key: Annotated[Optional[Annotated[str, Field(min_length=1, strict=True, max_length=128)]], Field(description="An optional string request header for making requests safely retryable. When included, duplicate requests with the same key will return identical responses. Refer to our [Idempotency docs](https://docs.cdp.coinbase.com/api-reference/v2/idempotency) for more information on using idempotency keys. ")] = None,
         _request_timeout: Union[
             None,
@@ -911,6 +929,10 @@ class PaymentSessionsApi:
         :type payment_session_id: str
         :param payment_signature: Optional. Base64-encoded (RFC 4648) x402-compliant payment payload.
         :type payment_signature: str
+        :param x_external_reference_id: An optional merchant-provided internal identifier for this x402 authorization, from the merchant's own system—not visible to the payer.
+        :type x_external_reference_id: str
+        :param x_customer_display_reference_code: A short customer-facing reference code for this x402 authorization, visible to the payer. Equivalent to `customerDisplay.referenceCode` on JSON authorization requests. Falls back to the session's `orderCode` when omitted.
+        :type x_customer_display_reference_code: str
         :param x_idempotency_key: An optional string request header for making requests safely retryable. When included, duplicate requests with the same key will return identical responses. Refer to our [Idempotency docs](https://docs.cdp.coinbase.com/api-reference/v2/idempotency) for more information on using idempotency keys. 
         :type x_idempotency_key: str
         :param _request_timeout: timeout setting for this request. If one
@@ -938,6 +960,8 @@ class PaymentSessionsApi:
         _param = self._authorize_x402_payment_session_serialize(
             payment_session_id=payment_session_id,
             payment_signature=payment_signature,
+            x_external_reference_id=x_external_reference_id,
+            x_customer_display_reference_code=x_customer_display_reference_code,
             x_idempotency_key=x_idempotency_key,
             _request_auth=_request_auth,
             _content_type=_content_type,
@@ -966,6 +990,8 @@ class PaymentSessionsApi:
         self,
         payment_session_id,
         payment_signature,
+        x_external_reference_id,
+        x_customer_display_reference_code,
         x_idempotency_key,
         _request_auth,
         _content_type,
@@ -994,6 +1020,10 @@ class PaymentSessionsApi:
         # process the header parameters
         if payment_signature is not None:
             _header_params['PAYMENT-SIGNATURE'] = payment_signature
+        if x_external_reference_id is not None:
+            _header_params['X-External-Reference-Id'] = x_external_reference_id
+        if x_customer_display_reference_code is not None:
+            _header_params['X-Customer-Display-Reference-Code'] = x_customer_display_reference_code
         if x_idempotency_key is not None:
             _header_params['X-Idempotency-Key'] = x_idempotency_key
         # process the form parameters

--- a/python/cdp/openapi_client/models/__init__.py
+++ b/python/cdp/openapi_client/models/__init__.py
@@ -80,6 +80,7 @@ from cdp.openapi_client.models.common_swap_response_fees import CommonSwapRespon
 from cdp.openapi_client.models.common_swap_response_issues import CommonSwapResponseIssues
 from cdp.openapi_client.models.common_swap_response_issues_allowance import CommonSwapResponseIssuesAllowance
 from cdp.openapi_client.models.common_swap_response_issues_balance import CommonSwapResponseIssuesBalance
+from cdp.openapi_client.models.common_swap_response_not import CommonSwapResponseNot
 from cdp.openapi_client.models.compliance import Compliance
 from cdp.openapi_client.models.create_account_request import CreateAccountRequest
 from cdp.openapi_client.models.create_capture_request import CreateCaptureRequest
@@ -301,6 +302,7 @@ from cdp.openapi_client.models.onramp_user_id_type import OnrampUserIdType
 from cdp.openapi_client.models.onramp_user_limit import OnrampUserLimit
 from cdp.openapi_client.models.onramp_verification_confirmation import OnrampVerificationConfirmation
 from cdp.openapi_client.models.onramp_verification_initiation import OnrampVerificationInitiation
+from cdp.openapi_client.models.operation_customer_display import OperationCustomerDisplay
 from cdp.openapi_client.models.order_fee import OrderFee
 from cdp.openapi_client.models.payment_action_status import PaymentActionStatus
 from cdp.openapi_client.models.payment_error import PaymentError
@@ -447,6 +449,7 @@ from cdp.openapi_client.models.spl_value_criterion import SplValueCriterion
 from cdp.openapi_client.models.submit_onramp_verification_request import SubmitOnrampVerificationRequest
 from cdp.openapi_client.models.swap_permit2_approval import SwapPermit2Approval
 from cdp.openapi_client.models.swap_unavailable_response import SwapUnavailableResponse
+from cdp.openapi_client.models.swap_unavailable_response1 import SwapUnavailableResponse1
 from cdp.openapi_client.models.swift_details import SwiftDetails
 from cdp.openapi_client.models.swift_payment_method import SwiftPaymentMethod
 from cdp.openapi_client.models.tax_attestation import TaxAttestation

--- a/python/cdp/openapi_client/models/authorization.py
+++ b/python/cdp/openapi_client/models/authorization.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
 from typing_extensions import Annotated
 from cdp.openapi_client.models.onchain_transaction import OnchainTransaction
+from cdp.openapi_client.models.operation_customer_display import OperationCustomerDisplay
 from cdp.openapi_client.models.payment_action_status import PaymentActionStatus
 from cdp.openapi_client.models.payment_error import PaymentError
 from cdp.openapi_client.models.payment_session_source import PaymentSessionSource
@@ -40,11 +41,13 @@ class Authorization(BaseModel):
     error: Optional[PaymentError] = None
     message: Optional[StrictStr] = Field(default=None, description="A human-readable message describing the outcome or status for display. Returned for x402 authorizations; omitted for other authorization flows unless documented otherwise.")
     metadata: Optional[Dict[str, Annotated[str, Field(min_length=0, strict=True, max_length=500)]]] = Field(default=None, description="Optional metadata as key-value pairs. Use this to store additional structured information on a resource, such as customer IDs, order references, or any application-specific data. Up to 10 key/value pairs may be provided. Keys and values are both strings. Keys must be ≤ 40 characters; values must be ≤ 500 characters.")
+    external_reference_id: Optional[Annotated[str, Field(strict=True, max_length=256)]] = Field(default=None, description="A merchant-provided internal identifier for this authorization, from the merchant's own system—not visible to the payer. Present only when supplied on the authorization request.", alias="externalReferenceId")
+    customer_display: Optional[OperationCustomerDisplay] = Field(default=None, description="Customer-facing display data for this authorization, shown to the payer. Present when supplied on the authorization request or when the session's `orderCode` fallback applies; otherwise omitted.", alias="customerDisplay")
     source: Optional[PaymentSessionSource] = Field(default=None, description="The payer for this authorization. For wallet authorizations, this is the blockchain address that signed the payloads. For Coinbase authorizations, this is the authenticated Coinbase account. This value is also reflected on the parent payment session's `source` field after a successful authorization.")
     onchain_transactions: Optional[List[OnchainTransaction]] = Field(default=None, description="The onchain transactions associated with this authorization.", alias="onchainTransactions")
     created_at: Optional[datetime] = Field(default=None, description="The UTC ISO 8601 timestamp at which the authorization was created.", alias="createdAt")
     updated_at: Optional[datetime] = Field(default=None, description="The UTC ISO 8601 timestamp at which the authorization was last updated.", alias="updatedAt")
-    __properties: ClassVar[List[str]] = ["authorizationId", "paymentSessionId", "status", "amount", "error", "message", "metadata", "source", "onchainTransactions", "createdAt", "updatedAt"]
+    __properties: ClassVar[List[str]] = ["authorizationId", "paymentSessionId", "status", "amount", "error", "message", "metadata", "externalReferenceId", "customerDisplay", "source", "onchainTransactions", "createdAt", "updatedAt"]
 
     @field_validator('authorization_id')
     def authorization_id_validate_regular_expression(cls, value):
@@ -108,6 +111,9 @@ class Authorization(BaseModel):
         # override the default output from pydantic by calling `to_dict()` of error
         if self.error:
             _dict['error'] = self.error.to_dict()
+        # override the default output from pydantic by calling `to_dict()` of customer_display
+        if self.customer_display:
+            _dict['customerDisplay'] = self.customer_display.to_dict()
         # override the default output from pydantic by calling `to_dict()` of source
         if self.source:
             _dict['source'] = self.source.to_dict()
@@ -137,6 +143,8 @@ class Authorization(BaseModel):
             "error": PaymentError.from_dict(obj["error"]) if obj.get("error") is not None else None,
             "message": obj.get("message"),
             "metadata": obj.get("metadata"),
+            "externalReferenceId": obj.get("externalReferenceId"),
+            "customerDisplay": OperationCustomerDisplay.from_dict(obj["customerDisplay"]) if obj.get("customerDisplay") is not None else None,
             "source": PaymentSessionSource.from_dict(obj["source"]) if obj.get("source") is not None else None,
             "onchainTransactions": [OnchainTransaction.from_dict(_item) for _item in obj["onchainTransactions"]] if obj.get("onchainTransactions") is not None else None,
             "createdAt": obj.get("createdAt"),

--- a/python/cdp/openapi_client/models/capture.py
+++ b/python/cdp/openapi_client/models/capture.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr, field_
 from typing import Any, ClassVar, Dict, List, Optional
 from typing_extensions import Annotated
 from cdp.openapi_client.models.onchain_transaction import OnchainTransaction
+from cdp.openapi_client.models.operation_customer_display import OperationCustomerDisplay
 from cdp.openapi_client.models.payment_action_status import PaymentActionStatus
 from cdp.openapi_client.models.payment_error import PaymentError
 from typing import Optional, Set
@@ -39,10 +40,12 @@ class Capture(BaseModel):
     final_capture: StrictBool = Field(description="When `true`, this capture is treated as the final one for the authorization. Any remaining capturable balance is released back to the payer immediately after the capture settles. When `false`, the remaining capturable balance stays held and is available for subsequent partial captures (subject to `captureExpiresAt`). Has no effect if `amount` equals the full capturable balance, since no remaining balance exists to release.", alias="finalCapture")
     error: Optional[PaymentError] = None
     metadata: Optional[Dict[str, Annotated[str, Field(min_length=0, strict=True, max_length=500)]]] = Field(default=None, description="Optional metadata as key-value pairs. Use this to store additional structured information on a resource, such as customer IDs, order references, or any application-specific data. Up to 10 key/value pairs may be provided. Keys and values are both strings. Keys must be ≤ 40 characters; values must be ≤ 500 characters.")
+    external_reference_id: Optional[Annotated[str, Field(strict=True, max_length=256)]] = Field(default=None, description="A merchant-provided internal identifier for this capture, from the merchant's own system—not visible to the payer. A manual capture uses the caller-provided value; an auto-capture reuses the authorization's value and omits it when the authorization omitted it. It never falls back to `PaymentSession.externalReferenceId`.", alias="externalReferenceId")
+    customer_display: Optional[OperationCustomerDisplay] = Field(default=None, description="Customer-facing display data for this capture, shown to the payer. A manual capture falls back to the session's `orderCode` when `referenceCode` is omitted; an auto-capture reuses the authorization's `referenceCode`.", alias="customerDisplay")
     onchain_transactions: Optional[List[OnchainTransaction]] = Field(default=None, description="The onchain transactions associated with this capture.", alias="onchainTransactions")
     created_at: Optional[datetime] = Field(default=None, description="The UTC ISO 8601 timestamp at which the capture was created.", alias="createdAt")
     updated_at: Optional[datetime] = Field(default=None, description="The UTC ISO 8601 timestamp at which the capture was last updated.", alias="updatedAt")
-    __properties: ClassVar[List[str]] = ["captureId", "paymentSessionId", "status", "amount", "finalCapture", "error", "metadata", "onchainTransactions", "createdAt", "updatedAt"]
+    __properties: ClassVar[List[str]] = ["captureId", "paymentSessionId", "status", "amount", "finalCapture", "error", "metadata", "externalReferenceId", "customerDisplay", "onchainTransactions", "createdAt", "updatedAt"]
 
     @field_validator('capture_id')
     def capture_id_validate_regular_expression(cls, value):
@@ -106,6 +109,9 @@ class Capture(BaseModel):
         # override the default output from pydantic by calling `to_dict()` of error
         if self.error:
             _dict['error'] = self.error.to_dict()
+        # override the default output from pydantic by calling `to_dict()` of customer_display
+        if self.customer_display:
+            _dict['customerDisplay'] = self.customer_display.to_dict()
         # override the default output from pydantic by calling `to_dict()` of each item in onchain_transactions (list)
         _items = []
         if self.onchain_transactions:
@@ -132,6 +138,8 @@ class Capture(BaseModel):
             "finalCapture": obj.get("finalCapture"),
             "error": PaymentError.from_dict(obj["error"]) if obj.get("error") is not None else None,
             "metadata": obj.get("metadata"),
+            "externalReferenceId": obj.get("externalReferenceId"),
+            "customerDisplay": OperationCustomerDisplay.from_dict(obj["customerDisplay"]) if obj.get("customerDisplay") is not None else None,
             "onchainTransactions": [OnchainTransaction.from_dict(_item) for _item in obj["onchainTransactions"]] if obj.get("onchainTransactions") is not None else None,
             "createdAt": obj.get("createdAt"),
             "updatedAt": obj.get("updatedAt")

--- a/python/cdp/openapi_client/models/common_swap_response.py
+++ b/python/cdp/openapi_client/models/common_swap_response.py
@@ -62,13 +62,6 @@ class CommonSwapResponse(BaseModel):
             raise ValueError(r"must validate the regular expression /^0x[a-fA-F0-9]{40}$/")
         return value
 
-    @field_validator('liquidity_available')
-    def liquidity_available_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['true']):
-            raise ValueError("must be one of enum values ('true')")
-        return value
-
     @field_validator('min_to_amount')
     def min_to_amount_validate_regular_expression(cls, value):
         """Validates the regular expression"""

--- a/python/cdp/openapi_client/models/common_swap_response_not.py
+++ b/python/cdp/openapi_client/models/common_swap_response_not.py
@@ -18,21 +18,27 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, StrictBool, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
-from typing_extensions import Annotated
-from cdp.openapi_client.models.operation_customer_display import OperationCustomerDisplay
 from typing import Optional, Set
 from typing_extensions import Self
 
-class CoinbaseAuthorizationRequest(BaseModel):
+class CommonSwapResponseNot(BaseModel):
     """
-    A request to authorize a payment session using the payer's Coinbase account authenticated via OAuth.
+    CommonSwapResponseNot
     """ # noqa: E501
-    metadata: Optional[Dict[str, Annotated[str, Field(min_length=0, strict=True, max_length=500)]]] = Field(default=None, description="Optional metadata as key-value pairs. Use this to store additional structured information on a resource, such as customer IDs, order references, or any application-specific data. Up to 10 key/value pairs may be provided. Keys and values are both strings. Keys must be ≤ 40 characters; values must be ≤ 500 characters.")
-    customer_display: Optional[OperationCustomerDisplay] = Field(default=None, description="Optional customer-facing display data for this authorization, shown to the payer. Falls back to the session's `orderCode` when `referenceCode` is omitted.", alias="customerDisplay")
-    external_reference_id: Optional[Annotated[str, Field(strict=True, max_length=256)]] = Field(default=None, description="An optional merchant-provided internal identifier for this Coinbase authorization, from the merchant's own system—not visible to the payer.", alias="externalReferenceId")
-    __properties: ClassVar[List[str]] = ["metadata", "customerDisplay", "externalReferenceId"]
+    liquidity_available: Optional[StrictBool] = Field(default=None, alias="liquidityAvailable")
+    __properties: ClassVar[List[str]] = ["liquidityAvailable"]
+
+    @field_validator('liquidity_available')
+    def liquidity_available_validate_enum(cls, value):
+        """Validates the enum"""
+        if value is None:
+            return value
+
+        if value not in set(['false']):
+            raise ValueError("must be one of enum values ('false')")
+        return value
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -52,7 +58,7 @@ class CoinbaseAuthorizationRequest(BaseModel):
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:
-        """Create an instance of CoinbaseAuthorizationRequest from a JSON string"""
+        """Create an instance of CommonSwapResponseNot from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
     def to_dict(self) -> Dict[str, Any]:
@@ -73,14 +79,11 @@ class CoinbaseAuthorizationRequest(BaseModel):
             exclude=excluded_fields,
             exclude_none=True,
         )
-        # override the default output from pydantic by calling `to_dict()` of customer_display
-        if self.customer_display:
-            _dict['customerDisplay'] = self.customer_display.to_dict()
         return _dict
 
     @classmethod
     def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
-        """Create an instance of CoinbaseAuthorizationRequest from a dict"""
+        """Create an instance of CommonSwapResponseNot from a dict"""
         if obj is None:
             return None
 
@@ -88,9 +91,7 @@ class CoinbaseAuthorizationRequest(BaseModel):
             return cls.model_validate(obj)
 
         _obj = cls.model_validate({
-            "metadata": obj.get("metadata"),
-            "customerDisplay": OperationCustomerDisplay.from_dict(obj["customerDisplay"]) if obj.get("customerDisplay") is not None else None,
-            "externalReferenceId": obj.get("externalReferenceId")
+            "liquidityAvailable": obj.get("liquidityAvailable")
         })
         return _obj
 

--- a/python/cdp/openapi_client/models/create_capture_request.py
+++ b/python/cdp/openapi_client/models/create_capture_request.py
@@ -21,6 +21,7 @@ import json
 from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
 from typing_extensions import Annotated
+from cdp.openapi_client.models.operation_customer_display import OperationCustomerDisplay
 from typing import Optional, Set
 from typing_extensions import Self
 
@@ -31,7 +32,9 @@ class CreateCaptureRequest(BaseModel):
     amount: Optional[StrictStr] = Field(default=None, description="A decimal representation of the amount to capture, denominated in the session's `asset`. If omitted, the full remaining capturable amount is captured.")
     final_capture: StrictBool = Field(description="When `true`, this capture is treated as the final one for the authorization. Any remaining capturable balance is released back to the payer immediately after the capture settles. When `false`, the remaining capturable balance stays held and is available for subsequent partial captures (subject to `captureExpiresAt`). Has no effect if `amount` equals the full capturable balance, since no remaining balance exists to release.", alias="finalCapture")
     metadata: Optional[Dict[str, Annotated[str, Field(min_length=0, strict=True, max_length=500)]]] = Field(default=None, description="Optional metadata as key-value pairs. Use this to store additional structured information on a resource, such as customer IDs, order references, or any application-specific data. Up to 10 key/value pairs may be provided. Keys and values are both strings. Keys must be ≤ 40 characters; values must be ≤ 500 characters.")
-    __properties: ClassVar[List[str]] = ["amount", "finalCapture", "metadata"]
+    external_reference_id: Optional[Annotated[str, Field(strict=True, max_length=256)]] = Field(default=None, description="An optional merchant-provided internal identifier for this manual capture, from the merchant's own system—not visible to the payer.", alias="externalReferenceId")
+    customer_display: Optional[OperationCustomerDisplay] = Field(default=None, description="Optional customer-facing display data for this manual capture, shown to the payer. Falls back to the session's `orderCode` when `referenceCode` is omitted.", alias="customerDisplay")
+    __properties: ClassVar[List[str]] = ["amount", "finalCapture", "metadata", "externalReferenceId", "customerDisplay"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -72,6 +75,9 @@ class CreateCaptureRequest(BaseModel):
             exclude=excluded_fields,
             exclude_none=True,
         )
+        # override the default output from pydantic by calling `to_dict()` of customer_display
+        if self.customer_display:
+            _dict['customerDisplay'] = self.customer_display.to_dict()
         return _dict
 
     @classmethod
@@ -86,7 +92,9 @@ class CreateCaptureRequest(BaseModel):
         _obj = cls.model_validate({
             "amount": obj.get("amount"),
             "finalCapture": obj.get("finalCapture"),
-            "metadata": obj.get("metadata")
+            "metadata": obj.get("metadata"),
+            "externalReferenceId": obj.get("externalReferenceId"),
+            "customerDisplay": OperationCustomerDisplay.from_dict(obj["customerDisplay"]) if obj.get("customerDisplay") is not None else None
         })
         return _obj
 

--- a/python/cdp/openapi_client/models/create_disbursement_request.py
+++ b/python/cdp/openapi_client/models/create_disbursement_request.py
@@ -24,6 +24,7 @@ from typing_extensions import Annotated
 from cdp.openapi_client.models.disbursement_compliance import DisbursementCompliance
 from cdp.openapi_client.models.disbursement_source import DisbursementSource
 from cdp.openapi_client.models.disbursement_target import DisbursementTarget
+from cdp.openapi_client.models.operation_customer_display import OperationCustomerDisplay
 from typing import Optional, Set
 from typing_extensions import Self
 
@@ -37,9 +38,10 @@ class CreateDisbursementRequest(BaseModel):
     asset: Annotated[str, Field(min_length=1, strict=True, max_length=42)] = Field(description="The symbol of the asset for the disbursement amount.")
     reason: Optional[StrictStr] = Field(default=None, description="Human-readable reason for the disbursement.")
     external_reference_id: Optional[Annotated[str, Field(strict=True, max_length=256)]] = Field(default=None, description="A merchant-provided internal identifier for this disbursement, from the merchant's own system—not visible to the payer. It must not contain personally identifiable information (PII) or payment credentials.", alias="externalReferenceId")
+    customer_display: Optional[OperationCustomerDisplay] = Field(default=None, description="Optional customer-facing display data for this disbursement, shown to the payer. If `referenceCode` is omitted, one is auto-generated — disbursements have no payment session to fall back to, unlike every other action type.", alias="customerDisplay")
     metadata: Optional[Dict[str, Annotated[str, Field(min_length=0, strict=True, max_length=500)]]] = Field(default=None, description="Optional metadata as key-value pairs. Use this to store additional structured information on a resource, such as customer IDs, order references, or any application-specific data. Up to 10 key/value pairs may be provided. Keys and values are both strings. Keys must be ≤ 40 characters; values must be ≤ 500 characters.")
     compliance: Optional[DisbursementCompliance] = Field(default=None, description="Compliance context for this disbursement. Carries recipient information required by some entity configurations to meet regulatory requirements.")
-    __properties: ClassVar[List[str]] = ["source", "target", "amount", "asset", "reason", "externalReferenceId", "metadata", "compliance"]
+    __properties: ClassVar[List[str]] = ["source", "target", "amount", "asset", "reason", "externalReferenceId", "customerDisplay", "metadata", "compliance"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -86,6 +88,9 @@ class CreateDisbursementRequest(BaseModel):
         # override the default output from pydantic by calling `to_dict()` of target
         if self.target:
             _dict['target'] = self.target.to_dict()
+        # override the default output from pydantic by calling `to_dict()` of customer_display
+        if self.customer_display:
+            _dict['customerDisplay'] = self.customer_display.to_dict()
         # override the default output from pydantic by calling `to_dict()` of compliance
         if self.compliance:
             _dict['compliance'] = self.compliance.to_dict()
@@ -107,6 +112,7 @@ class CreateDisbursementRequest(BaseModel):
             "asset": obj.get("asset"),
             "reason": obj.get("reason"),
             "externalReferenceId": obj.get("externalReferenceId"),
+            "customerDisplay": OperationCustomerDisplay.from_dict(obj["customerDisplay"]) if obj.get("customerDisplay") is not None else None,
             "metadata": obj.get("metadata"),
             "compliance": DisbursementCompliance.from_dict(obj["compliance"]) if obj.get("compliance") is not None else None
         })

--- a/python/cdp/openapi_client/models/create_refund_request.py
+++ b/python/cdp/openapi_client/models/create_refund_request.py
@@ -21,6 +21,7 @@ import json
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
 from typing_extensions import Annotated
+from cdp.openapi_client.models.operation_customer_display import OperationCustomerDisplay
 from cdp.openapi_client.models.refund_source import RefundSource
 from typing import Optional, Set
 from typing_extensions import Self
@@ -33,7 +34,9 @@ class CreateRefundRequest(BaseModel):
     amount: Optional[StrictStr] = Field(default=None, description="A decimal representation of the amount to refund, denominated in the session's `asset`. If omitted, the full remaining refundable amount is refunded.")
     reason: Optional[StrictStr] = Field(default=None, description="The reason for the refund.")
     metadata: Optional[Dict[str, Annotated[str, Field(min_length=0, strict=True, max_length=500)]]] = Field(default=None, description="Optional metadata as key-value pairs. Use this to store additional structured information on a resource, such as customer IDs, order references, or any application-specific data. Up to 10 key/value pairs may be provided. Keys and values are both strings. Keys must be ≤ 40 characters; values must be ≤ 500 characters.")
-    __properties: ClassVar[List[str]] = ["source", "amount", "reason", "metadata"]
+    external_reference_id: Optional[Annotated[str, Field(strict=True, max_length=256)]] = Field(default=None, description="An optional merchant-provided internal identifier for this refund, from the merchant's own system—not visible to the payer.", alias="externalReferenceId")
+    customer_display: Optional[OperationCustomerDisplay] = Field(default=None, description="Optional customer-facing display data for this refund, shown to the payer. Falls back to the session's `orderCode` when `referenceCode` is omitted.", alias="customerDisplay")
+    __properties: ClassVar[List[str]] = ["source", "amount", "reason", "metadata", "externalReferenceId", "customerDisplay"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -77,6 +80,9 @@ class CreateRefundRequest(BaseModel):
         # override the default output from pydantic by calling `to_dict()` of source
         if self.source:
             _dict['source'] = self.source.to_dict()
+        # override the default output from pydantic by calling `to_dict()` of customer_display
+        if self.customer_display:
+            _dict['customerDisplay'] = self.customer_display.to_dict()
         return _dict
 
     @classmethod
@@ -92,7 +98,9 @@ class CreateRefundRequest(BaseModel):
             "source": RefundSource.from_dict(obj["source"]) if obj.get("source") is not None else None,
             "amount": obj.get("amount"),
             "reason": obj.get("reason"),
-            "metadata": obj.get("metadata")
+            "metadata": obj.get("metadata"),
+            "externalReferenceId": obj.get("externalReferenceId"),
+            "customerDisplay": OperationCustomerDisplay.from_dict(obj["customerDisplay"]) if obj.get("customerDisplay") is not None else None
         })
         return _obj
 

--- a/python/cdp/openapi_client/models/create_swap_quote_response.py
+++ b/python/cdp/openapi_client/models/create_swap_quote_response.py
@@ -66,13 +66,6 @@ class CreateSwapQuoteResponse(BaseModel):
             raise ValueError(r"must validate the regular expression /^0x[a-fA-F0-9]{40}$/")
         return value
 
-    @field_validator('liquidity_available')
-    def liquidity_available_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['true']):
-            raise ValueError("must be one of enum values ('true')")
-        return value
-
     @field_validator('min_to_amount')
     def min_to_amount_validate_regular_expression(cls, value):
         """Validates the regular expression"""

--- a/python/cdp/openapi_client/models/create_void_request.py
+++ b/python/cdp/openapi_client/models/create_void_request.py
@@ -21,6 +21,7 @@ import json
 from pydantic import BaseModel, ConfigDict, Field
 from typing import Any, ClassVar, Dict, List, Optional
 from typing_extensions import Annotated
+from cdp.openapi_client.models.operation_customer_display import OperationCustomerDisplay
 from typing import Optional, Set
 from typing_extensions import Self
 
@@ -29,7 +30,9 @@ class CreateVoidRequest(BaseModel):
     A request to create a void for a payment session. A void releases all remaining capturable funds back to the payer, including after partial refunds as long as a capturableAmount remains.
     """ # noqa: E501
     metadata: Optional[Dict[str, Annotated[str, Field(min_length=0, strict=True, max_length=500)]]] = Field(default=None, description="Optional metadata as key-value pairs. Use this to store additional structured information on a resource, such as customer IDs, order references, or any application-specific data. Up to 10 key/value pairs may be provided. Keys and values are both strings. Keys must be ≤ 40 characters; values must be ≤ 500 characters.")
-    __properties: ClassVar[List[str]] = ["metadata"]
+    external_reference_id: Optional[Annotated[str, Field(strict=True, max_length=256)]] = Field(default=None, description="An optional merchant-provided internal identifier for this void, from the merchant's own system—not visible to the payer.", alias="externalReferenceId")
+    customer_display: Optional[OperationCustomerDisplay] = Field(default=None, description="Optional customer-facing display data for this void, shown to the payer. Falls back to the session's `orderCode` when `referenceCode` is omitted.", alias="customerDisplay")
+    __properties: ClassVar[List[str]] = ["metadata", "externalReferenceId", "customerDisplay"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -70,6 +73,9 @@ class CreateVoidRequest(BaseModel):
             exclude=excluded_fields,
             exclude_none=True,
         )
+        # override the default output from pydantic by calling `to_dict()` of customer_display
+        if self.customer_display:
+            _dict['customerDisplay'] = self.customer_display.to_dict()
         return _dict
 
     @classmethod
@@ -82,7 +88,9 @@ class CreateVoidRequest(BaseModel):
             return cls.model_validate(obj)
 
         _obj = cls.model_validate({
-            "metadata": obj.get("metadata")
+            "metadata": obj.get("metadata"),
+            "externalReferenceId": obj.get("externalReferenceId"),
+            "customerDisplay": OperationCustomerDisplay.from_dict(obj["customerDisplay"]) if obj.get("customerDisplay") is not None else None
         })
         return _obj
 

--- a/python/cdp/openapi_client/models/customer_display.py
+++ b/python/cdp/openapi_client/models/customer_display.py
@@ -31,7 +31,8 @@ class CustomerDisplay(BaseModel):
     """ # noqa: E501
     merchant_name: Optional[Annotated[str, Field(strict=True, max_length=128)]] = Field(default=None, description="The merchant name to display on the payment UI. When provided, this overrides the default name derived from the entity's profile. Useful when a merchant operates multiple storefronts or brands under a single entity.", alias="merchantName")
     display_amount: Optional[CustomerDisplayDisplayAmount] = Field(default=None, alias="displayAmount")
-    __properties: ClassVar[List[str]] = ["merchantName", "displayAmount"]
+    order_code: Optional[Annotated[str, Field(strict=True, max_length=128)]] = Field(default=None, description="A customer-visible code for the overall order. When omitted, CDP generates one and returns it. It must not contain personally identifiable information (PII) or payment credentials.", alias="orderCode")
+    __properties: ClassVar[List[str]] = ["merchantName", "displayAmount", "orderCode"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -88,7 +89,8 @@ class CustomerDisplay(BaseModel):
 
         _obj = cls.model_validate({
             "merchantName": obj.get("merchantName"),
-            "displayAmount": CustomerDisplayDisplayAmount.from_dict(obj["displayAmount"]) if obj.get("displayAmount") is not None else None
+            "displayAmount": CustomerDisplayDisplayAmount.from_dict(obj["displayAmount"]) if obj.get("displayAmount") is not None else None,
+            "orderCode": obj.get("orderCode")
         })
         return _obj
 

--- a/python/cdp/openapi_client/models/disbursement.py
+++ b/python/cdp/openapi_client/models/disbursement.py
@@ -25,6 +25,7 @@ from typing_extensions import Annotated
 from cdp.openapi_client.models.disbursement_source import DisbursementSource
 from cdp.openapi_client.models.disbursement_target import DisbursementTarget
 from cdp.openapi_client.models.onchain_transaction import OnchainTransaction
+from cdp.openapi_client.models.operation_customer_display import OperationCustomerDisplay
 from cdp.openapi_client.models.payment_action_status import PaymentActionStatus
 from cdp.openapi_client.models.payment_error import PaymentError
 from typing import Optional, Set
@@ -42,12 +43,13 @@ class Disbursement(BaseModel):
     status: PaymentActionStatus = Field(description="The current status of the disbursement.")
     reason: Optional[StrictStr] = Field(default=None, description="Human-readable reason for the disbursement.")
     external_reference_id: Optional[Annotated[str, Field(strict=True, max_length=256)]] = Field(default=None, description="A merchant-provided internal identifier for this disbursement, from the merchant's own system—not visible to the payer. It must not contain personally identifiable information (PII) or payment credentials.", alias="externalReferenceId")
+    customer_display: Optional[OperationCustomerDisplay] = Field(default=None, description="Customer-facing display data for this disbursement, shown to the payer. Always present: if the create request omits `referenceCode`, one is auto-generated, since disbursements have no payment session to fall back to.", alias="customerDisplay")
     metadata: Optional[Dict[str, Annotated[str, Field(min_length=0, strict=True, max_length=500)]]] = Field(default=None, description="Optional metadata as key-value pairs. Use this to store additional structured information on a resource, such as customer IDs, order references, or any application-specific data. Up to 10 key/value pairs may be provided. Keys and values are both strings. Keys must be ≤ 40 characters; values must be ≤ 500 characters.")
     error: Optional[PaymentError] = Field(default=None, description="Error details, present only when the disbursement failed.")
     onchain_transactions: Optional[List[OnchainTransaction]] = Field(default=None, description="The onchain transactions associated with this disbursement.", alias="onchainTransactions")
     created_at: datetime = Field(description="The UTC ISO 8601 timestamp at which the disbursement was created.", alias="createdAt")
     updated_at: datetime = Field(description="The UTC ISO 8601 timestamp at which the disbursement was last updated.", alias="updatedAt")
-    __properties: ClassVar[List[str]] = ["disbursementId", "source", "target", "amount", "asset", "status", "reason", "externalReferenceId", "metadata", "error", "onchainTransactions", "createdAt", "updatedAt"]
+    __properties: ClassVar[List[str]] = ["disbursementId", "source", "target", "amount", "asset", "status", "reason", "externalReferenceId", "customerDisplay", "metadata", "error", "onchainTransactions", "createdAt", "updatedAt"]
 
     @field_validator('disbursement_id')
     def disbursement_id_validate_regular_expression(cls, value):
@@ -101,6 +103,9 @@ class Disbursement(BaseModel):
         # override the default output from pydantic by calling `to_dict()` of target
         if self.target:
             _dict['target'] = self.target.to_dict()
+        # override the default output from pydantic by calling `to_dict()` of customer_display
+        if self.customer_display:
+            _dict['customerDisplay'] = self.customer_display.to_dict()
         # override the default output from pydantic by calling `to_dict()` of error
         if self.error:
             _dict['error'] = self.error.to_dict()
@@ -131,6 +136,7 @@ class Disbursement(BaseModel):
             "status": obj.get("status"),
             "reason": obj.get("reason"),
             "externalReferenceId": obj.get("externalReferenceId"),
+            "customerDisplay": OperationCustomerDisplay.from_dict(obj["customerDisplay"]) if obj.get("customerDisplay") is not None else None,
             "metadata": obj.get("metadata"),
             "error": PaymentError.from_dict(obj["error"]) if obj.get("error") is not None else None,
             "onchainTransactions": [OnchainTransaction.from_dict(_item) for _item in obj["onchainTransactions"]] if obj.get("onchainTransactions") is not None else None,

--- a/python/cdp/openapi_client/models/evm_user_operation.py
+++ b/python/cdp/openapi_client/models/evm_user_operation.py
@@ -30,7 +30,7 @@ from typing_extensions import Self
 
 class EvmUserOperation(BaseModel):
     """
-    EvmUserOperation
+    A smart account operation response.
     """ # noqa: E501
     network: EvmUserOperationNetwork
     user_op_hash: Annotated[str, Field(strict=True)] = Field(description="The hash of the user operation. This is not the transaction hash, as a transaction consists of multiple user operations. The user operation hash is the hash of this particular user operation which gets signed by the owner of the Smart Account.", alias="userOpHash")

--- a/python/cdp/openapi_client/models/get_swap_price_response.py
+++ b/python/cdp/openapi_client/models/get_swap_price_response.py
@@ -64,13 +64,6 @@ class GetSwapPriceResponse(BaseModel):
             raise ValueError(r"must validate the regular expression /^0x[a-fA-F0-9]{40}$/")
         return value
 
-    @field_validator('liquidity_available')
-    def liquidity_available_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['true']):
-            raise ValueError("must be one of enum values ('true')")
-        return value
-
     @field_validator('min_to_amount')
     def min_to_amount_validate_regular_expression(cls, value):
         """Validates the regular expression"""

--- a/python/cdp/openapi_client/models/operation_customer_display.py
+++ b/python/cdp/openapi_client/models/operation_customer_display.py
@@ -21,18 +21,15 @@ import json
 from pydantic import BaseModel, ConfigDict, Field
 from typing import Any, ClassVar, Dict, List, Optional
 from typing_extensions import Annotated
-from cdp.openapi_client.models.operation_customer_display import OperationCustomerDisplay
 from typing import Optional, Set
 from typing_extensions import Self
 
-class CoinbaseAuthorizationRequest(BaseModel):
+class OperationCustomerDisplay(BaseModel):
     """
-    A request to authorize a payment session using the payer's Coinbase account authenticated via OAuth.
+    Customer-facing display data for a payment operation, shown to the payer.
     """ # noqa: E501
-    metadata: Optional[Dict[str, Annotated[str, Field(min_length=0, strict=True, max_length=500)]]] = Field(default=None, description="Optional metadata as key-value pairs. Use this to store additional structured information on a resource, such as customer IDs, order references, or any application-specific data. Up to 10 key/value pairs may be provided. Keys and values are both strings. Keys must be ≤ 40 characters; values must be ≤ 500 characters.")
-    customer_display: Optional[OperationCustomerDisplay] = Field(default=None, description="Optional customer-facing display data for this authorization, shown to the payer. Falls back to the session's `orderCode` when `referenceCode` is omitted.", alias="customerDisplay")
-    external_reference_id: Optional[Annotated[str, Field(strict=True, max_length=256)]] = Field(default=None, description="An optional merchant-provided internal identifier for this Coinbase authorization, from the merchant's own system—not visible to the payer.", alias="externalReferenceId")
-    __properties: ClassVar[List[str]] = ["metadata", "customerDisplay", "externalReferenceId"]
+    reference_code: Optional[Annotated[str, Field(strict=True, max_length=128)]] = Field(default=None, description="A short reference code for this payment operation, visible to the payer.", alias="referenceCode")
+    __properties: ClassVar[List[str]] = ["referenceCode"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -52,7 +49,7 @@ class CoinbaseAuthorizationRequest(BaseModel):
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:
-        """Create an instance of CoinbaseAuthorizationRequest from a JSON string"""
+        """Create an instance of OperationCustomerDisplay from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
     def to_dict(self) -> Dict[str, Any]:
@@ -73,14 +70,11 @@ class CoinbaseAuthorizationRequest(BaseModel):
             exclude=excluded_fields,
             exclude_none=True,
         )
-        # override the default output from pydantic by calling `to_dict()` of customer_display
-        if self.customer_display:
-            _dict['customerDisplay'] = self.customer_display.to_dict()
         return _dict
 
     @classmethod
     def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
-        """Create an instance of CoinbaseAuthorizationRequest from a dict"""
+        """Create an instance of OperationCustomerDisplay from a dict"""
         if obj is None:
             return None
 
@@ -88,9 +82,7 @@ class CoinbaseAuthorizationRequest(BaseModel):
             return cls.model_validate(obj)
 
         _obj = cls.model_validate({
-            "metadata": obj.get("metadata"),
-            "customerDisplay": OperationCustomerDisplay.from_dict(obj["customerDisplay"]) if obj.get("customerDisplay") is not None else None,
-            "externalReferenceId": obj.get("externalReferenceId")
+            "referenceCode": obj.get("referenceCode")
         })
         return _obj
 

--- a/python/cdp/openapi_client/models/payment_session_event_data_authorization.py
+++ b/python/cdp/openapi_client/models/payment_session_event_data_authorization.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
 from typing_extensions import Annotated
 from cdp.openapi_client.models.onchain_transaction import OnchainTransaction
+from cdp.openapi_client.models.operation_customer_display import OperationCustomerDisplay
 from cdp.openapi_client.models.payment_action_status import PaymentActionStatus
 from cdp.openapi_client.models.payment_error import PaymentError
 from cdp.openapi_client.models.payment_session_source import PaymentSessionSource
@@ -36,13 +37,15 @@ class PaymentSessionEventDataAuthorization(BaseModel):
     authorization_id: Annotated[str, Field(strict=True)] = Field(description="The unique identifier of the authorization.", alias="authorizationId")
     status: PaymentActionStatus = Field(description="The current status of the authorization.")
     amount: StrictStr = Field(description="A decimal representation of the authorized amount, denominated in the session's `asset`.")
+    external_reference_id: Optional[Annotated[str, Field(strict=True, max_length=256)]] = Field(default=None, description="An optional merchant-provided internal identifier for this authorization, from the merchant's own system—not visible to the payer. Present only when supplied on the authorization request.", alias="externalReferenceId")
+    customer_display: Optional[OperationCustomerDisplay] = Field(default=None, description="Customer-facing display data for this authorization, shown to the payer. Present when supplied on the authorization request or when the session's `orderCode` fallback applies; otherwise omitted.", alias="customerDisplay")
     error: Optional[PaymentError] = Field(default=None, description="Error details, present only when the authorization failed.")
     onchain_transactions: Optional[List[OnchainTransaction]] = Field(default=None, description="The onchain transactions associated with this authorization.", alias="onchainTransactions")
     metadata: Optional[Dict[str, Annotated[str, Field(min_length=0, strict=True, max_length=500)]]] = Field(default=None, description="Optional metadata as key-value pairs. Use this to store additional structured information on a resource, such as customer IDs, order references, or any application-specific data. Up to 10 key/value pairs may be provided. Keys and values are both strings. Keys must be ≤ 40 characters; values must be ≤ 500 characters.")
     source: Optional[PaymentSessionSource] = Field(default=None, description="The payer for this authorization. For wallet authorizations, this is the blockchain address that signed the payloads. For Coinbase authorizations, this is the authenticated Coinbase account.")
     created_at: datetime = Field(description="The UTC ISO 8601 timestamp at which the authorization was created.", alias="createdAt")
     updated_at: datetime = Field(description="The UTC ISO 8601 timestamp at which the authorization was last updated.", alias="updatedAt")
-    __properties: ClassVar[List[str]] = ["authorizationId", "status", "amount", "error", "onchainTransactions", "metadata", "source", "createdAt", "updatedAt"]
+    __properties: ClassVar[List[str]] = ["authorizationId", "status", "amount", "externalReferenceId", "customerDisplay", "error", "onchainTransactions", "metadata", "source", "createdAt", "updatedAt"]
 
     @field_validator('authorization_id')
     def authorization_id_validate_regular_expression(cls, value):
@@ -90,6 +93,9 @@ class PaymentSessionEventDataAuthorization(BaseModel):
             exclude=excluded_fields,
             exclude_none=True,
         )
+        # override the default output from pydantic by calling `to_dict()` of customer_display
+        if self.customer_display:
+            _dict['customerDisplay'] = self.customer_display.to_dict()
         # override the default output from pydantic by calling `to_dict()` of error
         if self.error:
             _dict['error'] = self.error.to_dict()
@@ -118,6 +124,8 @@ class PaymentSessionEventDataAuthorization(BaseModel):
             "authorizationId": obj.get("authorizationId"),
             "status": obj.get("status"),
             "amount": obj.get("amount"),
+            "externalReferenceId": obj.get("externalReferenceId"),
+            "customerDisplay": OperationCustomerDisplay.from_dict(obj["customerDisplay"]) if obj.get("customerDisplay") is not None else None,
             "error": PaymentError.from_dict(obj["error"]) if obj.get("error") is not None else None,
             "onchainTransactions": [OnchainTransaction.from_dict(_item) for _item in obj["onchainTransactions"]] if obj.get("onchainTransactions") is not None else None,
             "metadata": obj.get("metadata"),

--- a/python/cdp/openapi_client/models/payment_session_event_data_capture.py
+++ b/python/cdp/openapi_client/models/payment_session_event_data_capture.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr, field_
 from typing import Any, ClassVar, Dict, List, Optional
 from typing_extensions import Annotated
 from cdp.openapi_client.models.onchain_transaction import OnchainTransaction
+from cdp.openapi_client.models.operation_customer_display import OperationCustomerDisplay
 from cdp.openapi_client.models.payment_action_status import PaymentActionStatus
 from cdp.openapi_client.models.payment_error import PaymentError
 from typing import Optional, Set
@@ -35,13 +36,15 @@ class PaymentSessionEventDataCapture(BaseModel):
     capture_id: Annotated[str, Field(strict=True)] = Field(description="The unique identifier of the capture.", alias="captureId")
     status: PaymentActionStatus = Field(description="The current status of the capture.")
     amount: StrictStr = Field(description="A decimal representation of the captured amount, denominated in the session's `asset`.")
+    external_reference_id: Optional[Annotated[str, Field(strict=True, max_length=256)]] = Field(default=None, description="An optional merchant-provided internal identifier for this capture, from the merchant's own system—not visible to the payer. For an auto-capture, it is copied from the authorization.", alias="externalReferenceId")
+    customer_display: Optional[OperationCustomerDisplay] = Field(default=None, description="Customer-facing display data for this capture, shown to the payer. An auto-capture reuses the authorization's `referenceCode`.", alias="customerDisplay")
     final_capture: StrictBool = Field(description="When `true`, this capture is treated as the final one for the authorization. Any remaining capturable balance is released back to the payer immediately after the capture settles. When `false`, the remaining capturable balance stays held and is available for subsequent partial captures (subject to `captureExpiresAt`). Has no effect if `amount` equals the full capturable balance, since no remaining balance exists to release.", alias="finalCapture")
     error: Optional[PaymentError] = Field(default=None, description="Error details, present only when the capture failed.")
     onchain_transactions: Optional[List[OnchainTransaction]] = Field(default=None, description="The onchain transactions associated with this capture.", alias="onchainTransactions")
     metadata: Optional[Dict[str, Annotated[str, Field(min_length=0, strict=True, max_length=500)]]] = Field(default=None, description="Optional metadata as key-value pairs. Use this to store additional structured information on a resource, such as customer IDs, order references, or any application-specific data. Up to 10 key/value pairs may be provided. Keys and values are both strings. Keys must be ≤ 40 characters; values must be ≤ 500 characters.")
     created_at: datetime = Field(description="The UTC ISO 8601 timestamp at which the capture was created.", alias="createdAt")
     updated_at: datetime = Field(description="The UTC ISO 8601 timestamp at which the capture was last updated.", alias="updatedAt")
-    __properties: ClassVar[List[str]] = ["captureId", "status", "amount", "finalCapture", "error", "onchainTransactions", "metadata", "createdAt", "updatedAt"]
+    __properties: ClassVar[List[str]] = ["captureId", "status", "amount", "externalReferenceId", "customerDisplay", "finalCapture", "error", "onchainTransactions", "metadata", "createdAt", "updatedAt"]
 
     @field_validator('capture_id')
     def capture_id_validate_regular_expression(cls, value):
@@ -89,6 +92,9 @@ class PaymentSessionEventDataCapture(BaseModel):
             exclude=excluded_fields,
             exclude_none=True,
         )
+        # override the default output from pydantic by calling `to_dict()` of customer_display
+        if self.customer_display:
+            _dict['customerDisplay'] = self.customer_display.to_dict()
         # override the default output from pydantic by calling `to_dict()` of error
         if self.error:
             _dict['error'] = self.error.to_dict()
@@ -114,6 +120,8 @@ class PaymentSessionEventDataCapture(BaseModel):
             "captureId": obj.get("captureId"),
             "status": obj.get("status"),
             "amount": obj.get("amount"),
+            "externalReferenceId": obj.get("externalReferenceId"),
+            "customerDisplay": OperationCustomerDisplay.from_dict(obj["customerDisplay"]) if obj.get("customerDisplay") is not None else None,
             "finalCapture": obj.get("finalCapture"),
             "error": PaymentError.from_dict(obj["error"]) if obj.get("error") is not None else None,
             "onchainTransactions": [OnchainTransaction.from_dict(_item) for _item in obj["onchainTransactions"]] if obj.get("onchainTransactions") is not None else None,

--- a/python/cdp/openapi_client/models/payment_session_event_data_refund.py
+++ b/python/cdp/openapi_client/models/payment_session_event_data_refund.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
 from typing_extensions import Annotated
 from cdp.openapi_client.models.onchain_transaction import OnchainTransaction
+from cdp.openapi_client.models.operation_customer_display import OperationCustomerDisplay
 from cdp.openapi_client.models.payment_action_status import PaymentActionStatus
 from cdp.openapi_client.models.payment_error import PaymentError
 from typing import Optional, Set
@@ -35,13 +36,15 @@ class PaymentSessionEventDataRefund(BaseModel):
     refund_id: Annotated[str, Field(strict=True)] = Field(description="The unique identifier of the refund.", alias="refundId")
     status: PaymentActionStatus = Field(description="The current status of the refund.")
     amount: StrictStr = Field(description="A decimal representation of the refunded amount, denominated in the session's `asset`.")
+    external_reference_id: Optional[Annotated[str, Field(strict=True, max_length=256)]] = Field(default=None, description="An optional merchant-provided internal identifier for this refund, from the merchant's own system—not visible to the payer. Present only when supplied on the create refund request.", alias="externalReferenceId")
+    customer_display: Optional[OperationCustomerDisplay] = Field(default=None, description="Customer-facing display data for this refund, shown to the payer. Present when supplied on the create refund request or when the session's `orderCode` fallback applies; otherwise omitted.", alias="customerDisplay")
     reason: Optional[StrictStr] = Field(default=None, description="The reason for the refund, if provided when the refund was created.")
     error: Optional[PaymentError] = Field(default=None, description="Error details, present only when the refund failed.")
     onchain_transactions: Optional[List[OnchainTransaction]] = Field(default=None, description="The onchain transactions associated with this refund.", alias="onchainTransactions")
     metadata: Optional[Dict[str, Annotated[str, Field(min_length=0, strict=True, max_length=500)]]] = Field(default=None, description="Optional metadata as key-value pairs. Use this to store additional structured information on a resource, such as customer IDs, order references, or any application-specific data. Up to 10 key/value pairs may be provided. Keys and values are both strings. Keys must be ≤ 40 characters; values must be ≤ 500 characters.")
     created_at: datetime = Field(description="The UTC ISO 8601 timestamp at which the refund was created.", alias="createdAt")
     updated_at: datetime = Field(description="The UTC ISO 8601 timestamp at which the refund was last updated.", alias="updatedAt")
-    __properties: ClassVar[List[str]] = ["refundId", "status", "amount", "reason", "error", "onchainTransactions", "metadata", "createdAt", "updatedAt"]
+    __properties: ClassVar[List[str]] = ["refundId", "status", "amount", "externalReferenceId", "customerDisplay", "reason", "error", "onchainTransactions", "metadata", "createdAt", "updatedAt"]
 
     @field_validator('refund_id')
     def refund_id_validate_regular_expression(cls, value):
@@ -89,6 +92,9 @@ class PaymentSessionEventDataRefund(BaseModel):
             exclude=excluded_fields,
             exclude_none=True,
         )
+        # override the default output from pydantic by calling `to_dict()` of customer_display
+        if self.customer_display:
+            _dict['customerDisplay'] = self.customer_display.to_dict()
         # override the default output from pydantic by calling `to_dict()` of error
         if self.error:
             _dict['error'] = self.error.to_dict()
@@ -114,6 +120,8 @@ class PaymentSessionEventDataRefund(BaseModel):
             "refundId": obj.get("refundId"),
             "status": obj.get("status"),
             "amount": obj.get("amount"),
+            "externalReferenceId": obj.get("externalReferenceId"),
+            "customerDisplay": OperationCustomerDisplay.from_dict(obj["customerDisplay"]) if obj.get("customerDisplay") is not None else None,
             "reason": obj.get("reason"),
             "error": PaymentError.from_dict(obj["error"]) if obj.get("error") is not None else None,
             "onchainTransactions": [OnchainTransaction.from_dict(_item) for _item in obj["onchainTransactions"]] if obj.get("onchainTransactions") is not None else None,

--- a/python/cdp/openapi_client/models/payment_session_event_data_void.py
+++ b/python/cdp/openapi_client/models/payment_session_event_data_void.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
 from typing_extensions import Annotated
 from cdp.openapi_client.models.onchain_transaction import OnchainTransaction
+from cdp.openapi_client.models.operation_customer_display import OperationCustomerDisplay
 from cdp.openapi_client.models.payment_action_status import PaymentActionStatus
 from cdp.openapi_client.models.payment_error import PaymentError
 from typing import Optional, Set
@@ -35,12 +36,14 @@ class PaymentSessionEventDataVoid(BaseModel):
     void_id: Annotated[str, Field(strict=True)] = Field(description="The unique identifier of the void.", alias="voidId")
     status: PaymentActionStatus = Field(description="The current status of the void.")
     amount: StrictStr = Field(description="A decimal representation of the voided amount, denominated in the session's `asset`.")
+    external_reference_id: Optional[Annotated[str, Field(strict=True, max_length=256)]] = Field(default=None, description="An optional merchant-provided internal identifier for this void, from the merchant's own system—not visible to the payer. Present only when supplied on the create void request.", alias="externalReferenceId")
+    customer_display: Optional[OperationCustomerDisplay] = Field(default=None, description="Customer-facing display data for this void, shown to the payer. Present when supplied on the create void request or when the session's `orderCode` fallback applies; otherwise omitted.", alias="customerDisplay")
     error: Optional[PaymentError] = Field(default=None, description="Error details, present only when the void failed.")
     onchain_transactions: Optional[List[OnchainTransaction]] = Field(default=None, description="The onchain transactions associated with this void.", alias="onchainTransactions")
     metadata: Optional[Dict[str, Annotated[str, Field(min_length=0, strict=True, max_length=500)]]] = Field(default=None, description="Optional metadata as key-value pairs. Use this to store additional structured information on a resource, such as customer IDs, order references, or any application-specific data. Up to 10 key/value pairs may be provided. Keys and values are both strings. Keys must be ≤ 40 characters; values must be ≤ 500 characters.")
     created_at: datetime = Field(description="The UTC ISO 8601 timestamp at which the void was created.", alias="createdAt")
     updated_at: datetime = Field(description="The UTC ISO 8601 timestamp at which the void was last updated.", alias="updatedAt")
-    __properties: ClassVar[List[str]] = ["voidId", "status", "amount", "error", "onchainTransactions", "metadata", "createdAt", "updatedAt"]
+    __properties: ClassVar[List[str]] = ["voidId", "status", "amount", "externalReferenceId", "customerDisplay", "error", "onchainTransactions", "metadata", "createdAt", "updatedAt"]
 
     @field_validator('void_id')
     def void_id_validate_regular_expression(cls, value):
@@ -88,6 +91,9 @@ class PaymentSessionEventDataVoid(BaseModel):
             exclude=excluded_fields,
             exclude_none=True,
         )
+        # override the default output from pydantic by calling `to_dict()` of customer_display
+        if self.customer_display:
+            _dict['customerDisplay'] = self.customer_display.to_dict()
         # override the default output from pydantic by calling `to_dict()` of error
         if self.error:
             _dict['error'] = self.error.to_dict()
@@ -113,6 +119,8 @@ class PaymentSessionEventDataVoid(BaseModel):
             "voidId": obj.get("voidId"),
             "status": obj.get("status"),
             "amount": obj.get("amount"),
+            "externalReferenceId": obj.get("externalReferenceId"),
+            "customerDisplay": OperationCustomerDisplay.from_dict(obj["customerDisplay"]) if obj.get("customerDisplay") is not None else None,
             "error": PaymentError.from_dict(obj["error"]) if obj.get("error") is not None else None,
             "onchainTransactions": [OnchainTransaction.from_dict(_item) for _item in obj["onchainTransactions"]] if obj.get("onchainTransactions") is not None else None,
             "metadata": obj.get("metadata"),

--- a/python/cdp/openapi_client/models/refund.py
+++ b/python/cdp/openapi_client/models/refund.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
 from typing_extensions import Annotated
 from cdp.openapi_client.models.onchain_transaction import OnchainTransaction
+from cdp.openapi_client.models.operation_customer_display import OperationCustomerDisplay
 from cdp.openapi_client.models.payment_action_status import PaymentActionStatus
 from cdp.openapi_client.models.payment_error import PaymentError
 from cdp.openapi_client.models.refund_source import RefundSource
@@ -41,10 +42,12 @@ class Refund(BaseModel):
     reason: Optional[StrictStr] = Field(default=None, description="The reason for the refund.")
     error: Optional[PaymentError] = None
     metadata: Optional[Dict[str, Annotated[str, Field(min_length=0, strict=True, max_length=500)]]] = Field(default=None, description="Optional metadata as key-value pairs. Use this to store additional structured information on a resource, such as customer IDs, order references, or any application-specific data. Up to 10 key/value pairs may be provided. Keys and values are both strings. Keys must be ≤ 40 characters; values must be ≤ 500 characters.")
+    external_reference_id: Optional[Annotated[str, Field(strict=True, max_length=256)]] = Field(default=None, description="A merchant-provided internal identifier for this refund, from the merchant's own system—not visible to the payer. Present only when supplied on the create refund request.", alias="externalReferenceId")
+    customer_display: Optional[OperationCustomerDisplay] = Field(default=None, description="Customer-facing display data for this refund, shown to the payer. Present when supplied on the create refund request or when the session's `orderCode` fallback applies; otherwise omitted.", alias="customerDisplay")
     onchain_transactions: Optional[List[OnchainTransaction]] = Field(default=None, description="The onchain transactions associated with this refund.", alias="onchainTransactions")
     created_at: Optional[datetime] = Field(default=None, description="The UTC ISO 8601 timestamp at which the refund was created.", alias="createdAt")
     updated_at: Optional[datetime] = Field(default=None, description="The UTC ISO 8601 timestamp at which the refund was last updated.", alias="updatedAt")
-    __properties: ClassVar[List[str]] = ["refundId", "paymentSessionId", "source", "status", "amount", "reason", "error", "metadata", "onchainTransactions", "createdAt", "updatedAt"]
+    __properties: ClassVar[List[str]] = ["refundId", "paymentSessionId", "source", "status", "amount", "reason", "error", "metadata", "externalReferenceId", "customerDisplay", "onchainTransactions", "createdAt", "updatedAt"]
 
     @field_validator('refund_id')
     def refund_id_validate_regular_expression(cls, value):
@@ -111,6 +114,9 @@ class Refund(BaseModel):
         # override the default output from pydantic by calling `to_dict()` of error
         if self.error:
             _dict['error'] = self.error.to_dict()
+        # override the default output from pydantic by calling `to_dict()` of customer_display
+        if self.customer_display:
+            _dict['customerDisplay'] = self.customer_display.to_dict()
         # override the default output from pydantic by calling `to_dict()` of each item in onchain_transactions (list)
         _items = []
         if self.onchain_transactions:
@@ -138,6 +144,8 @@ class Refund(BaseModel):
             "reason": obj.get("reason"),
             "error": PaymentError.from_dict(obj["error"]) if obj.get("error") is not None else None,
             "metadata": obj.get("metadata"),
+            "externalReferenceId": obj.get("externalReferenceId"),
+            "customerDisplay": OperationCustomerDisplay.from_dict(obj["customerDisplay"]) if obj.get("customerDisplay") is not None else None,
             "onchainTransactions": [OnchainTransaction.from_dict(_item) for _item in obj["onchainTransactions"]] if obj.get("onchainTransactions") is not None else None,
             "createdAt": obj.get("createdAt"),
             "updatedAt": obj.get("updatedAt")

--- a/python/cdp/openapi_client/models/swap_unavailable_response.py
+++ b/python/cdp/openapi_client/models/swap_unavailable_response.py
@@ -18,7 +18,7 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, Field, StrictBool, field_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictBool
 from typing import Any, ClassVar, Dict, List
 from typing import Optional, Set
 from typing_extensions import Self
@@ -29,13 +29,6 @@ class SwapUnavailableResponse(BaseModel):
     """ # noqa: E501
     liquidity_available: StrictBool = Field(description="Whether sufficient liquidity is available to settle the swap. All other fields in the response will be empty if this is false.", alias="liquidityAvailable")
     __properties: ClassVar[List[str]] = ["liquidityAvailable"]
-
-    @field_validator('liquidity_available')
-    def liquidity_available_validate_enum(cls, value):
-        """Validates the enum"""
-        if value not in set(['false']):
-            raise ValueError("must be one of enum values ('false')")
-        return value
 
     model_config = ConfigDict(
         populate_by_name=True,

--- a/python/cdp/openapi_client/models/swap_unavailable_response1.py
+++ b/python/cdp/openapi_client/models/swap_unavailable_response1.py
@@ -18,21 +18,27 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, StrictBool, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
-from typing_extensions import Annotated
-from cdp.openapi_client.models.operation_customer_display import OperationCustomerDisplay
 from typing import Optional, Set
 from typing_extensions import Self
 
-class CoinbaseAuthorizationRequest(BaseModel):
+class SwapUnavailableResponse1(BaseModel):
     """
-    A request to authorize a payment session using the payer's Coinbase account authenticated via OAuth.
+    SwapUnavailableResponse1
     """ # noqa: E501
-    metadata: Optional[Dict[str, Annotated[str, Field(min_length=0, strict=True, max_length=500)]]] = Field(default=None, description="Optional metadata as key-value pairs. Use this to store additional structured information on a resource, such as customer IDs, order references, or any application-specific data. Up to 10 key/value pairs may be provided. Keys and values are both strings. Keys must be ≤ 40 characters; values must be ≤ 500 characters.")
-    customer_display: Optional[OperationCustomerDisplay] = Field(default=None, description="Optional customer-facing display data for this authorization, shown to the payer. Falls back to the session's `orderCode` when `referenceCode` is omitted.", alias="customerDisplay")
-    external_reference_id: Optional[Annotated[str, Field(strict=True, max_length=256)]] = Field(default=None, description="An optional merchant-provided internal identifier for this Coinbase authorization, from the merchant's own system—not visible to the payer.", alias="externalReferenceId")
-    __properties: ClassVar[List[str]] = ["metadata", "customerDisplay", "externalReferenceId"]
+    liquidity_available: Optional[StrictBool] = Field(default=None, alias="liquidityAvailable")
+    __properties: ClassVar[List[str]] = ["liquidityAvailable"]
+
+    @field_validator('liquidity_available')
+    def liquidity_available_validate_enum(cls, value):
+        """Validates the enum"""
+        if value is None:
+            return value
+
+        if value not in set(['true']):
+            raise ValueError("must be one of enum values ('true')")
+        return value
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -52,7 +58,7 @@ class CoinbaseAuthorizationRequest(BaseModel):
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:
-        """Create an instance of CoinbaseAuthorizationRequest from a JSON string"""
+        """Create an instance of SwapUnavailableResponse1 from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
     def to_dict(self) -> Dict[str, Any]:
@@ -73,14 +79,11 @@ class CoinbaseAuthorizationRequest(BaseModel):
             exclude=excluded_fields,
             exclude_none=True,
         )
-        # override the default output from pydantic by calling `to_dict()` of customer_display
-        if self.customer_display:
-            _dict['customerDisplay'] = self.customer_display.to_dict()
         return _dict
 
     @classmethod
     def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
-        """Create an instance of CoinbaseAuthorizationRequest from a dict"""
+        """Create an instance of SwapUnavailableResponse1 from a dict"""
         if obj is None:
             return None
 
@@ -88,9 +91,7 @@ class CoinbaseAuthorizationRequest(BaseModel):
             return cls.model_validate(obj)
 
         _obj = cls.model_validate({
-            "metadata": obj.get("metadata"),
-            "customerDisplay": OperationCustomerDisplay.from_dict(obj["customerDisplay"]) if obj.get("customerDisplay") is not None else None,
-            "externalReferenceId": obj.get("externalReferenceId")
+            "liquidityAvailable": obj.get("liquidityAvailable")
         })
         return _obj
 

--- a/python/cdp/openapi_client/models/void.py
+++ b/python/cdp/openapi_client/models/void.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
 from typing_extensions import Annotated
 from cdp.openapi_client.models.onchain_transaction import OnchainTransaction
+from cdp.openapi_client.models.operation_customer_display import OperationCustomerDisplay
 from cdp.openapi_client.models.payment_action_status import PaymentActionStatus
 from cdp.openapi_client.models.payment_error import PaymentError
 from typing import Optional, Set
@@ -38,10 +39,12 @@ class Void(BaseModel):
     amount: Optional[StrictStr] = Field(default=None, description="A decimal representation of the voided amount, denominated in the session's `asset`.")
     error: Optional[PaymentError] = None
     metadata: Optional[Dict[str, Annotated[str, Field(min_length=0, strict=True, max_length=500)]]] = Field(default=None, description="Optional metadata as key-value pairs. Use this to store additional structured information on a resource, such as customer IDs, order references, or any application-specific data. Up to 10 key/value pairs may be provided. Keys and values are both strings. Keys must be ≤ 40 characters; values must be ≤ 500 characters.")
+    external_reference_id: Optional[Annotated[str, Field(strict=True, max_length=256)]] = Field(default=None, description="A merchant-provided internal identifier for this void, from the merchant's own system—not visible to the payer. Present only when supplied on the create void request.", alias="externalReferenceId")
+    customer_display: Optional[OperationCustomerDisplay] = Field(default=None, description="Customer-facing display data for this void, shown to the payer. Present when supplied on the create void request or when the session's `orderCode` fallback applies; otherwise omitted.", alias="customerDisplay")
     onchain_transactions: Optional[List[OnchainTransaction]] = Field(default=None, description="The onchain transactions associated with this void.", alias="onchainTransactions")
     created_at: Optional[datetime] = Field(default=None, description="The UTC ISO 8601 timestamp at which the void was created.", alias="createdAt")
     updated_at: Optional[datetime] = Field(default=None, description="The UTC ISO 8601 timestamp at which the void was last updated.", alias="updatedAt")
-    __properties: ClassVar[List[str]] = ["voidId", "paymentSessionId", "status", "amount", "error", "metadata", "onchainTransactions", "createdAt", "updatedAt"]
+    __properties: ClassVar[List[str]] = ["voidId", "paymentSessionId", "status", "amount", "error", "metadata", "externalReferenceId", "customerDisplay", "onchainTransactions", "createdAt", "updatedAt"]
 
     @field_validator('void_id')
     def void_id_validate_regular_expression(cls, value):
@@ -105,6 +108,9 @@ class Void(BaseModel):
         # override the default output from pydantic by calling `to_dict()` of error
         if self.error:
             _dict['error'] = self.error.to_dict()
+        # override the default output from pydantic by calling `to_dict()` of customer_display
+        if self.customer_display:
+            _dict['customerDisplay'] = self.customer_display.to_dict()
         # override the default output from pydantic by calling `to_dict()` of each item in onchain_transactions (list)
         _items = []
         if self.onchain_transactions:
@@ -130,6 +136,8 @@ class Void(BaseModel):
             "amount": obj.get("amount"),
             "error": PaymentError.from_dict(obj["error"]) if obj.get("error") is not None else None,
             "metadata": obj.get("metadata"),
+            "externalReferenceId": obj.get("externalReferenceId"),
+            "customerDisplay": OperationCustomerDisplay.from_dict(obj["customerDisplay"]) if obj.get("customerDisplay") is not None else None,
             "onchainTransactions": [OnchainTransaction.from_dict(_item) for _item in obj["onchainTransactions"]] if obj.get("onchainTransactions") is not None else None,
             "createdAt": obj.get("createdAt"),
             "updatedAt": obj.get("updatedAt")

--- a/python/cdp/openapi_client/models/wallet_authorization_request.py
+++ b/python/cdp/openapi_client/models/wallet_authorization_request.py
@@ -22,6 +22,7 @@ from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
 from typing_extensions import Annotated
 from cdp.openapi_client.models.onchain_signed_payload import OnchainSignedPayload
+from cdp.openapi_client.models.operation_customer_display import OperationCustomerDisplay
 from typing import Optional, Set
 from typing_extensions import Self
 
@@ -32,7 +33,9 @@ class WalletAuthorizationRequest(BaseModel):
     option_id: StrictStr = Field(description="The identifier of the chosen authorization option. Must match an `optionId` from the wallet authorization options response.", alias="optionId")
     signed_payloads: List[OnchainSignedPayload] = Field(description="The processed payloads from the payer, corresponding to the payloads in the selected authorization option.", alias="signedPayloads")
     metadata: Optional[Dict[str, Annotated[str, Field(min_length=0, strict=True, max_length=500)]]] = Field(default=None, description="Optional metadata as key-value pairs. Use this to store additional structured information on a resource, such as customer IDs, order references, or any application-specific data. Up to 10 key/value pairs may be provided. Keys and values are both strings. Keys must be ≤ 40 characters; values must be ≤ 500 characters.")
-    __properties: ClassVar[List[str]] = ["optionId", "signedPayloads", "metadata"]
+    customer_display: Optional[OperationCustomerDisplay] = Field(default=None, description="Optional customer-facing display data for this authorization, shown to the payer. Falls back to the session's `orderCode` when `referenceCode` is omitted.", alias="customerDisplay")
+    external_reference_id: Optional[Annotated[str, Field(strict=True, max_length=256)]] = Field(default=None, description="An optional merchant-provided internal identifier for this wallet authorization, from the merchant's own system—not visible to the payer.", alias="externalReferenceId")
+    __properties: ClassVar[List[str]] = ["optionId", "signedPayloads", "metadata", "customerDisplay", "externalReferenceId"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -80,6 +83,9 @@ class WalletAuthorizationRequest(BaseModel):
                 if _item_signed_payloads:
                     _items.append(_item_signed_payloads.to_dict())
             _dict['signedPayloads'] = _items
+        # override the default output from pydantic by calling `to_dict()` of customer_display
+        if self.customer_display:
+            _dict['customerDisplay'] = self.customer_display.to_dict()
         return _dict
 
     @classmethod
@@ -94,7 +100,9 @@ class WalletAuthorizationRequest(BaseModel):
         _obj = cls.model_validate({
             "optionId": obj.get("optionId"),
             "signedPayloads": [OnchainSignedPayload.from_dict(_item) for _item in obj["signedPayloads"]] if obj.get("signedPayloads") is not None else None,
-            "metadata": obj.get("metadata")
+            "metadata": obj.get("metadata"),
+            "customerDisplay": OperationCustomerDisplay.from_dict(obj["customerDisplay"]) if obj.get("customerDisplay") is not None else None,
+            "externalReferenceId": obj.get("externalReferenceId")
         })
         return _obj
 

--- a/python/cdp/openapi_client/test/test_authorization.py
+++ b/python/cdp/openapi_client/test/test_authorization.py
@@ -43,6 +43,8 @@ class TestAuthorization(unittest.TestCase):
                 error = {code=insufficient_funds, message=The payer does not have sufficient funds., occurredAt=2025-06-15T12:00:00.000Z},
                 message = 'Your payment was successfully submitted',
                 metadata = {customer_id=cust_12345, order_reference=order-67890},
+                external_reference_id = 'merchant-reference-abc123',
+                customer_display = {referenceCode=REF-ABC123},
                 source = {address=0xAbC1234567890aBcDeF1234567890AbCdEf123456, network=base, asset=usdc},
                 onchain_transactions = [{transactionHash=0xabc123def456789012345678901234567890abcdef1234567890abcdef123456, network=base}],
                 created_at = '2025-06-15T12:00:00.000Z',

--- a/python/cdp/openapi_client/test/test_capture.py
+++ b/python/cdp/openapi_client/test/test_capture.py
@@ -43,6 +43,8 @@ class TestCapture(unittest.TestCase):
                 final_capture = True,
                 error = {code=insufficient_funds, message=The payer does not have sufficient funds., occurredAt=2025-06-15T12:00:00.000Z},
                 metadata = {customer_id=cust_12345, order_reference=order-67890},
+                external_reference_id = 'merchant-reference-abc123',
+                customer_display = {referenceCode=REF-ABC123},
                 onchain_transactions = [{transactionHash=0xdef456abc789012345678901234567890abcdef1234567890abcdef12345678, network=base}],
                 created_at = '2025-06-15T12:20:00.000Z',
                 updated_at = '2025-06-15T12:21:00.000Z'

--- a/python/cdp/openapi_client/test/test_common_swap_response_not.py
+++ b/python/cdp/openapi_client/test/test_common_swap_response_not.py
@@ -15,10 +15,10 @@
 
 import unittest
 
-from cdp.openapi_client.models.coinbase_authorization_request import CoinbaseAuthorizationRequest
+from cdp.openapi_client.models.common_swap_response_not import CommonSwapResponseNot
 
-class TestCoinbaseAuthorizationRequest(unittest.TestCase):
-    """CoinbaseAuthorizationRequest unit test stubs"""
+class TestCommonSwapResponseNot(unittest.TestCase):
+    """CommonSwapResponseNot unit test stubs"""
 
     def setUp(self):
         pass
@@ -26,27 +26,25 @@ class TestCoinbaseAuthorizationRequest(unittest.TestCase):
     def tearDown(self):
         pass
 
-    def make_instance(self, include_optional) -> CoinbaseAuthorizationRequest:
-        """Test CoinbaseAuthorizationRequest
+    def make_instance(self, include_optional) -> CommonSwapResponseNot:
+        """Test CommonSwapResponseNot
             include_optional is a boolean, when False only required
             params are included, when True both required and
             optional params are included """
-        # uncomment below to create an instance of `CoinbaseAuthorizationRequest`
+        # uncomment below to create an instance of `CommonSwapResponseNot`
         """
-        model = CoinbaseAuthorizationRequest()
+        model = CommonSwapResponseNot()
         if include_optional:
-            return CoinbaseAuthorizationRequest(
-                metadata = {customer_id=cust_12345, order_reference=order-67890},
-                customer_display = {referenceCode=REF-ABC123},
-                external_reference_id = 'merchant-reference-abc123'
+            return CommonSwapResponseNot(
+                liquidity_available = false
             )
         else:
-            return CoinbaseAuthorizationRequest(
+            return CommonSwapResponseNot(
         )
         """
 
-    def testCoinbaseAuthorizationRequest(self):
-        """Test CoinbaseAuthorizationRequest"""
+    def testCommonSwapResponseNot(self):
+        """Test CommonSwapResponseNot"""
         # inst_req_only = self.make_instance(include_optional=False)
         # inst_req_and_optional = self.make_instance(include_optional=True)
 

--- a/python/cdp/openapi_client/test/test_create_capture_request.py
+++ b/python/cdp/openapi_client/test/test_create_capture_request.py
@@ -38,7 +38,9 @@ class TestCreateCaptureRequest(unittest.TestCase):
             return CreateCaptureRequest(
                 amount = '1.00',
                 final_capture = True,
-                metadata = {customer_id=cust_12345, order_reference=order-67890}
+                metadata = {customer_id=cust_12345, order_reference=order-67890},
+                external_reference_id = 'merchant-reference-abc123',
+                customer_display = {referenceCode=REF-ABC123}
             )
         else:
             return CreateCaptureRequest(

--- a/python/cdp/openapi_client/test/test_create_disbursement_request.py
+++ b/python/cdp/openapi_client/test/test_create_disbursement_request.py
@@ -42,6 +42,7 @@ class TestCreateDisbursementRequest(unittest.TestCase):
                 asset = 'usd',
                 reason = 'Goodwill disbursement for delayed shipment.',
                 external_reference_id = 'disbursement-2026-04-1234',
+                customer_display = {referenceCode=REF-ABC123},
                 metadata = {customer_id=cust_12345, order_reference=order-67890},
                 compliance = {recipient={name=Jane Smith, address={line1=456 Oak Ave, city=Austin, state=TX, postCode=78701, countryCode=US}}}
             )

--- a/python/cdp/openapi_client/test/test_create_refund_request.py
+++ b/python/cdp/openapi_client/test/test_create_refund_request.py
@@ -39,7 +39,9 @@ class TestCreateRefundRequest(unittest.TestCase):
                 source = None,
                 amount = '0.50',
                 reason = 'Customer returned the item.',
-                metadata = {customer_id=cust_12345, order_reference=order-67890}
+                metadata = {customer_id=cust_12345, order_reference=order-67890},
+                external_reference_id = 'merchant-reference-abc123',
+                customer_display = {referenceCode=REF-ABC123}
             )
         else:
             return CreateRefundRequest(

--- a/python/cdp/openapi_client/test/test_create_void_request.py
+++ b/python/cdp/openapi_client/test/test_create_void_request.py
@@ -36,7 +36,9 @@ class TestCreateVoidRequest(unittest.TestCase):
         model = CreateVoidRequest()
         if include_optional:
             return CreateVoidRequest(
-                metadata = {customer_id=cust_12345, order_reference=order-67890}
+                metadata = {customer_id=cust_12345, order_reference=order-67890},
+                external_reference_id = 'merchant-reference-abc123',
+                customer_display = {referenceCode=REF-ABC123}
             )
         else:
             return CreateVoidRequest(

--- a/python/cdp/openapi_client/test/test_customer_display.py
+++ b/python/cdp/openapi_client/test/test_customer_display.py
@@ -37,7 +37,8 @@ class TestCustomerDisplay(unittest.TestCase):
         if include_optional:
             return CustomerDisplay(
                 merchant_name = 'Acme Store',
-                display_amount = {amount=1.37, currency=cad}
+                display_amount = {amount=1.37, currency=cad},
+                order_code = 'ORDER-ABC123'
             )
         else:
             return CustomerDisplay(

--- a/python/cdp/openapi_client/test/test_disbursement.py
+++ b/python/cdp/openapi_client/test/test_disbursement.py
@@ -44,6 +44,7 @@ class TestDisbursement(unittest.TestCase):
                 status = 'pending',
                 reason = 'Goodwill disbursement for delayed shipment.',
                 external_reference_id = 'disbursement-2026-04-1234',
+                customer_display = {referenceCode=REF-ABC123},
                 metadata = {customer_id=cust_12345, order_reference=order-67890},
                 error = {code=insufficient_funds, message=The payer does not have sufficient funds., occurredAt=2025-06-15T12:00:00.000Z},
                 onchain_transactions = [{transactionHash=0xabc123def456789012345678901234567890abcdef1234567890abcdef123456, network=base}],

--- a/python/cdp/openapi_client/test/test_operation_customer_display.py
+++ b/python/cdp/openapi_client/test/test_operation_customer_display.py
@@ -15,10 +15,10 @@
 
 import unittest
 
-from cdp.openapi_client.models.coinbase_authorization_request import CoinbaseAuthorizationRequest
+from cdp.openapi_client.models.operation_customer_display import OperationCustomerDisplay
 
-class TestCoinbaseAuthorizationRequest(unittest.TestCase):
-    """CoinbaseAuthorizationRequest unit test stubs"""
+class TestOperationCustomerDisplay(unittest.TestCase):
+    """OperationCustomerDisplay unit test stubs"""
 
     def setUp(self):
         pass
@@ -26,27 +26,25 @@ class TestCoinbaseAuthorizationRequest(unittest.TestCase):
     def tearDown(self):
         pass
 
-    def make_instance(self, include_optional) -> CoinbaseAuthorizationRequest:
-        """Test CoinbaseAuthorizationRequest
+    def make_instance(self, include_optional) -> OperationCustomerDisplay:
+        """Test OperationCustomerDisplay
             include_optional is a boolean, when False only required
             params are included, when True both required and
             optional params are included """
-        # uncomment below to create an instance of `CoinbaseAuthorizationRequest`
+        # uncomment below to create an instance of `OperationCustomerDisplay`
         """
-        model = CoinbaseAuthorizationRequest()
+        model = OperationCustomerDisplay()
         if include_optional:
-            return CoinbaseAuthorizationRequest(
-                metadata = {customer_id=cust_12345, order_reference=order-67890},
-                customer_display = {referenceCode=REF-ABC123},
-                external_reference_id = 'merchant-reference-abc123'
+            return OperationCustomerDisplay(
+                reference_code = 'REF-ABC123'
             )
         else:
-            return CoinbaseAuthorizationRequest(
+            return OperationCustomerDisplay(
         )
         """
 
-    def testCoinbaseAuthorizationRequest(self):
-        """Test CoinbaseAuthorizationRequest"""
+    def testOperationCustomerDisplay(self):
+        """Test OperationCustomerDisplay"""
         # inst_req_only = self.make_instance(include_optional=False)
         # inst_req_and_optional = self.make_instance(include_optional=True)
 

--- a/python/cdp/openapi_client/test/test_payment_session_event_data_authorization.py
+++ b/python/cdp/openapi_client/test/test_payment_session_event_data_authorization.py
@@ -39,6 +39,8 @@ class TestPaymentSessionEventDataAuthorization(unittest.TestCase):
                 authorization_id = 'authorization_82c879c1-84e1-44ed-a8c2-1ac239cf09ad',
                 status = 'pending',
                 amount = '1.00',
+                external_reference_id = 'merchant-reference-abc123',
+                customer_display = {referenceCode=REF-ABC123},
                 error = {code=insufficient_funds, message=The payer does not have sufficient funds., occurredAt=2025-06-15T12:00:00.000Z},
                 onchain_transactions = [{transactionHash=0xabc123def456789012345678901234567890abcdef1234567890abcdef123456, network=base}],
                 metadata = {customer_id=cust_12345, order_reference=order-67890},

--- a/python/cdp/openapi_client/test/test_payment_session_event_data_capture.py
+++ b/python/cdp/openapi_client/test/test_payment_session_event_data_capture.py
@@ -39,6 +39,8 @@ class TestPaymentSessionEventDataCapture(unittest.TestCase):
                 capture_id = 'capture_82c879c1-84e1-44ed-a8c2-1ac239cf09ad',
                 status = 'pending',
                 amount = '1.00',
+                external_reference_id = 'merchant-reference-abc123',
+                customer_display = {referenceCode=REF-ABC123},
                 final_capture = True,
                 error = {code=insufficient_funds, message=The payer does not have sufficient funds., occurredAt=2025-06-15T12:00:00.000Z},
                 onchain_transactions = [{transactionHash=0xdef456abc789012345678901234567890abcdef1234567890abcdef12345678, network=base}],

--- a/python/cdp/openapi_client/test/test_payment_session_event_data_refund.py
+++ b/python/cdp/openapi_client/test/test_payment_session_event_data_refund.py
@@ -39,6 +39,8 @@ class TestPaymentSessionEventDataRefund(unittest.TestCase):
                 refund_id = 'refund_82c879c1-84e1-44ed-a8c2-1ac239cf09ad',
                 status = 'pending',
                 amount = '0.50',
+                external_reference_id = 'merchant-reference-abc123',
+                customer_display = {referenceCode=REF-ABC123},
                 reason = 'Customer returned the item.',
                 error = {code=insufficient_funds, message=The payer does not have sufficient funds., occurredAt=2025-06-15T12:00:00.000Z},
                 onchain_transactions = [{transactionHash=0x012345678901234567890abcdef1234567890abcdef1234567890abcdef1234, network=base}],

--- a/python/cdp/openapi_client/test/test_payment_session_event_data_void.py
+++ b/python/cdp/openapi_client/test/test_payment_session_event_data_void.py
@@ -39,6 +39,8 @@ class TestPaymentSessionEventDataVoid(unittest.TestCase):
                 void_id = 'void_82c879c1-84e1-44ed-a8c2-1ac239cf09ad',
                 status = 'pending',
                 amount = '1.00',
+                external_reference_id = 'merchant-reference-abc123',
+                customer_display = {referenceCode=REF-ABC123},
                 error = {code=insufficient_funds, message=The payer does not have sufficient funds., occurredAt=2025-06-15T12:00:00.000Z},
                 onchain_transactions = [{transactionHash=0x789012345678901234567890abcdef1234567890abcdef1234567890abcdef12, network=base}],
                 metadata = {customer_id=cust_12345, order_reference=order-67890},

--- a/python/cdp/openapi_client/test/test_refund.py
+++ b/python/cdp/openapi_client/test/test_refund.py
@@ -44,6 +44,8 @@ class TestRefund(unittest.TestCase):
                 reason = 'Customer returned the item.',
                 error = {code=insufficient_funds, message=The payer does not have sufficient funds., occurredAt=2025-06-15T12:00:00.000Z},
                 metadata = {customer_id=cust_12345, order_reference=order-67890},
+                external_reference_id = 'merchant-reference-abc123',
+                customer_display = {referenceCode=REF-ABC123},
                 onchain_transactions = [{transactionHash=0x012345678901234567890abcdef1234567890abcdef1234567890abcdef1234, network=base}],
                 created_at = '2025-06-15T12:40:00.000Z',
                 updated_at = '2025-06-15T12:41:00.000Z'

--- a/python/cdp/openapi_client/test/test_swap_unavailable_response1.py
+++ b/python/cdp/openapi_client/test/test_swap_unavailable_response1.py
@@ -15,10 +15,10 @@
 
 import unittest
 
-from cdp.openapi_client.models.coinbase_authorization_request import CoinbaseAuthorizationRequest
+from cdp.openapi_client.models.swap_unavailable_response1 import SwapUnavailableResponse1
 
-class TestCoinbaseAuthorizationRequest(unittest.TestCase):
-    """CoinbaseAuthorizationRequest unit test stubs"""
+class TestSwapUnavailableResponse1(unittest.TestCase):
+    """SwapUnavailableResponse1 unit test stubs"""
 
     def setUp(self):
         pass
@@ -26,27 +26,25 @@ class TestCoinbaseAuthorizationRequest(unittest.TestCase):
     def tearDown(self):
         pass
 
-    def make_instance(self, include_optional) -> CoinbaseAuthorizationRequest:
-        """Test CoinbaseAuthorizationRequest
+    def make_instance(self, include_optional) -> SwapUnavailableResponse1:
+        """Test SwapUnavailableResponse1
             include_optional is a boolean, when False only required
             params are included, when True both required and
             optional params are included """
-        # uncomment below to create an instance of `CoinbaseAuthorizationRequest`
+        # uncomment below to create an instance of `SwapUnavailableResponse1`
         """
-        model = CoinbaseAuthorizationRequest()
+        model = SwapUnavailableResponse1()
         if include_optional:
-            return CoinbaseAuthorizationRequest(
-                metadata = {customer_id=cust_12345, order_reference=order-67890},
-                customer_display = {referenceCode=REF-ABC123},
-                external_reference_id = 'merchant-reference-abc123'
+            return SwapUnavailableResponse1(
+                liquidity_available = true
             )
         else:
-            return CoinbaseAuthorizationRequest(
+            return SwapUnavailableResponse1(
         )
         """
 
-    def testCoinbaseAuthorizationRequest(self):
-        """Test CoinbaseAuthorizationRequest"""
+    def testSwapUnavailableResponse1(self):
+        """Test SwapUnavailableResponse1"""
         # inst_req_only = self.make_instance(include_optional=False)
         # inst_req_and_optional = self.make_instance(include_optional=True)
 

--- a/python/cdp/openapi_client/test/test_void.py
+++ b/python/cdp/openapi_client/test/test_void.py
@@ -42,6 +42,8 @@ class TestVoid(unittest.TestCase):
                 amount = '1.00',
                 error = {code=insufficient_funds, message=The payer does not have sufficient funds., occurredAt=2025-06-15T12:00:00.000Z},
                 metadata = {customer_id=cust_12345, order_reference=order-67890},
+                external_reference_id = 'merchant-reference-abc123',
+                customer_display = {referenceCode=REF-ABC123},
                 onchain_transactions = [{transactionHash=0x789012345678901234567890abcdef1234567890abcdef1234567890abcdef12, network=base}],
                 created_at = '2025-06-15T12:30:00.000Z',
                 updated_at = '2025-06-15T12:31:00.000Z'

--- a/python/cdp/openapi_client/test/test_wallet_authorization_request.py
+++ b/python/cdp/openapi_client/test/test_wallet_authorization_request.py
@@ -38,7 +38,9 @@ class TestWalletAuthorizationRequest(unittest.TestCase):
             return WalletAuthorizationRequest(
                 option_id = 'opt_a1b2c3d4-e5f6-7890-abcd-ef1234567890',
                 signed_payloads = [{payloadId=payload_af2937b0-9846-4fe7-bfe9-ccc22d935114, signature=0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab}],
-                metadata = {customer_id=cust_12345, order_reference=order-67890}
+                metadata = {customer_id=cust_12345, order_reference=order-67890},
+                customer_display = {referenceCode=REF-ABC123},
+                external_reference_id = 'merchant-reference-abc123'
             )
         else:
             return WalletAuthorizationRequest(

--- a/python/cdp/test/test_e2e.py
+++ b/python/cdp/test/test_e2e.py
@@ -24,7 +24,6 @@ from cdp.evm_local_account import EvmLocalAccount
 from cdp.evm_transaction_types import TransactionRequestEIP1559
 from cdp.openapi_client.errors import ApiError
 from cdp.openapi_client.models.authentication_method import AuthenticationMethod
-from cdp.openapi_client.models.common_swap_response_fees import CommonSwapResponseFees
 from cdp.openapi_client.models.create_end_user_request_evm_account import (
     CreateEndUserRequestEvmAccount,
 )
@@ -34,6 +33,7 @@ from cdp.openapi_client.models.create_end_user_request_solana_account import (
 from cdp.openapi_client.models.create_evm_swap_quote_request import (
     CreateEvmSwapQuoteRequest,
 )
+from cdp.openapi_client.models.create_swap_quote_response import CreateSwapQuoteResponse
 from cdp.openapi_client.models.eip712_domain import EIP712Domain
 from cdp.openapi_client.models.email_authentication import EmailAuthentication
 from cdp.openapi_client.models.evm_swaps_network import EvmSwapsNetwork
@@ -162,8 +162,8 @@ async def test_create_get_and_list_accounts(cdp_client):
 
 @pytest.mark.e2e
 @pytest.mark.asyncio
-async def test_create_swap_quote_accepts_nullable_gas_fee(cdp_client):
-    """Test that a live swap quote accepts the nullable gasFee response field."""
+async def test_create_swap_quote_deserializes_live_response(cdp_client):
+    """Test complete deserialization of a live successful swap quote."""
     accounts = await cdp_client.evm.list_accounts(page_size=1)
     assert accounts.accounts
 
@@ -187,8 +187,9 @@ async def test_create_swap_quote_accepts_nullable_gas_fee(cdp_client):
     if response_data.get("fees", {}).get("gasFee") is not None:
         pytest.skip("Swap API did not return a nullable gasFee for this quote.")
 
-    fees = CommonSwapResponseFees.from_dict(response_data["fees"])
-    assert fees.gas_fee is None
+    swap_quote = CreateSwapQuoteResponse.from_dict(response_data)
+    assert swap_quote.liquidity_available is True
+    assert swap_quote.fees.gas_fee is None
 
 
 @pytest.mark.e2e

--- a/python/changelog.d/788.bugfix.md
+++ b/python/changelog.d/788.bugfix.md
@@ -1,0 +1,1 @@
+Fixed swap quote response deserialization when the API returns a boolean `liquidityAvailable` value.

--- a/typescript/packages/cdp-sdk/src/openapi-client/generated/coinbaseDeveloperPlatformAPIs.schemas.ts
+++ b/typescript/packages/cdp-sdk/src/openapi-client/generated/coinbaseDeveloperPlatformAPIs.schemas.ts
@@ -2114,6 +2114,26 @@ export interface PaymentError {
 }
 
 /**
+ * A merchant-provided internal identifier for a resource from the merchant's own system—not visible to the payer. It must not contain personally identifiable information (PII) or payment credentials.
+ * @maxLength 256
+ */
+export type ExternalReferenceId = string;
+
+/**
+ * A short customer-facing reference for an operation, visible to the payer. It must not contain personally identifiable information (PII) or payment credentials.
+ * @maxLength 128
+ */
+export type CustomerReferenceCode = string;
+
+/**
+ * Customer-facing display data for a payment operation, shown to the payer.
+ */
+export interface OperationCustomerDisplay {
+  /** A short reference code for this payment operation, visible to the payer. */
+  referenceCode?: CustomerReferenceCode;
+}
+
+/**
  * An onchain transaction associated with a payment action.
  */
 export interface OnchainTransaction {
@@ -2139,6 +2159,10 @@ export interface Authorization {
   /** A human-readable message describing the outcome or status for display. Returned for x402 authorizations; omitted for other authorization flows unless documented otherwise. */
   message?: string;
   metadata?: Metadata;
+  /** A merchant-provided internal identifier for this authorization, from the merchant's own system—not visible to the payer. Present only when supplied on the authorization request. */
+  externalReferenceId?: ExternalReferenceId;
+  /** Customer-facing display data for this authorization, shown to the payer. Present when supplied on the authorization request or when the session's `orderCode` fallback applies; otherwise omitted. */
+  customerDisplay?: OperationCustomerDisplay;
   /** The payer for this authorization. For wallet authorizations, this is the blockchain address that signed the payloads. For Coinbase authorizations, this is the authenticated Coinbase account. This value is also reflected on the parent payment session's `source` field after a successful authorization. */
   source?: PaymentSessionSource;
   /** The onchain transactions associated with this authorization. */
@@ -2171,6 +2195,10 @@ export interface Capture {
   finalCapture: boolean;
   error?: PaymentError;
   metadata?: Metadata;
+  /** A merchant-provided internal identifier for this capture, from the merchant's own system—not visible to the payer. A manual capture uses the caller-provided value; an auto-capture reuses the authorization's value and omits it when the authorization omitted it. It never falls back to `PaymentSession.externalReferenceId`. */
+  externalReferenceId?: ExternalReferenceId;
+  /** Customer-facing display data for this capture, shown to the payer. A manual capture falls back to the session's `orderCode` when `referenceCode` is omitted; an auto-capture reuses the authorization's `referenceCode`. */
+  customerDisplay?: OperationCustomerDisplay;
   /** The onchain transactions associated with this capture. */
   onchainTransactions?: OnchainTransaction[];
   /** The UTC ISO 8601 timestamp at which the capture was created. */
@@ -2199,6 +2227,10 @@ export interface Void {
   amount?: string;
   error?: PaymentError;
   metadata?: Metadata;
+  /** A merchant-provided internal identifier for this void, from the merchant's own system—not visible to the payer. Present only when supplied on the create void request. */
+  externalReferenceId?: ExternalReferenceId;
+  /** Customer-facing display data for this void, shown to the payer. Present when supplied on the create void request or when the session's `orderCode` fallback applies; otherwise omitted. */
+  customerDisplay?: OperationCustomerDisplay;
   /** The onchain transactions associated with this void. */
   onchainTransactions?: OnchainTransaction[];
   /** The UTC ISO 8601 timestamp at which the void was created. */
@@ -2244,6 +2276,10 @@ export interface Refund {
   reason?: string;
   error?: PaymentError;
   metadata?: Metadata;
+  /** A merchant-provided internal identifier for this refund, from the merchant's own system—not visible to the payer. Present only when supplied on the create refund request. */
+  externalReferenceId?: ExternalReferenceId;
+  /** Customer-facing display data for this refund, shown to the payer. Present when supplied on the create refund request or when the session's `orderCode` fallback applies; otherwise omitted. */
+  customerDisplay?: OperationCustomerDisplay;
   /** The onchain transactions associated with this refund. */
   onchainTransactions?: OnchainTransaction[];
   /** The UTC ISO 8601 timestamp at which the refund was created. */
@@ -2283,6 +2319,11 @@ export interface CustomerDisplay {
   merchantName?: string;
   /** The amount to present to the payer, which may differ from the authoritative settlement amount and asset. Commonly used when the payer's local currency differs from the settlement currency (e.g., charging in USD but displaying the equivalent in CAD). Stored and returned as-is — no cross-validation is performed against the authoritative `amount` and `asset`. Both `amount` and `currency` must be provided together. */
   displayAmount?: CustomerDisplayDisplayAmount;
+  /**
+   * A customer-visible code for the overall order. When omitted, CDP generates one and returns it. It must not contain personally identifiable information (PII) or payment credentials.
+   * @maxLength 128
+   */
+  orderCode?: string;
 }
 
 /**
@@ -2654,6 +2695,10 @@ export interface WalletAuthorizationRequest {
   /** The processed payloads from the payer, corresponding to the payloads in the selected authorization option. */
   signedPayloads: OnchainSignedPayload[];
   metadata?: Metadata;
+  /** Optional customer-facing display data for this authorization, shown to the payer. Falls back to the session's `orderCode` when `referenceCode` is omitted. */
+  customerDisplay?: OperationCustomerDisplay;
+  /** An optional merchant-provided internal identifier for this wallet authorization, from the merchant's own system—not visible to the payer. */
+  externalReferenceId?: ExternalReferenceId;
 }
 
 /**
@@ -2661,6 +2706,10 @@ export interface WalletAuthorizationRequest {
  */
 export interface CoinbaseAuthorizationRequest {
   metadata?: Metadata;
+  /** Optional customer-facing display data for this authorization, shown to the payer. Falls back to the session's `orderCode` when `referenceCode` is omitted. */
+  customerDisplay?: OperationCustomerDisplay;
+  /** An optional merchant-provided internal identifier for this Coinbase authorization, from the merchant's own system—not visible to the payer. */
+  externalReferenceId?: ExternalReferenceId;
 }
 
 /**
@@ -2672,6 +2721,10 @@ export interface CreateCaptureRequest {
   /** When `true`, this capture is treated as the final one for the authorization. Any remaining capturable balance is released back to the payer immediately after the capture settles. When `false`, the remaining capturable balance stays held and is available for subsequent partial captures (subject to `captureExpiresAt`). Has no effect if `amount` equals the full capturable balance, since no remaining balance exists to release. */
   finalCapture: boolean;
   metadata?: Metadata;
+  /** An optional merchant-provided internal identifier for this manual capture, from the merchant's own system—not visible to the payer. */
+  externalReferenceId?: ExternalReferenceId;
+  /** Optional customer-facing display data for this manual capture, shown to the payer. Falls back to the session's `orderCode` when `referenceCode` is omitted. */
+  customerDisplay?: OperationCustomerDisplay;
 }
 
 /**
@@ -2679,6 +2732,10 @@ export interface CreateCaptureRequest {
  */
 export interface CreateVoidRequest {
   metadata?: Metadata;
+  /** An optional merchant-provided internal identifier for this void, from the merchant's own system—not visible to the payer. */
+  externalReferenceId?: ExternalReferenceId;
+  /** Optional customer-facing display data for this void, shown to the payer. Falls back to the session's `orderCode` when `referenceCode` is omitted. */
+  customerDisplay?: OperationCustomerDisplay;
 }
 
 /**
@@ -2692,6 +2749,10 @@ export interface CreateRefundRequest {
   /** The reason for the refund. */
   reason?: string;
   metadata?: Metadata;
+  /** An optional merchant-provided internal identifier for this refund, from the merchant's own system—not visible to the payer. */
+  externalReferenceId?: ExternalReferenceId;
+  /** Optional customer-facing display data for this refund, shown to the payer. Falls back to the session's `orderCode` when `referenceCode` is omitted. */
+  customerDisplay?: OperationCustomerDisplay;
 }
 
 /**
@@ -2772,6 +2833,8 @@ export interface Disbursement {
    * @maxLength 256
    */
   externalReferenceId?: string;
+  /** Customer-facing display data for this disbursement, shown to the payer. Always present: if the create request omits `referenceCode`, one is auto-generated, since disbursements have no payment session to fall back to. */
+  customerDisplay?: OperationCustomerDisplay;
   metadata?: Metadata;
   /** Error details, present only when the disbursement failed. */
   error?: PaymentError;
@@ -2813,6 +2876,8 @@ export interface CreateDisbursementRequest {
    * @maxLength 256
    */
   externalReferenceId?: string;
+  /** Optional customer-facing display data for this disbursement, shown to the payer. If `referenceCode` is omitted, one is auto-generated — disbursements have no payment session to fall back to, unlike every other action type. */
+  customerDisplay?: OperationCustomerDisplay;
   metadata?: Metadata;
   /** Compliance context for this disbursement. Carries recipient information required by some entity configurations to meet regulatory requirements. */
   compliance?: DisbursementCompliance;
@@ -3205,6 +3270,9 @@ export const EvmUserOperationStatus = {
   failed: "failed",
 } as const;
 
+/**
+ * A smart account operation response.
+ */
 export interface EvmUserOperation {
   network: EvmUserOperationNetwork;
   /**
@@ -9811,6 +9879,10 @@ export type PaymentSessionEventDataAuthorization = {
   status: PaymentActionStatus;
   /** A decimal representation of the authorized amount, denominated in the session's `asset`. */
   amount: string;
+  /** An optional merchant-provided internal identifier for this authorization, from the merchant's own system—not visible to the payer. Present only when supplied on the authorization request. */
+  externalReferenceId?: ExternalReferenceId;
+  /** Customer-facing display data for this authorization, shown to the payer. Present when supplied on the authorization request or when the session's `orderCode` fallback applies; otherwise omitted. */
+  customerDisplay?: OperationCustomerDisplay;
   /** Error details, present only when the authorization failed. */
   error?: PaymentError;
   /** The onchain transactions associated with this authorization. */
@@ -9834,6 +9906,10 @@ export type PaymentSessionEventDataCapture = {
   status: PaymentActionStatus;
   /** A decimal representation of the captured amount, denominated in the session's `asset`. */
   amount: string;
+  /** An optional merchant-provided internal identifier for this capture, from the merchant's own system—not visible to the payer. For an auto-capture, it is copied from the authorization. */
+  externalReferenceId?: ExternalReferenceId;
+  /** Customer-facing display data for this capture, shown to the payer. An auto-capture reuses the authorization's `referenceCode`. */
+  customerDisplay?: OperationCustomerDisplay;
   /** When `true`, this capture is treated as the final one for the authorization. Any remaining capturable balance is released back to the payer immediately after the capture settles. When `false`, the remaining capturable balance stays held and is available for subsequent partial captures (subject to `captureExpiresAt`). Has no effect if `amount` equals the full capturable balance, since no remaining balance exists to release. */
   finalCapture: boolean;
   /** Error details, present only when the capture failed. */
@@ -9857,6 +9933,10 @@ export type PaymentSessionEventDataVoid = {
   status: PaymentActionStatus;
   /** A decimal representation of the voided amount, denominated in the session's `asset`. */
   amount: string;
+  /** An optional merchant-provided internal identifier for this void, from the merchant's own system—not visible to the payer. Present only when supplied on the create void request. */
+  externalReferenceId?: ExternalReferenceId;
+  /** Customer-facing display data for this void, shown to the payer. Present when supplied on the create void request or when the session's `orderCode` fallback applies; otherwise omitted. */
+  customerDisplay?: OperationCustomerDisplay;
   /** Error details, present only when the void failed. */
   error?: PaymentError;
   /** The onchain transactions associated with this void. */
@@ -9878,6 +9958,10 @@ export type PaymentSessionEventDataRefund = {
   status: PaymentActionStatus;
   /** A decimal representation of the refunded amount, denominated in the session's `asset`. */
   amount: string;
+  /** An optional merchant-provided internal identifier for this refund, from the merchant's own system—not visible to the payer. Present only when supplied on the create refund request. */
+  externalReferenceId?: ExternalReferenceId;
+  /** Customer-facing display data for this refund, shown to the payer. Present when supplied on the create refund request or when the session's `orderCode` fallback applies; otherwise omitted. */
+  customerDisplay?: OperationCustomerDisplay;
   /** The reason for the refund, if provided when the refund was created. */
   reason?: string;
   /** Error details, present only when the refund failed. */


### PR DESCRIPTION
## Description

Syncs the CDP SDK to the latest merged OpenAPI spec and regenerates all clients, and adds a regression E2E that deserializes a complete live swap quote.

- Pulls the merged CDP API spec via `make update-openapi`, which includes the EVM swap `liquidityAvailable` boolean fix ([c3/cdp-api#1662](https://coinbase.ghe.com/c3/cdp-api/pull/1662)). Because the spec is a single monolithic document, this sync also brings in other API changes merged since the SDK last synced (payment sessions, mandates, borrow, outage read API, etc.).
- Regenerates the TypeScript, Python, Go, and Java clients. `liquidityAvailable` is now a plain boolean in every language instead of a singleton enum that OpenAPI Generator turned into a broken string-comparison validator.
- Restores full generated-model deserialization in the live swap-quote E2E (`CreateSwapQuoteResponse.from_dict`), which previously parsed only the nested `fees` object and therefore hid response-level validation bugs.

Generated with Pi

## Tests

Method: `POST /v2/evm/swaps` through the generated Python client
Network: Base mainnet
Setup: existing CDP EVM server account; USDC-to-WETH quote for 1 USDC. No transaction was signed or submitted.

```text
make update-openapi                 # pulled merged spec (liquidity fix present)
cd typescript && pnpm orval        # regenerated TS client
cd python && make python-client    # regenerated Python client
cd go && make client               # regenerated Go client
cd java && make client             # regenerated Java client

uv run pytest cdp/test/test_e2e.py::test_create_swap_quote_deserializes_live_response -v   # PASS
uv run pytest -k "not test_e2e" -q                                                         # 1228 passed
```

Before this change the E2E failed with:

```text
CreateSwapQuoteResponse.liquidityAvailable
Value error, must be one of enum values ('true')
```

## Checklist

- [ ] Updated the [typescript README](https://github.com/coinbase/cdp-sdk/blob/main/typescript/packages/cdp-sdk/README.md) if relevant (not relevant)
- [ ] Updated the [python README](https://github.com/coinbase/cdp-sdk/blob/main/python/README.md) if relevant (not relevant)
- [ ] Added a changelog entry (not relevant; spec sync + regenerated clients + regression test)
- [x] Added e2e tests if introducing new functionality
