### PR TITLE
feat: raise policy rule limit to 100

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7665,7 +7665,9 @@ paths:
                   example: Default policy
                 rules:
                   type: array
-                  description: A list of rules that comprise the policy. There is a limit of 10 rules per policy.
+                  minItems: 1
+                  maxItems: 100
+                  description: A list of rules that comprise the policy. Each policy is limited to 100 rules and a total serialized size of 8 MiB.
                   items:
                     $ref: '#/components/schemas/Rule'
               required:
@@ -7835,7 +7837,9 @@ paths:
                   example: Default policy
                 rules:
                   type: array
-                  description: A list of rules that comprise the policy. There is a limit of 10 rules per policy.
+                  minItems: 1
+                  maxItems: 100
+                  description: A list of rules that comprise the policy. Each policy is limited to 100 rules and a total serialized size of 8 MiB.
                   items:
                     $ref: '#/components/schemas/Rule'
               required:

--- a/python/cdp/openapi_client/models/create_policy_request.py
+++ b/python/cdp/openapi_client/models/create_policy_request.py
@@ -31,7 +31,7 @@ class CreatePolicyRequest(BaseModel):
     """ # noqa: E501
     scope: StrictStr = Field(description="The scope of the policy.")
     description: Optional[Annotated[str, Field(strict=True)]] = Field(default=None, description="An optional human-readable description for the policy. Policy descriptions can consist of alphanumeric characters, spaces, commas, and periods, and be 50 characters or less.")
-    rules: List[Rule] = Field(description="A list of rules that comprise the policy. There is a limit of 10 rules per policy.")
+    rules: Annotated[List[Rule], Field(min_length=1, max_length=100)] = Field(description="A list of rules that comprise the policy. Each policy is limited to 100 rules and a total serialized size of 8 MiB.")
     __properties: ClassVar[List[str]] = ["scope", "description", "rules"]
 
     @field_validator('scope')

--- a/python/cdp/openapi_client/models/update_policy_request.py
+++ b/python/cdp/openapi_client/models/update_policy_request.py
@@ -30,7 +30,7 @@ class UpdatePolicyRequest(BaseModel):
     UpdatePolicyRequest
     """ # noqa: E501
     description: Optional[Annotated[str, Field(strict=True)]] = Field(default=None, description="An optional human-readable description for the policy. Policy descriptions can consist of alphanumeric characters, spaces, commas, and periods, and be 50 characters or less.")
-    rules: List[Rule] = Field(description="A list of rules that comprise the policy. There is a limit of 10 rules per policy.")
+    rules: Annotated[List[Rule], Field(min_length=1, max_length=100)] = Field(description="A list of rules that comprise the policy. Each policy is limited to 100 rules and a total serialized size of 8 MiB.")
     __properties: ClassVar[List[str]] = ["description", "rules"]
 
     @field_validator('description')

--- a/python/changelog.d/CDPSDK-3895.feature.md
+++ b/python/changelog.d/CDPSDK-3895.feature.md
@@ -1,1 +1,1 @@
-Raised the maximum rules per policy from 10 to 100.
+Added client-side validation that requires 1 to 100 rules per policy. Invalid rule counts now raise a Pydantic `ValidationError` before the SDK sends the request.

--- a/python/changelog.d/CDPSDK-3895.feature.md
+++ b/python/changelog.d/CDPSDK-3895.feature.md
@@ -1,0 +1,1 @@
+Raised the maximum rules per policy from 10 to 100.

--- a/typescript/.changeset/tidy-rules-grow.md
+++ b/typescript/.changeset/tidy-rules-grow.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/cdp-sdk": minor
+---
+
+Raised the maximum rules per policy from 10 to 100 and exported `MAX_RULES_PER_POLICY`.

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -61,7 +61,8 @@
     "typedoc-plugin-markdown": "4.10.0",
     "typescript": "5.9.3",
     "uuid": "11.1.0",
-    "vitest": "1.6.1"
+    "vitest": "1.6.1",
+    "yaml": "2.8.2"
   },
   "pnpm": {
     "patchedDependencies": {

--- a/typescript/packages/cdp-sdk/src/index.ts
+++ b/typescript/packages/cdp-sdk/src/index.ts
@@ -10,6 +10,7 @@ export type {
 export type { Policy } from "./policies/types.js";
 export {
   CreatePolicyBodySchema,
+  MAX_RULES_PER_POLICY,
   UpdatePolicyBodySchema,
   type CreatePolicyBody,
   type UpdatePolicyBody,

--- a/typescript/packages/cdp-sdk/src/openapi-client/generated/coinbaseDeveloperPlatformAPIs.schemas.ts
+++ b/typescript/packages/cdp-sdk/src/openapi-client/generated/coinbaseDeveloperPlatformAPIs.schemas.ts
@@ -8993,7 +8993,11 @@ Policy descriptions can consist of alphanumeric characters, spaces, commas, and 
    * @pattern ^[A-Za-z0-9 ,.]{1,50}$
    */
   description?: string;
-  /** A list of rules that comprise the policy. There is a limit of 10 rules per policy. */
+  /**
+   * A list of rules that comprise the policy. Each policy is limited to 100 rules and a total serialized size of 8 MiB.
+   * @minItems 1
+   * @maxItems 100
+   */
   rules: Rule[];
 };
 
@@ -9004,7 +9008,11 @@ Policy descriptions can consist of alphanumeric characters, spaces, commas, and 
    * @pattern ^[A-Za-z0-9 ,.]{1,50}$
    */
   description?: string;
-  /** A list of rules that comprise the policy. There is a limit of 10 rules per policy. */
+  /**
+   * A list of rules that comprise the policy. Each policy is limited to 100 rules and a total serialized size of 8 MiB.
+   * @minItems 1
+   * @maxItems 100
+   */
   rules: Rule[];
 };
 

--- a/typescript/packages/cdp-sdk/src/policies/types.test.ts
+++ b/typescript/packages/cdp-sdk/src/policies/types.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+import { MAX_RULES_PER_POLICY } from "./types.js";
+
+const policySchemas = [
+  { name: "CreatePolicyBody", operationId: "createPolicy" },
+  { name: "UpdatePolicyBody", operationId: "updatePolicy" },
+];
+
+describe("policy rule limit", () => {
+  const openApi = readFileSync(new URL("../../../../../openapi.yaml", import.meta.url), "utf8");
+
+  it.each(policySchemas)("keeps $name rules maxItems in sync", ({ operationId }) => {
+    const operationStart = openApi.indexOf(`operationId: ${operationId}`);
+    const operationEnd = openApi.indexOf("\n  /", operationStart);
+    const operation = openApi.slice(operationStart, operationEnd);
+    const rulesStart = operation.indexOf("\n                rules:");
+    const rulesEnd = operation.indexOf("\n              required:", rulesStart);
+    const rulesSchema = operation.slice(rulesStart, rulesEnd);
+    const maxItems = rulesSchema.match(/\n\s+maxItems: (\d+)/)?.[1];
+
+    expect(Number(maxItems)).toBe(MAX_RULES_PER_POLICY);
+  });
+});

--- a/typescript/packages/cdp-sdk/src/policies/types.test.ts
+++ b/typescript/packages/cdp-sdk/src/policies/types.test.ts
@@ -1,26 +1,55 @@
 import { readFileSync } from "node:fs";
 
 import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+import { z } from "zod";
 
 import { MAX_RULES_PER_POLICY } from "./types.js";
 
+const rulesSchema = z.object({
+  minItems: z.number().optional(),
+  maxItems: z.number().optional(),
+});
+
+const operationSchema = z.object({
+  requestBody: z.object({
+    content: z.object({
+      "application/json": z.object({
+        schema: z.object({
+          properties: z.object({
+            rules: rulesSchema,
+          }),
+        }),
+      }),
+    }),
+  }),
+});
+
+const openApiSchema = z.object({
+  paths: z.record(z.record(z.unknown())),
+});
+
 const policySchemas = [
-  { name: "CreatePolicyBody", operationId: "createPolicy" },
-  { name: "UpdatePolicyBody", operationId: "updatePolicy" },
-];
+  { name: "CreatePolicyBody", path: "/v2/policy-engine/policies", method: "post" },
+  {
+    name: "UpdatePolicyBody",
+    path: "/v2/policy-engine/policies/{policyId}",
+    method: "put",
+  },
+] satisfies ReadonlyArray<{ name: string; path: string; method: "post" | "put" }>;
 
 describe("policy rule limit", () => {
-  const openApi = readFileSync(new URL("../../../../../openapi.yaml", import.meta.url), "utf8");
+  const openApi = openApiSchema.parse(
+    parse(readFileSync(new URL("../../../../../openapi.yaml", import.meta.url), "utf8")),
+  );
 
-  it.each(policySchemas)("keeps $name rules maxItems in sync", ({ operationId }) => {
-    const operationStart = openApi.indexOf(`operationId: ${operationId}`);
-    const operationEnd = openApi.indexOf("\n  /", operationStart);
-    const operation = openApi.slice(operationStart, operationEnd);
-    const rulesStart = operation.indexOf("\n                rules:");
-    const rulesEnd = operation.indexOf("\n              required:", rulesStart);
-    const rulesSchema = operation.slice(rulesStart, rulesEnd);
-    const maxItems = rulesSchema.match(/\n\s+maxItems: (\d+)/)?.[1];
+  it.each(policySchemas)("keeps $name rules bounds in sync", ({ name, path, method }) => {
+    const operation = operationSchema.parse(openApi.paths[path][method]);
+    const rules = operation.requestBody.content["application/json"].schema.properties.rules;
 
-    expect(Number(maxItems)).toBe(MAX_RULES_PER_POLICY);
+    expect(rules.maxItems, `${name} rules maxItems is missing from openapi.yaml`).toBeDefined();
+    expect(rules.maxItems).toBe(MAX_RULES_PER_POLICY);
+    expect(rules.minItems, `${name} rules minItems is missing from openapi.yaml`).toBeDefined();
+    expect(rules.minItems).toBe(1);
   });
 });

--- a/typescript/packages/cdp-sdk/src/policies/types.ts
+++ b/typescript/packages/cdp-sdk/src/policies/types.ts
@@ -27,6 +27,8 @@ import {
   SendEndUserSolAssetRuleSchema,
 } from "./solanaSchema.js";
 
+export const MAX_RULES_PER_POLICY = 100;
+
 /**
  * A single Policy that can be used to govern the behavior of projects and accounts.
  */
@@ -108,9 +110,9 @@ export const CreatePolicyBodySchema = z.object({
     .optional(),
   /**
    * Array of rules that comprise the policy.
-   * Limited to a maximum of 10 rules per policy.
+   * Limited to a maximum of 100 rules per policy.
    */
-  rules: z.array(RuleSchema).max(10).min(1),
+  rules: z.array(RuleSchema).max(MAX_RULES_PER_POLICY).min(1),
 });
 /**
  * Type representing the request body for creating a new policy.
@@ -129,9 +131,9 @@ export const UpdatePolicyBodySchema = z.object({
     .optional(),
   /**
    * Array of rules that comprise the policy.
-   * Limited to a maximum of 10 rules per policy.
+   * Limited to a maximum of 100 rules per policy.
    */
-  rules: z.array(RuleSchema).max(10).min(1),
+  rules: z.array(RuleSchema).max(MAX_RULES_PER_POLICY).min(1),
 });
 /**
  * Type representing the request body for updating an existing policy.

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -112,6 +112,9 @@ importers:
       vitest:
         specifier: 1.6.1
         version: 1.6.1(@types/node@20.19.37)
+      yaml:
+        specifier: 2.8.2
+        version: 2.8.2
 
   packages/cdp-sdk:
     dependencies:


### PR DESCRIPTION
## Description

Raises the maximum rules per policy from 10 to 100 (CDPSDK-3895).

This SDK was the binding constraint in the whole system. The server allowed 18 and the OpenAPI spec said 10, but the CDP portal validates policy JSON against `CreatePolicyBodySchema` from the published npm package, so `.max(10)` in `policies/types.ts` was the ceiling no customer could get past regardless of what the server would have accepted.

The cap now comes from an exported `MAX_RULES_PER_POLICY`, so consumers can read the number instead of hardcoding it, and zod's default message reports the right bound automatically.

The number lives in two places in this repo, the hand-written zod schema and the vendored `openapi.yaml`, and this exact number has already drifted once across the system. A test now parses the vendored spec and asserts both `maxItems` and `minItems` match the zod schema on both request bodies. It parses the YAML rather than slicing on indentation, because that file is a synced artifact and a benign reformat should not read as drift.

The vendored `openapi.yaml` was hand-edited to match cdp-api rather than pulled from the CDN, because the upstream publish had not landed yet. `make update-openapi` will reconcile it to the same values.

Python gets a real behavior change worth calling out. It never enforced a rule count at all, only a description string. The regenerated model now carries `Field(min_length=1, max_length=100)`, which pydantic enforces, so a caller who previously sent an out-of-range rules list and got a server 400 now gets a local `ValidationError`. The changelog entry says that rather than claiming a limit was raised.

Nothing changed in `evmSchema.ts` or `solanaSchema.ts`. Those carry roughly twenty `.max(10)` calls that cap criteria per rule, a different limit that is not moving, and a find-and-replace across the policies directory would have corrupted them.

## Tests

```
Method: CreatePolicyBodySchema.safeParse
Setup: exported constant read at runtime from the built package

Output:
{"exportedLimit":100,"acceptsAtLimit":true,"rejectsAboveLimit":true}
```

Full TypeScript suite passes, 775 tests across 55 files. Python suite passes, 1053 tests. Build, format, and typecheck pass.

The drift test was checked against mutated copies of the spec rather than assumed to work. It fails when `maxItems` changes value, fails with a diagnosable message when the `maxItems` line is removed rather than comparing against `NaN`, fails when `minItems` changes, and passes on both the unmodified file and a YAML round trip of it. That last case is the reason for the rewrite.

## Checklist

- [ ] Updated the [typescript README](https://github.com/coinbase/cdp-sdk/blob/main/typescript/packages/cdp-sdk/README.md) if relevant
- [ ] Updated the [python README](https://github.com/coinbase/cdp-sdk/blob/main/python/README.md) if relevant
- [x] Added a changelog entry
- [ ] Added e2e tests if introducing new functionality

Neither README states a rule-count limit, so there is nothing to update. No e2e test, since this changes a bound on an existing method rather than adding functionality, and the drift test plus the unit assertions cover it.
