### PR TITLE
chore(java): prepare 1.0.0 public release

### DIFF
--- a/java/build.gradle.kts
+++ b/java/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "com.coinbase"
-version = "0.6.0"
+version = "1.0.0"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21


### PR DESCRIPTION
## Description

Bumps the public GitHub Packages publication version from `0.6.0` to `1.0.0` for the Fern Java-client cutover.

This is the public-only companion to internal release PR `c3/cdp-sdk#73`. The internal PR owns the changelog and release-fragment consumption; this PR changes only the public Gradle publishing configuration because `java/build.gradle.kts` is intentionally excluded from GHE-to-public tree sync.

Do not publish until both PRs are merged.

Generated with Toshi

## Tests

- `git diff --check`
- `cd java && ./gradlew build -x test generatePomFileForMavenJavaPublication`
- Verified generated Maven POM version is `1.0.0`.

## Checklist

- [ ] Updated the typescript README if relevant
- [ ] Updated the python README if relevant
- [ ] Added a changelog entry
- [ ] Added e2e tests if introducing new functionality

Not applicable: the internal companion PR carries the Java changelog. This public PR only updates the version used for GitHub Packages publication.
