### PR TITLE
docs(java): document JitPack consumer repository

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -18,6 +18,8 @@ gpr.token=YOUR_GITHUB_PERSONAL_ACCESS_TOKEN
 ```kotlin
 repositories {
     mavenCentral()
+    // Required by the SDK's Solana dependency.
+    maven { url = uri("https://jitpack.io") }
     maven {
         url = uri("https://maven.pkg.github.com/coinbase/cdp-sdk")
         credentials {
@@ -31,6 +33,8 @@ dependencies {
     implementation("com.coinbase:cdp-sdk:<version>")
 }
 ```
+
+The SDK currently depends on the Solana library `com.github.skynetcap:solanaj`, which is resolved from JitPack. Keep the JitPack repository even if your application does not directly call Solana APIs.
 
 ## Configure a client
 


### PR DESCRIPTION
## Description

Documents the JitPack repository required to resolve the Java SDK's transitive Solana dependency, `com.github.skynetcap:solanaj`.

Without this repository, a consumer using the documented Maven Central and GitHub Packages configuration receives a runtime classpath resolution failure. The Gradle example now includes JitPack and explains why it must remain configured.

Generated with Toshi

## Tests

- `git diff --check`
- Verified the documented repository and dependency explanation are present.
- Ran the standalone consumer smoke project against published `com.coinbase:cdp-sdk:1.0.0`; it resolved dependencies and successfully listed EVM accounts.

## Checklist

- [ ] Updated the typescript README if relevant
- [ ] Updated the python README if relevant
- [ ] Added a changelog entry
- [ ] Added e2e tests if introducing new functionality

Not applicable: public Java installation documentation only; no SDK runtime behavior changed.
