### PR TITLE
fix(python,rust): avoid wallet auth for custodial account creation

### DIFF
--- a/python/cdp/auth/test/test_http.py
+++ b/python/cdp/auth/test/test_http.py
@@ -52,8 +52,8 @@ def test_get_auth_headers_missing_wallet_auth(mock_jwt, auth_options_factory):
     """Test error when wallet auth is required but not provided."""
     # Setup
     mock_jwt.return_value = "mock.jwt.token"
-    # POST to accounts path requires wallet auth
-    options = auth_options_factory(request_method="POST", request_path="/accounts")
+    # POST to an EVM accounts path requires wallet auth
+    options = auth_options_factory(request_method="POST", request_path="/v2/evm/accounts")
 
     # Execute & Verify
     with pytest.raises(
@@ -61,6 +61,20 @@ def test_get_auth_headers_missing_wallet_auth(mock_jwt, auth_options_factory):
         match="Wallet Secret not configured. Please set the CDP_WALLET_SECRET environment variable, or pass it as an option to the CdpClient constructor.",
     ):
         get_auth_headers(options)
+
+
+@patch("cdp.auth.utils.http.generate_jwt")
+def test_get_auth_headers_does_not_require_wallet_auth_for_custodial_accounts(
+    mock_jwt, auth_options_factory
+):
+    """Test that custodial account creation does not require wallet auth."""
+    mock_jwt.return_value = "mock.jwt.token"
+    options = auth_options_factory(request_method="POST", request_path="/v2/accounts")
+
+    headers = get_auth_headers(options)
+
+    assert headers["Authorization"] == "Bearer mock.jwt.token"
+    assert "X-Wallet-Auth" not in headers
 
 
 @patch("cdp.auth.utils.http.generate_jwt")
@@ -119,12 +133,14 @@ def test_get_auth_headers_still_sends_bearer_token_for_public_operation_with_cre
 @pytest.mark.parametrize(
     "request_method,request_path,expected",
     [
-        ("POST", "/accounts", True),
+        ("POST", "/v2/evm/accounts", True),
+        ("POST", "/v2/solana/accounts", True),
+        ("POST", "/v2/accounts", False),
         ("POST", "/any/123", False),
-        ("PUT", "/accounts/123", True),
+        ("PUT", "/v2/evm/accounts/123", True),
         ("PUT", "/spend-permissions", True),
         ("PUT", "/any/123", False),
-        ("DELETE", "/accounts/123", True),
+        ("DELETE", "/v2/evm/accounts/123", True),
         ("DELETE", "/any/123", False),
         ("GET", "/any/accounts", False),
         ("GET", "/any/path", False),

--- a/python/cdp/auth/utils/http.py
+++ b/python/cdp/auth/utils/http.py
@@ -128,7 +128,8 @@ def _requires_wallet_auth(method: str, path: str) -> bool:
     import re
 
     return (
-        "/accounts" in path
+        "/evm/accounts" in path
+        or "/solana/accounts" in path
         or "/spend-permissions" in path
         or "/user-operations/prepare-and-send" in path
         or "/embedded-wallet-api/" in path

--- a/rust/src/auth.rs
+++ b/rust/src/auth.rs
@@ -458,7 +458,8 @@ impl WalletAuth {
             return false;
         }
 
-        path.contains("/accounts")
+        path.contains("/evm/accounts")
+            || path.contains("/solana/accounts")
             || path.contains("/spend-permissions")
             || path.contains("/user-operations/prepare-and-send")
             || path.contains("/embedded-wallet-api/")
@@ -733,8 +734,12 @@ mod tests {
             .build()
             .unwrap();
 
-        // Should require wallet auth for POST to accounts
+        // Should require wallet auth for POST to EVM and Solana accounts
         assert!(auth.requires_wallet_auth("POST", "/v2/evm/accounts"));
+        assert!(auth.requires_wallet_auth("POST", "/v2/solana/accounts"));
+
+        // Custodial account creation uses API key auth only
+        assert!(!auth.requires_wallet_auth("POST", "/v2/accounts"));
 
         // Should require wallet auth for PUT to accounts
         assert!(auth.requires_wallet_auth("PUT", "/v2/evm/accounts/0x123"));


### PR DESCRIPTION
## Description

Python and Rust treated every mutating route containing `/accounts` as requiring `X-Wallet-Auth`. This also matched custodial `POST /v2/accounts`, which uses API key authentication only.

As a result, clients without a wallet secret failed locally before sending a valid custodial account creation request.

This change narrows account route matching in both SDKs to `/evm/accounts` and `/solana/accounts`, matching the existing TypeScript behavior. All other wallet authentication route checks remain unchanged.

Regression coverage verifies that:

- EVM and Solana account routes still require wallet authentication.
- Custodial `POST /v2/accounts` does not require wallet authentication.
- Python generates authentication headers for custodial account creation without `X-Wallet-Auth`.

## Tests

- `DISABLE_CDP_ERROR_REPORTING=true uv run pytest cdp/auth/test/test_http.py -q`
- `cargo test --lib` — 19 passed
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`

## Checklist

- [x] Updated the TypeScript README if relevant — N/A, no TypeScript changes
- [x] Updated the Python README if relevant — N/A, internal authentication bug fix
- [x] Added e2e tests if introducing new functionality — N/A, existing behavior fixed with regression unit tests
